### PR TITLE
chore: shared 模块 KMP DSL 更名 androidLibrary → android

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "whl.trending.ai.shared"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()


### PR DESCRIPTION
## 背景

AGP 9.1.1 下构建提示：

> 'androidLibrary' block is deprecated. Please use 'android' instead.

`com.android.kotlin.multiplatform.library` 插件在 AGP 9.x 将 `kotlin {}` 内的 `androidLibrary {}` 块更名为 `android {}`，旧名进入弃用通道。

## 改动

- `shared/build.gradle.kts`：`androidLibrary {` → `android {`，一行更名，内部属性（namespace/compileSdk/minSdk/compilerOptions/androidResources/withHostTest）全部兼容不变

注：`:androidLibrary:updater` / `:androidLibrary:chat` 两个模块用的是常规 `com.android.library` 插件，与本弃用无关，不在范围内。

## 验证

- `:shared:compileCommonMainKotlinMetadata` 配置阶段通过，弃用警告消失
- `:shared:compileAndroidMain` BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- 在 KMP 插件下，将共享模块的 Gradle 配置从使用 `androidLibrary` 更新为使用新的 `android` 块名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update shared module Gradle configuration to use the new android block name instead of androidLibrary under the KMP plugin.

</details>