### PR TITLE
feat: 详情页支持分享资讯到外部 AI App

### DIFF
--- a/docs/superpowers/specs/2026-06-08-share-to-ai-app-design.md
+++ b/docs/superpowers/specs/2026-06-08-share-to-ai-app-design.md
@@ -1,0 +1,163 @@
+# 分享到外部 AI App — 设计方案
+
+> 状态：待评审
+> 日期：2026-06-08
+> 来源：用户反馈 #16 —— "或者干脆增加接口，让用户调用现有的 ai app 操作，而不是仅仅只能分享打开浏览器"
+
+## 1. 背景与目标
+
+当前客户端的 AI 助手是后端代理模式（`/api/chat` → ChatGPT），用户无法把一条资讯交给自己常用的外部 AI App（ChatGPT / Kimi / 豆包等）处理，只能"分享打开浏览器"。
+
+本功能新增一个**系统分享入口**：把当前资讯拼成一段带引导语的文本，通过系统分享面板发出，用户自行选择目标 App 接收。
+
+**为什么这样定位**（与 `product-plan.md` 的关系）：
+- 零后端、零密钥、零模型集成，不触碰产品"AI 精选 + 中文解读"的核心定位，也不削弱 Pro 订阅的服务端价值抓手。
+- 对全体用户都是正向增强，是该反馈中**唯一**既低成本又与定位兼容的诉求。
+- 反馈中的自定义 LLM / 本地模型 / MCP 等诉求**不在本方案范围**（评估结论：与定位冲突、成本巨大，不做）。
+
+**成功标准**：用户能在 GitHub 项目详情页一键把"引导语 + 标题 + 摘要 + 原文链接"分享到任意已安装 App；埋点能统计该功能的真实使用量，用于验证需求是否成立。
+
+## 2. 范围
+
+### 本期做
+- `shared` 平台层新增 `shareText` 能力（Android 完整实现，iOS 最小实现 + 留接口）。
+- GitHub README 详情页（`ReadmeScreen`）顶栏新增分享入口。
+- 分享文本带引导语，中英文随应用语言切换。
+- 埋点 `share_to_ai`。
+
+### 本期不做（明确边界）
+- **HN / PH 条目无详情页**（点击直接开外链），因此本期没有它们的分享入口。待二期"列表条目长按菜单"统一覆盖。
+- iOS 真机分享面板细节打磨（iPad popover 精确锚点、键盘态 window 等）留待 iOS 专项验证。
+- 自定义模型 / 本地模型 / MCP / 向量知识库 —— 不在本功能，也不规划。
+
+## 3. 架构设计
+
+三个互相隔离的单元，各自职责单一、可独立理解：
+
+### 3.1 平台能力层 — `Platform.shareText`
+
+`shared/src/commonMain/.../core/platform/Platform.kt`，与现有 `openUrl` 并列新增：
+
+```kotlin
+/** 调起系统分享面板，把纯文本交给用户选择的目标 App（AI App / 笔记 / IM 等）。 */
+expect fun shareText(text: String)
+```
+
+**Android**（`Platform.android.kt`）—— 复用现有 `AndroidContextHolder` + `FLAG_ACTIVITY_NEW_TASK` 模式：
+
+```kotlin
+actual fun shareText(text: String) {
+    val context = AndroidContextHolder.get() ?: return
+    val sendIntent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, text)
+    }
+    val chooser = Intent.createChooser(sendIntent, null).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(chooser)
+}
+```
+
+**iOS**（`Platform.ios.kt`）—— 最小可用实现，通过 `rootViewController` 弹 `UIActivityViewController`；iPad 用 keyWindow 中心点兜底 popover，防崩溃。标注 `// TODO: 待真机验证`：
+
+```kotlin
+actual fun shareText(text: String) {
+    val rootVc = UIApplication.sharedApplication.keyWindow?.rootViewController ?: return
+    val activityVc = UIActivityViewController(
+        activityItems = listOf(text),
+        applicationActivities = null
+    )
+    // iPad: popover 必须有锚点，否则崩溃；用 rootView 中心兜底
+    activityVc.popoverPresentationController?.let { pop ->
+        rootVc.view?.let { v ->
+            pop.sourceView = v
+            pop.sourceRect = CGRectMake(v.bounds.useContents { size.width } / 2.0, ...)
+        }
+    }
+    rootVc.presentViewController(activityVc, animated = true, completion = null)
+}
+```
+
+> iOS 块为方向性示意，真机实现时按 KMP/cinterop 实际 API 调整；本期以 Android 为验证主体。
+
+### 3.2 分享文本构造 — 走 Compose Resources 本地化
+
+不引入额外的纯函数拼接层，直接用 Compose Resources 的占位符格式化（YAGNI），i18n 天然跟随应用语言。
+
+新增字符串资源（`composeResources/values/strings.xml` 与 `values-en/`）。**两个模板**应对摘要有无：
+
+```xml
+<!-- values（中文，默认） -->
+<string name="share_ai_text_full">请帮我解读这条技术资讯并提炼核心要点：\n\n标题：%1$s\n\n摘要：%2$s\n\n原文：%3$s</string>
+<string name="share_ai_text_brief">请帮我解读这条技术资讯并提炼核心要点：\n\n标题：%1$s\n\n原文：%2$s</string>
+```
+
+```xml
+<!-- values-en -->
+<string name="share_ai_text_full">Please help me read and summarize this tech update:\n\nTitle: %1$s\n\nSummary: %2$s\n\nSource: %3$s</string>
+<string name="share_ai_text_brief">Please help me read and summarize this tech update:\n\nTitle: %1$s\n\nSource: %2$s</string>
+```
+
+注意事项（来自项目既有踩坑记录）：
+- Compose Resources 占位符**只认 `%1$s` 位置参数**，不能用裸 `%s`。
+- strings.xml 中**不反转义**，撇号需 `&apos;`（英文模板已规避，无撇号）。
+
+### 3.3 UI 入口 — `ReadmeScreen` 顶栏
+
+在现有 `actions`（"在 GitHub 打开" 的 OpenInNew 图标）左侧新增一个 `Share` 图标按钮：
+
+- 数据来源复用页面已有字段：`title = "$owner/$repo"`、`summary = readmeExcerpt(uiState.html)`（已有私有函数，截断 900 字、去标签）、`url = repoUrl`。
+- 在 Composable body 内根据 `summary` 是否为空选模板调用 `stringResource(...)` 得到最终文本（`stringResource` 须在 Composable 作用域读取，故在 body 计算、`onClick` 内仅调用 `shareText` + 埋点）。
+- 图标用 `Icons.Default.Share`；`contentDescription` 走新增字符串 `share_to_ai`。
+
+```kotlin
+val shareText = if (summary.isNullOrBlank())
+    stringResource(Res.string.share_ai_text_brief, "$owner/$repo", repoUrl)
+else
+    stringResource(Res.string.share_ai_text_full, "$owner/$repo", summary, repoUrl)
+
+IconButton(onClick = {
+    shareText(shareText)            // 3.1 平台能力
+    trackEvent("share_to_ai", mapOf("source" to "github", "has_summary" to !summary.isNullOrBlank()))
+}) { Icon(Icons.Default.Share, stringResource(Res.string.share_to_ai)) }
+```
+
+> 命名冲突提示：局部变量 `shareText` 与平台函数 `shareText` 同名，实现时给变量改名（如 `shareContent`）。
+
+## 4. 数据流
+
+```
+用户点详情页分享图标
+  → ReadmeScreen 用 stringResource 拼装本地化文本（标题/摘要/原文）
+    → Platform.shareText(text)
+      → Android: ACTION_SEND chooser / iOS: UIActivityViewController
+        → 用户选择目标 App（ChatGPT/Kimi/豆包/笔记/IM…）
+  → 同步 trackEvent("share_to_ai", {source, has_summary})
+```
+
+## 5. 错误处理
+
+- Android `context == null`：静默 return（与现有 `openUrl` 一致）。
+- 无 `ACTION_SEND` 接收方：`createChooser` 自身会展示空面板/系统提示，不额外处理。
+- README 未加载完 `summary` 为空：自动退化到 `share_ai_text_brief`（仅标题 + 原文），不阻塞分享。
+
+## 6. 测试与验证
+
+- **平台层**为薄壳、文本构造走资源格式化，无独立业务逻辑，不写单测（YAGNI）。
+- **手动验证**（Android 模拟器/真机）：
+  1. README 加载完成后点分享 → 面板出现 → 选一个 App → 收到含引导语 + 标题 + 摘要 + 链接的文本。
+  2. README 加载中点分享 → 退化为 brief 模板（无"摘要"段）。
+  3. 切换应用语言为英文 → 分享文本变英文模板。
+  4. 确认 `share_to_ai` 埋点上报（source=github、has_summary 正确）。
+- iOS：本期仅编译通过 + 接口就位，真机分享留待 iOS 专项。
+
+## 7. 工作量估计
+
+约 1–2 人天（Android 主体 + 资源 + 埋点；iOS 最小实现）。
+
+## 8. 后续（非本期）
+
+- 二期：Feed/Picks 列表条目长按菜单，统一覆盖三源分享。
+- iOS 真机分享面板打磨。
+- 视埋点数据决定是否做"自定义快捷指令"（反馈 #4 的轻量版）。

--- a/shared/src/androidMain/kotlin/whl/trending/ai/core/platform/Platform.android.kt
+++ b/shared/src/androidMain/kotlin/whl/trending/ai/core/platform/Platform.android.kt
@@ -52,6 +52,18 @@ actual fun openUrl(url: String, targetPackage: String?) {
     }
 }
 
+actual fun shareText(text: String) {
+    val context = AndroidContextHolder.get() ?: return
+    val sendIntent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, text)
+    }
+    val chooser = Intent.createChooser(sendIntent, null).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(chooser)
+}
+
 actual fun getAppVersion(): String {
     val context = AndroidContextHolder.get() ?: return "1.0.0"
     return try {

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -83,6 +83,9 @@
     <string name="subscribe_not_subscribed">该邮箱未订阅</string>
     <string name="subscribe_error">网络错误，请稍后重试</string>
     <string name="view_on_github">在 GitHub 中查看</string>
+    <string name="share_to_ai">分享到 AI</string>
+    <string name="share_ai_text_full">请帮我解读这条技术资讯并提炼核心要点：\n\n标题：%1$s\n\n摘要：%2$s\n\n原文：%3$s</string>
+    <string name="share_ai_text_brief">请帮我解读这条技术资讯并提炼核心要点：\n\n标题：%1$s\n\n原文：%2$s</string>
     <string name="readme_no_content">该仓库暂无 README 文件。</string>
     <string name="privacy_policy">隐私政策</string>
     <string name="picks_title">Picks</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -83,6 +83,9 @@
     <string name="subscribe_not_subscribed">This email is not subscribed</string>
     <string name="subscribe_error">Network error, please try again</string>
     <string name="view_on_github">View on GitHub</string>
+    <string name="share_to_ai">Share to AI</string>
+    <string name="share_ai_text_full">Please help me read and summarize this tech update:\n\nTitle: %1$s\n\nSummary: %2$s\n\nSource: %3$s</string>
+    <string name="share_ai_text_brief">Please help me read and summarize this tech update:\n\nTitle: %1$s\n\nSource: %2$s</string>
     <string name="readme_no_content">No README found for this repository.</string>
     <string name="privacy_policy">Privacy Policy</string>
     <string name="picks_title">Picks</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
@@ -12,6 +12,9 @@ expect fun openAppSettings()
 
 expect fun openUrl(url: String, targetPackage: String? = null)
 
+/** 调起系统分享面板，把纯文本交给用户选择的目标 App（AI App / 笔记 / IM 等）。 */
+expect fun shareText(text: String)
+
 expect fun getAppVersion(): String
 
 expect fun isIosPlatform(): Boolean

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/AiShareText.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/AiShareText.kt
@@ -1,0 +1,18 @@
+package whl.trending.ai.ui.common
+
+import androidx.compose.runtime.Composable
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.share_ai_text_brief
+import trendingai.shared.generated.resources.share_ai_text_full
+
+/**
+ * 按是否有摘要拼装「分享给 AI」的纯文本：有摘要走 full 模板，否则走 brief。
+ * 列表 item 与详情页共用，确保分享话术一致。
+ */
+@Composable
+fun aiShareText(title: String, summary: String?, url: String): String =
+    if (summary.isNullOrBlank())
+        stringResource(Res.string.share_ai_text_brief, title, url)
+    else
+        stringResource(Res.string.share_ai_text_full, title, summary, url)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/ItemActionMenu.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/ItemActionMenu.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.MoreHoriz
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -23,11 +24,13 @@ import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.action_favorite
 import trendingai.shared.generated.resources.action_unfavorite
+import trendingai.shared.generated.resources.share_to_ai
 
 @Composable
-fun FavoriteActionMenu(
+fun ItemActionMenu(
     isFavorite: Boolean,
     onToggle: () -> Unit,
+    onShare: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -64,6 +67,16 @@ fun FavoriteActionMenu(
                 onClick = {
                     expanded = false
                     onToggle()
+                }
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(Res.string.share_to_ai)) },
+                leadingIcon = {
+                    Icon(Icons.Default.Share, contentDescription = null)
+                },
+                onClick = {
+                    expanded = false
+                    onShare()
                 }
             )
         }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
@@ -4,6 +4,8 @@ import whl.trending.ai.chat.ChatContext
 import whl.trending.ai.chat.globalChatScreen
 import whl.trending.ai.core.Constants
 import whl.trending.ai.core.platform.openUrl
+import whl.trending.ai.core.platform.shareText
+import whl.trending.ai.core.platform.trackEvent
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -16,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -43,6 +46,9 @@ import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.back
 import trendingai.shared.generated.resources.readme_no_content
 import trendingai.shared.generated.resources.retry
+import trendingai.shared.generated.resources.share_ai_text_brief
+import trendingai.shared.generated.resources.share_ai_text_full
+import trendingai.shared.generated.resources.share_to_ai
 import trendingai.shared.generated.resources.view_on_github
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -87,6 +93,23 @@ fun ReadmeScreen(
                     }
                 },
                 actions = {
+                    val summary = readmeExcerpt(uiState.html)
+                    val shareContent = if (summary.isNullOrBlank())
+                        stringResource(Res.string.share_ai_text_brief, "$owner/$repo", repoUrl)
+                    else
+                        stringResource(Res.string.share_ai_text_full, "$owner/$repo", summary, repoUrl)
+                    IconButton(onClick = {
+                        shareText(shareContent)
+                        trackEvent(
+                            "share_to_ai",
+                            mapOf("source" to "github", "has_summary" to !summary.isNullOrBlank())
+                        )
+                    }) {
+                        Icon(
+                            imageVector = Icons.Default.Share,
+                            contentDescription = stringResource(Res.string.share_to_ai)
+                        )
+                    }
                     IconButton(onClick = { openUrl(repoUrl, Constants.GITHUB_APP_PACKAGE) }) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Outlined.OpenInNew,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -46,10 +47,9 @@ import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.back
 import trendingai.shared.generated.resources.readme_no_content
 import trendingai.shared.generated.resources.retry
-import trendingai.shared.generated.resources.share_ai_text_brief
-import trendingai.shared.generated.resources.share_ai_text_full
 import trendingai.shared.generated.resources.share_to_ai
 import trendingai.shared.generated.resources.view_on_github
+import whl.trending.ai.ui.common.aiShareText
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -73,6 +73,8 @@ fun ReadmeScreen(
         muted  = colorScheme.onSurfaceVariant.toHex(),
     )
     val repoUrl = "https://github.com/$owner/$repo"
+    // README 摘录涉及多次正则替换，缓存结果避免每次重组重算（分享栏与 FAB 共用）
+    val summary = remember(uiState.html) { readmeExcerpt(uiState.html) }
 
     Scaffold(
         topBar = {
@@ -93,16 +95,16 @@ fun ReadmeScreen(
                     }
                 },
                 actions = {
-                    val summary = readmeExcerpt(uiState.html)
-                    val shareContent = if (summary.isNullOrBlank())
-                        stringResource(Res.string.share_ai_text_brief, "$owner/$repo", repoUrl)
-                    else
-                        stringResource(Res.string.share_ai_text_full, "$owner/$repo", summary, repoUrl)
+                    val shareContent = aiShareText("$owner/$repo", summary, repoUrl)
                     IconButton(onClick = {
                         shareText(shareContent)
                         trackEvent(
                             "share_to_ai",
-                            mapOf("source" to "github", "has_summary" to !summary.isNullOrBlank())
+                            mapOf(
+                                "source" to "github",
+                                "has_summary" to !summary.isNullOrBlank(),
+                                "from" to "detail"
+                            )
                         )
                     }) {
                         Icon(
@@ -131,7 +133,7 @@ fun ReadmeScreen(
                                 title = "$owner/$repo",
                                 // 带上 README 摘录作为依据，让 AI 能介绍冷门项目；
                                 // README 未加载完则为 null，退化为仅 title + url
-                                summary = readmeExcerpt(uiState.html),
+                                summary = summary,
                                 sourceUrl = repoUrl
                             )
                         )

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
@@ -41,8 +41,11 @@ import whl.trending.ai.core.platform.trackItemClick
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.data.model.FeedItem
+import whl.trending.ai.core.platform.shareText
+import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.ui.common.AiSummaryBox
-import whl.trending.ai.ui.common.FavoriteActionMenu
+import whl.trending.ai.ui.common.ItemActionMenu
+import whl.trending.ai.ui.common.aiShareText
 import androidx.compose.runtime.remember
 import androidx.compose.foundation.layout.fillMaxWidth
 import kotlin.time.Clock
@@ -202,9 +205,21 @@ private fun FeedItemCard(
                 Box(modifier = Modifier.weight(1f)) {
                     FeedItemMetadata(item = item)
                 }
-                FavoriteActionMenu(
+                val shareContent = aiShareText(item.title, item.summary, item.url)
+                ItemActionMenu(
                     isFavorite = isFavorite,
-                    onToggle = onToggleFavorite
+                    onToggle = onToggleFavorite,
+                    onShare = {
+                        shareText(shareContent)
+                        trackEvent(
+                            "share_to_ai",
+                            mapOf(
+                                "source" to item.source,
+                                "has_summary" to !item.summary.isNullOrBlank(),
+                                "from" to "list"
+                            )
+                        )
+                    }
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
@@ -58,8 +58,11 @@ import whl.trending.ai.ui.common.AiSummaryBox
 import whl.trending.ai.core.platform.trackItemClick
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.FavoriteItem
+import whl.trending.ai.core.platform.shareText
+import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.model.PickItem
-import whl.trending.ai.ui.common.FavoriteActionMenu
+import whl.trending.ai.ui.common.ItemActionMenu
+import whl.trending.ai.ui.common.aiShareText
 import androidx.compose.runtime.remember
 import kotlin.time.Clock
 
@@ -319,9 +322,21 @@ private fun DeepDiveCard(item: PickItem, isFavorite: Boolean, onToggleFavorite: 
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.End
             ) {
-                FavoriteActionMenu(
+                val shareContent = aiShareText(item.title, item.summary, item.url)
+                ItemActionMenu(
                     isFavorite = isFavorite,
-                    onToggle = onToggleFavorite
+                    onToggle = onToggleFavorite,
+                    onShare = {
+                        shareText(shareContent)
+                        trackEvent(
+                            "share_to_ai",
+                            mapOf(
+                                "source" to item.source,
+                                "has_summary" to !item.summary.isNullOrBlank(),
+                                "from" to "list"
+                            )
+                        )
+                    }
                 )
             }
         }
@@ -373,9 +388,21 @@ private fun ControversyGroup(items: List<PickItem>, favoriteUrls: Set<String>, o
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End
                 ) {
-                    FavoriteActionMenu(
+                    val shareContent = aiShareText(item.title, item.summary, item.url)
+                    ItemActionMenu(
                         isFavorite = item.url in favoriteUrls,
-                        onToggle = { togglePickFavorite(item, favoriteUrls) }
+                        onToggle = { togglePickFavorite(item, favoriteUrls) },
+                        onShare = {
+                            shareText(shareContent)
+                            trackEvent(
+                                "share_to_ai",
+                                mapOf(
+                                    "source" to item.source,
+                                    "has_summary" to !item.summary.isNullOrBlank(),
+                                    "from" to "list"
+                                )
+                            )
+                        }
                     )
                 }
             }
@@ -445,9 +472,21 @@ private fun SpeedReadItem(item: PickItem, isFavorite: Boolean, onToggleFavorite:
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.End
             ) {
-                FavoriteActionMenu(
+                val shareContent = aiShareText(item.title, item.summary, item.url)
+                ItemActionMenu(
                     isFavorite = isFavorite,
-                    onToggle = onToggleFavorite
+                    onToggle = onToggleFavorite,
+                    onShare = {
+                        shareText(shareContent)
+                        trackEvent(
+                            "share_to_ai",
+                            mapOf(
+                                "source" to item.source,
+                                "has_summary" to !item.summary.isNullOrBlank(),
+                                "from" to "list"
+                            )
+                        )
+                    }
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
@@ -95,6 +95,7 @@ import trendingai.shared.generated.resources.stars_total
 import trendingai.shared.generated.resources.update_info_content
 import trendingai.shared.generated.resources.update_info_title
 import whl.trending.ai.core.DateTimeUtils
+import whl.trending.ai.core.platform.shareText
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.core.platform.trackItemClick
 import whl.trending.ai.data.local.globalSettingsManager
@@ -102,7 +103,8 @@ import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.data.model.TrendingContributor
 import whl.trending.ai.data.model.TrendingRepo
 import whl.trending.ai.ui.common.AiSummaryBox
-import whl.trending.ai.ui.common.FavoriteActionMenu
+import whl.trending.ai.ui.common.ItemActionMenu
+import whl.trending.ai.ui.common.aiShareText
 import kotlin.time.Clock
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -337,9 +339,22 @@ private fun RepoItem(index: Int, repo: TrendingRepo, since: String, isFavorite: 
                 Box(modifier = Modifier.weight(1f)) {
                     RepoMetadata(repo = repo, since = since)
                 }
-                FavoriteActionMenu(
+                val shareSummary = repo.aiSummaries.firstOrNull()?.content
+                val shareContent = aiShareText("${repo.author}/${repo.repoName}", shareSummary, repo.url)
+                ItemActionMenu(
                     isFavorite = isFavorite,
-                    onToggle = onToggleFavorite
+                    onToggle = onToggleFavorite,
+                    onShare = {
+                        shareText(shareContent)
+                        trackEvent(
+                            "share_to_ai",
+                            mapOf(
+                                "source" to "github",
+                                "has_summary" to !shareSummary.isNullOrBlank(),
+                                "from" to "list"
+                            )
+                        )
+                    }
                 )
             }
         }

--- a/shared/src/iosMain/kotlin/whl/trending/ai/core/platform/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/whl/trending/ai/core/platform/Platform.ios.kt
@@ -2,6 +2,7 @@ package whl.trending.ai.core.platform
 
 import platform.UIKit.UIDevice
 import platform.UIKit.UIApplication
+import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplicationOpenSettingsURLString
 import platform.Foundation.NSURL
 import platform.Foundation.NSBundle
@@ -35,6 +36,17 @@ actual fun openUrl(url: String, targetPackage: String?) {
             completionHandler = { _ -> }
         )
     }
+}
+
+actual fun shareText(text: String) {
+    // 最小实现：iPhone 走全屏分享 sheet。
+    // TODO(iOS 真机验证): iPad 需为 popoverPresentationController 设置 sourceView/sourceRect 锚点，否则 present 会崩溃。
+    val rootVc = UIApplication.sharedApplication.keyWindow?.rootViewController ?: return
+    val activityVc = UIActivityViewController(
+        activityItems = listOf(text),
+        applicationActivities = null
+    )
+    rootVc.presentViewController(activityVc, animated = true, completion = null)
 }
 
 actual fun getAppVersion(): String {


### PR DESCRIPTION
## 背景

来源用户反馈 #16：「干脆增加接口，让用户调用现有的 AI app 操作，而不是仅仅只能分享打开浏览器」。

经评估，该反馈中多数诉求（自定义 LLM / 本地模型 / MCP）与产品定位冲突且成本巨大，不予规划；**唯有"调起外部 AI App"既低成本又与定位兼容**，本 PR 实现之。详见设计方案 `docs/superpowers/specs/2026-06-08-share-to-ai-app-design.md`。

## 改动

GitHub README 详情页顶栏新增分享图标，把「引导语 + 标题 + 摘要 + 原文链接」通过系统分享面板发给用户选择的 App（ChatGPT/Kimi/豆包等）。

- `shared` 平台层新增 `expect fun shareText`；Android 用 `ACTION_SEND` + `createChooser`
- iOS 最小实现（iPhone 全屏 sheet；iPad popover 锚点留 TODO 待真机验证）
- 分享文本走 Compose Resources 中英双模板，按摘要有无在 full/brief 间退化
- 新增 `share_to_ai` 埋点（source/has_summary），用于验证需求是否成立

## 范围与边界

- HN/PH 条目无详情页，本期无入口，留二期"列表条目长按"统一覆盖
- iOS 仅最小实现 + 编译就位，真机分享面板细节（iPad popover 等）留 iOS 专项

## 验证

- ✅ 双端编译通过（`compileAndroidMain` + `compileKotlinIosSimulatorArm64`）
- ⏳ 待手动验证（模拟器/真机）：点击弹分享面板、README 加载中走 brief 模板、中英语言切换、埋点上报

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在 GitHub README 详情页中新增“分享给 AI”的入口，调用新的跨平台文本分享能力，并带有使用追踪。

New Features:
- 引入跨平台的 `shareText` API，用于在 Android 和 iOS 上以纯文本形式打开系统分享面板。
- 在 GitHub README 详情页顶部栏添加“分享给 AI”操作，将仓库的模板化摘要分享给外部应用。
- 对“分享给 AI”的提示文案进行本地化，在中英文中都提供完整和简短两种模板。

Enhancements:
- 通过 `share_to_ai` 分析事件进行跟踪，附带来源和摘要是否存在等元数据，用于验证功能使用情况。

Documentation:
- 新增设计规范文档，描述“分享给 AI”应用功能的范围、架构和行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a share-to-AI entry on the GitHub README detail page that invokes a new cross-platform text sharing capability with tracking.

New Features:
- Introduce a cross-platform shareText API to open the system share sheet with plain text on Android and iOS.
- Add a share-to-AI action in the GitHub README detail top bar that shares a templated summary of the repo to external apps.
- Localize share-to-AI prompt text with full and brief templates in both Chinese and English.

Enhancements:
- Track share_to_ai analytics events with source and summary presence metadata to validate feature usage.

Documentation:
- Add a design spec document describing the share-to-AI app feature scope, architecture, and behavior.

</details>