### PR TITLE
feat: Feed 页摘要跟随应用语言设置，更新摘要语言说明文案

### DIFF
--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -17,8 +17,8 @@
     <string name="language_option_english">英文</string>
     <string name="open_system_settings">前往系统设置</string>
     <string name="summary_language">摘要语言</string>
-    <string name="summary_language_desc">GitHub 支持中英文，其余暂仅中文 · 点击了解</string>
-    <string name="summary_language_message">目前 GitHub 的摘要支持中文和英文；Hacker News 和 Product Hunt 暂时只有中文。\n\nTrending AI 最初是为帮助中文开发者了解全球技术趋势而做的，所以其余来源还没做多语言。如果你希望它们也支持你的语言，欢迎反馈告诉我们，我们会根据需求情况评估。</string>
+    <string name="summary_language_desc">三源摘要支持中英文，Picks 暂仅中文 · 点击了解</string>
+    <string name="summary_language_message">摘要语言跟随上方的语言设置：GitHub、Hacker News 和 Product Hunt 的 AI 摘要均支持中文和英文，切换语言后自动刷新。\n\nPicks 页的每日精选与深度解读暂时只有中文。如果你希望 Picks 也支持英文，欢迎反馈告诉我们，我们会根据需求情况评估。</string>
     <string name="summary_language_feedback">去反馈</string>
     <string name="close">关闭</string>
     <string name="datasource_settings">数据源设置</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -17,8 +17,8 @@
     <string name="language_option_english">English</string>
     <string name="open_system_settings">Open system settings</string>
     <string name="summary_language">Summary Language</string>
-    <string name="summary_language_desc">GitHub in Chinese &amp; English, others Chinese only · Tap to learn more</string>
-    <string name="summary_language_message">GitHub summaries are available in both Chinese and English. Hacker News and Product Hunt are Chinese only for now.\n\nTrending AI started out helping Chinese developers keep up with global tech trends, so the other sources aren\'t localized yet. If you\'d like them in your language, let us know — we\'ll gauge how many people want it and decide.</string>
+    <string name="summary_language_desc">All sources in Chinese &amp; English, Picks Chinese only · Tap to learn more</string>
+    <string name="summary_language_message">Summary language follows the app language setting above: AI summaries for GitHub, Hacker News and Product Hunt are available in both Chinese and English, and refresh automatically when you switch languages.\n\nThe Picks page (daily picks &amp; deep dives) is Chinese only for now. If you\'d like Picks in English, let us know — we\'ll gauge demand and decide.</string>
     <string name="summary_language_feedback">Send Feedback</string>
     <string name="close">Close</string>
     <string name="datasource_settings">Data Source</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedViewModel.kt
@@ -2,6 +2,9 @@ package whl.trending.ai.ui.feed
 
 import whl.trending.ai.data.model.FeedItem
 import whl.trending.ai.data.repository.TrendingRepository
+import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.core.platform.getSystemLanguage
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -10,6 +13,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -22,7 +27,8 @@ data class FeedUiState(
 
 class FeedViewModel(
     private val source: String,
-    private val repository: TrendingRepository = TrendingRepository()
+    private val repository: TrendingRepository = TrendingRepository(),
+    private val settingsManager: SettingsManager = globalSettingsManager
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(FeedUiState())
     val uiState: StateFlow<FeedUiState> = _uiState.asStateFlow()
@@ -31,6 +37,13 @@ class FeedViewModel(
 
     init {
         fetchFeed()
+
+        viewModelScope.launch {
+            // drop(1) 丢弃首次初始化的当前值，只监听真正发生的设置修改，避免初始化时重复调用 fetchFeed
+            settingsManager.appLanguage.drop(1).collect {
+                fetchFeed(isRefresh = true)
+            }
+        }
     }
 
     private fun fetchFeed(isRefresh: Boolean = false) {
@@ -43,7 +56,9 @@ class FeedViewModel(
                 _uiState.update { it.copy(isLoading = true, error = null) }
             }
             try {
-                val response = repository.getFeed(source)
+                val currentAppLanguage = settingsManager.appLanguage.first()
+                val summaryLang = currentAppLanguage.isoCode ?: getSystemLanguage()
+                val response = repository.getFeed(source, summaryLang)
                 _uiState.update {
                     it.copy(
                         isLoading = false,


### PR DESCRIPTION
## 背景

配合后端 HN/PH 摘要双语化（github-ai-trending-api#feat/bilingual-hn-ph-summaries），Feed 页此前请求 `/api/feed` 不传语言参数，固定走默认中文，英文用户拿不到英文摘要。

## 改动

- `FeedViewModel.kt`：
  - 注入 `SettingsManager`，请求时传 `summary_lang`（用户设置 → 系统语言兜底）
  - `init` 监听语言切换自动刷新，写法与 `TrendingViewModel` 完全对齐
- 设置页文案（`values/strings.xml` + `values-zh/strings.xml`）：
  - desc：「三源摘要支持中英文，Picks 暂仅中文 · 点击了解」
  - 弹窗：说明摘要跟随语言设置、切换自动刷新；Picks 暂仅中文，保留「去反馈」按钮收集 Picks 英文版需求
  - 字符串 name 均未变，无代码影响

## 明确不改

- Picks 页继续不传 `summary_lang`，整页保持中文（产品决策：避免英文摘要 + 中文解读混排）
- 英文缺失时摘要框不显示（沿用现状，不做客户端回退）

## 验证

- `:shared:compileCommonMainKotlinMetadata` 通过
- 手动验证路径：切换 App 语言为英文 → Feed 页摘要显示英文（需后端 PR 合并且次日数据生成后）；切回中文确认自动刷新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

使订阅摘要与应用的语言设置保持一致，并更新设置界面中关于摘要语言的说明。

New Features:
- 将用户选择的语言或系统语言传递给订阅（feed）API，以便返回相应语言的摘要。
- 当应用语言设置发生变化时，自动刷新订阅页面的摘要。

Enhancements:
- 明确设置文案中对摘要语言支持的说明，包括双语订阅源，以及在英文和中文区域中仅提供中文的 Picks 内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align feed summaries with the app language setting and update summary language explanations in the settings UI.

New Features:
- Pass the user-selected or system language to the feed API so summaries are returned in the appropriate language.
- Automatically refresh the Feed page summaries when the app language setting changes.

Enhancements:
- Clarify settings copy for summary language support, including bilingual feed sources and Chinese-only Picks content in both English and Chinese locales.

</details>