### PR TITLE
feat: Picks 页解读支持英文，跟随应用语言设置

### DIFF
--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -17,9 +17,8 @@
     <string name="language_option_english">英文</string>
     <string name="open_system_settings">前往系统设置</string>
     <string name="summary_language">摘要语言</string>
-    <string name="summary_language_desc">三源摘要支持中英文，Picks 暂仅中文 · 点击了解</string>
-    <string name="summary_language_message">摘要语言跟随上方的语言设置：GitHub、Hacker News 和 Product Hunt 的 AI 摘要均支持中文和英文，切换语言后自动刷新。\n\nPicks 页的每日精选与深度解读暂时只有中文。如果你希望 Picks 也支持英文，欢迎反馈告诉我们，我们会根据需求情况评估。</string>
-    <string name="summary_language_feedback">去反馈</string>
+    <string name="summary_language_desc">三源摘要与 Picks 解读均支持中英文 · 点击了解</string>
+    <string name="summary_language_message">摘要语言跟随上方的语言设置：GitHub、Hacker News、Product Hunt 的 AI 摘要与 Picks 深度解读均支持中文和英文，切换语言后自动刷新。\n\n注意：英文支持上线前的历史 Picks 解读仅有中文，英文模式下不会显示解读内容。</string>
     <string name="close">关闭</string>
     <string name="datasource_settings">数据源设置</string>
     <string name="current_datasource">当前使用: Gemini API</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -17,8 +17,9 @@
     <string name="language_option_english">英文</string>
     <string name="open_system_settings">前往系统设置</string>
     <string name="summary_language">摘要语言</string>
-    <string name="summary_language_desc">三源摘要与 Picks 解读均支持中英文 · 点击了解</string>
-    <string name="summary_language_message">摘要语言跟随上方的语言设置：GitHub、Hacker News、Product Hunt 的 AI 摘要与 Picks 深度解读均支持中文和英文，切换语言后自动刷新。\n\n注意：英文支持上线前的历史 Picks 解读仅有中文，英文模式下不会显示解读内容。</string>
+    <string name="summary_language_desc">AI 摘要支持中英文 · 点击了解</string>
+    <string name="summary_language_message">摘要语言跟随上方的语言设置：GitHub、Hacker News、Product Hunt 的 AI 摘要与 Picks 深度解读均支持中文和英文，切换语言后自动刷新。\n\n希望支持你的语言？欢迎反馈告诉我们，我们会根据需求情况评估。</string>
+    <string name="summary_language_feedback">去反馈</string>
     <string name="close">关闭</string>
     <string name="datasource_settings">数据源设置</string>
     <string name="current_datasource">当前使用: Gemini API</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -18,7 +18,7 @@
     <string name="open_system_settings">前往系统设置</string>
     <string name="summary_language">摘要语言</string>
     <string name="summary_language_desc">AI 摘要支持中英文 · 点击了解</string>
-    <string name="summary_language_message">摘要语言跟随上方的语言设置：GitHub、Hacker News、Product Hunt 的 AI 摘要与 Picks 深度解读均支持中文和英文，切换语言后自动刷新。\n\n希望支持你的语言？欢迎反馈告诉我们，我们会根据需求情况评估。</string>
+    <string name="summary_language_message">摘要语言跟随应用语言设置：GitHub、Hacker News、Product Hunt 的 AI 摘要与 Picks 深度解读均支持中文和英文，切换语言后自动刷新。\n\n希望支持你的语言？欢迎反馈告诉我们，我们会根据需求情况评估。</string>
     <string name="summary_language_feedback">去反馈</string>
     <string name="close">关闭</string>
     <string name="datasource_settings">数据源设置</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -17,8 +17,9 @@
     <string name="language_option_english">English</string>
     <string name="open_system_settings">Open system settings</string>
     <string name="summary_language">Summary Language</string>
-    <string name="summary_language_desc">All sources &amp; Picks in Chinese and English · Tap to learn more</string>
-    <string name="summary_language_message">Summary language follows the app language setting above: AI summaries for GitHub, Hacker News and Product Hunt, as well as Picks deep dives, are available in both Chinese and English, and refresh automatically when you switch languages.\n\nNote: Picks analyses published before English support launched are Chinese only and won\'t show in English mode.</string>
+    <string name="summary_language_desc">AI summaries in Chinese &amp; English · Tap to learn more</string>
+    <string name="summary_language_message">Summary language follows the app language setting above: AI summaries for GitHub, Hacker News and Product Hunt, as well as Picks deep dives, are available in both Chinese and English, and refresh automatically when you switch languages.\n\nWant your language supported? Send us feedback — we\'ll consider it based on demand.</string>
+    <string name="summary_language_feedback">Send Feedback</string>
     <string name="close">Close</string>
     <string name="datasource_settings">Data Source</string>
     <string name="current_datasource">Current: Gemini API</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -17,9 +17,8 @@
     <string name="language_option_english">English</string>
     <string name="open_system_settings">Open system settings</string>
     <string name="summary_language">Summary Language</string>
-    <string name="summary_language_desc">All sources in Chinese &amp; English, Picks Chinese only · Tap to learn more</string>
-    <string name="summary_language_message">Summary language follows the app language setting above: AI summaries for GitHub, Hacker News and Product Hunt are available in both Chinese and English, and refresh automatically when you switch languages.\n\nThe Picks page (daily picks &amp; deep dives) is Chinese only for now. If you\'d like Picks in English, let us know — we\'ll gauge demand and decide.</string>
-    <string name="summary_language_feedback">Send Feedback</string>
+    <string name="summary_language_desc">All sources &amp; Picks in Chinese and English · Tap to learn more</string>
+    <string name="summary_language_message">Summary language follows the app language setting above: AI summaries for GitHub, Hacker News and Product Hunt, as well as Picks deep dives, are available in both Chinese and English, and refresh automatically when you switch languages.\n\nNote: Picks analyses published before English support launched are Chinese only and won\'t show in English mode.</string>
     <string name="close">Close</string>
     <string name="datasource_settings">Data Source</string>
     <string name="current_datasource">Current: Gemini API</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="open_system_settings">Open system settings</string>
     <string name="summary_language">Summary Language</string>
     <string name="summary_language_desc">AI summaries in Chinese &amp; English · Tap to learn more</string>
-    <string name="summary_language_message">Summary language follows the app language setting above: AI summaries for GitHub, Hacker News and Product Hunt, as well as Picks deep dives, are available in both Chinese and English, and refresh automatically when you switch languages.\n\nWant your language supported? Send us feedback — we\'ll consider it based on demand.</string>
+    <string name="summary_language_message">Summary language follows the app language setting: AI summaries for GitHub, Hacker News and Product Hunt, as well as Picks deep dives, are available in both Chinese and English, and refresh automatically when you switch languages.\n\nWant your language supported? Send us feedback — we\'ll consider it based on demand.</string>
     <string name="summary_language_feedback">Send Feedback</string>
     <string name="close">Close</string>
     <string name="datasource_settings">Data Source</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -77,8 +77,10 @@ open class TrendingApi {
         return response.body<FeedResponse>()
     }
 
-    open suspend fun fetchPicks(): PicksResponse {
-        val response = client.get("$baseHost/api/picks")
+    open suspend fun fetchPicks(summaryLang: String = "zh"): PicksResponse {
+        val response = client.get("$baseHost/api/picks") {
+            parameter("summary_lang", summaryLang)
+        }
         return response.body<PicksResponse>()
     }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/TrendingRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/TrendingRepository.kt
@@ -12,8 +12,8 @@ class TrendingRepository(private val api: TrendingApi = TrendingApi()) {
         return api.fetchFeed(source, summaryLang)
     }
 
-    suspend fun getPicks(): PicksResponse {
-        return api.fetchPicks()
+    suspend fun getPicks(summaryLang: String = "zh"): PicksResponse {
+        return api.fetchPicks(summaryLang)
     }
 
     suspend fun getReadme(owner: String, repo: String): ReadmeResponse {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksViewModel.kt
@@ -2,6 +2,9 @@ package whl.trending.ai.ui.picks
 
 import whl.trending.ai.data.model.PicksResponse
 import whl.trending.ai.data.repository.TrendingRepository
+import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.core.platform.getSystemLanguage
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -10,6 +13,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -21,7 +26,8 @@ data class PicksUiState(
 )
 
 class PicksViewModel(
-    private val repository: TrendingRepository = TrendingRepository()
+    private val repository: TrendingRepository = TrendingRepository(),
+    private val settingsManager: SettingsManager = globalSettingsManager
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(PicksUiState())
     val uiState: StateFlow<PicksUiState> = _uiState.asStateFlow()
@@ -30,6 +36,13 @@ class PicksViewModel(
 
     init {
         fetchPicks()
+
+        viewModelScope.launch {
+            // drop(1) 丢弃首次初始化的当前值，只监听真正发生的设置修改，避免初始化时重复调用 fetchPicks
+            settingsManager.appLanguage.drop(1).collect {
+                fetchPicks(isRefresh = true)
+            }
+        }
     }
 
     private fun fetchPicks(isRefresh: Boolean = false) {
@@ -42,7 +55,9 @@ class PicksViewModel(
                 _uiState.update { it.copy(isLoading = true, error = null) }
             }
             try {
-                val response = repository.getPicks()
+                val currentAppLanguage = settingsManager.appLanguage.first()
+                val summaryLang = currentAppLanguage.isoCode ?: getSystemLanguage()
+                val response = repository.getPicks(summaryLang)
                 _uiState.update {
                     it.copy(
                         isLoading = false,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -114,6 +114,7 @@ import trendingai.shared.generated.resources.subscribe_title
 import trendingai.shared.generated.resources.subscribe_desc
 import trendingai.shared.generated.resources.summary_language
 import trendingai.shared.generated.resources.summary_language_desc
+import trendingai.shared.generated.resources.summary_language_feedback
 import trendingai.shared.generated.resources.summary_language_message
 import trendingai.shared.generated.resources.version
 import trendingai.shared.generated.resources.version_up_to_date
@@ -143,6 +144,15 @@ fun SettingsScreen(
             title = { Text(stringResource(Res.string.summary_language)) },
             text = { Text(stringResource(Res.string.summary_language_message)) },
             confirmButton = {
+                TextButton(onClick = {
+                    showSummaryLanguageDialog = false
+                    trackEvent("settings_summary_language_feedback")
+                    onNavigateToFeedback()
+                }) {
+                    Text(stringResource(Res.string.summary_language_feedback))
+                }
+            },
+            dismissButton = {
                 TextButton(onClick = { showSummaryLanguageDialog = false }) {
                     Text(stringResource(Res.string.close))
                 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -114,7 +114,6 @@ import trendingai.shared.generated.resources.subscribe_title
 import trendingai.shared.generated.resources.subscribe_desc
 import trendingai.shared.generated.resources.summary_language
 import trendingai.shared.generated.resources.summary_language_desc
-import trendingai.shared.generated.resources.summary_language_feedback
 import trendingai.shared.generated.resources.summary_language_message
 import trendingai.shared.generated.resources.version
 import trendingai.shared.generated.resources.version_up_to_date
@@ -144,15 +143,6 @@ fun SettingsScreen(
             title = { Text(stringResource(Res.string.summary_language)) },
             text = { Text(stringResource(Res.string.summary_language_message)) },
             confirmButton = {
-                TextButton(onClick = {
-                    showSummaryLanguageDialog = false
-                    trackEvent("settings_summary_language_feedback")
-                    onNavigateToFeedback()
-                }) {
-                    Text(stringResource(Res.string.summary_language_feedback))
-                }
-            },
-            dismissButton = {
                 TextButton(onClick = { showSummaryLanguageDialog = false }) {
                     Text(stringResource(Res.string.close))
                 }


### PR DESCRIPTION
## 背景

后端已支持 Picks analysis 双语（github-ai-trending-api#9，已上线），本 PR 让客户端 Picks 页接入英文，面向海外受众。

## 改动

- **TrendingApi / TrendingRepository**：`fetchPicks(summaryLang)` 传 `summary_lang` 参数（默认 zh）
- **PicksViewModel**：注入 `SettingsManager`，完整沿用 Feed 页（PR #17）的模式——`appLanguage.first()` 取语言（`isoCode ?: getSystemLanguage()`），`drop(1)` 监听语言切换自动刷新
- **历史数据行为**：英文支持上线前的 Picks 无英文 analysis，API 返回 `null`；UI 此前已用 `?.let` 判空，解读区块自然隐藏（缺则不显示，与三源摘要决策一致）
- **设置页「摘要语言」弹窗**：文案改为开放收集多语言需求——「AI 摘要支持中英文……希望支持你的语言？欢迎反馈告诉我们」，「去反馈」按钮保留并承接新使命（原 Picks 英文需求收集已交付）

## 验证

- `./gradlew :shared:assembleAndroidMain` 编译通过（含 Compose 资源 codegen）
- Picks 相关 UI label（深度解读/争议话题/速览/适合场景等）此前已全部资源化双语，无需改动

## 建议合并时机

明日（2026-06-08）UTC 01:00 后端产出首批真实双语数据后，先验证 en 质量再合并——确保用户切英文后第一眼是有内容的解读。

🤖 Generated with [Claude Code](https://claude.com/claude-code)