### PR TITLE
feat: 拆分 apk 渠道为 github / r2 并全链路注入 channel 埋点

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Build Release APK & AAB
         run: |
-          ./gradlew :androidApp:assembleApkRelease :androidApp:bundlePlayRelease
+          ./gradlew :androidApp:assembleGithubRelease :androidApp:assembleR2Release :androidApp:bundlePlayRelease
         env:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
@@ -183,7 +183,7 @@ jobs:
           # 2. 获取上一个 Tag
           PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | grep -v "${{ github.ref_name }}" | head -n 1)
           
-          NEW_APK=$(find androidApp/build/outputs/apk/apk/release -name "*.apk" | head -n 1)
+          NEW_APK=$(find androidApp/build/outputs/apk/github/release -name "*.apk" | head -n 1)
           
           echo "### Apk Diff" >> release_summary.md
           
@@ -259,8 +259,8 @@ jobs:
             IS_PRERELEASE="--prerelease"
           fi
           
-          # 收集待上传的文件（APK + AAB）
-          FILES=(androidApp/build/outputs/apk/apk/release/*.apk)
+          # 收集待上传的文件（github 渠道 APK + play 渠道 AAB）
+          FILES=(androidApp/build/outputs/apk/github/release/*.apk)
           for aab in androidApp/build/outputs/bundle/playRelease/*.aab; do
             [ -f "$aab" ] && FILES+=("$aab")
           done
@@ -282,8 +282,8 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
         run: |
-          # 动态寻找刚才打包好的 APK 路径 
-          APK_PATH=$(find androidApp/build/outputs/apk/apk/release -name "*.apk" | head -n 1)
+          # 动态寻找刚才打包好的 r2 渠道 APK 路径（官网/R2 分发的就是 r2 包）
+          APK_PATH=$(find androidApp/build/outputs/apk/r2/release -name "*.apk" | head -n 1)
           
           if [ -z "$APK_PATH" ]; then
             echo "Error: APK file not found!"

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -91,19 +91,34 @@ android {
         }
     }
 
-    // apk:    独立分发（GitHub Release + R2），包含自建 updater
+    // 渠道埋点：每个 flavor 注入 BuildConfig.CHANNEL，Application 启动时写入 ChannelHolder，
+    // 供 shared 的埋点（trackEvent）与请求 UA（getUserAgent）统一打标。
+    buildFeatures {
+        buildConfig = true
+    }
+
+    // github: GitHub Release 分发，含自建 updater，更新弹窗跳 GitHub Release（保持 channel 稳定）
+    // r2:     官网/R2 分发，含自建 updater，更新弹窗跳官网（保持 channel 稳定）
     // play:   Google Play 渠道，不含 updater（Play 自管更新）
     // fdroid: F-Droid 渠道，不含 updater（F-Droid 客户端统一管理更新）
+    // 四渠道仅 CHANNEL 不同，applicationId / versionCode / versionName / 签名完全一致，可互相覆盖升级。
     flavorDimensions += "distribution"
     productFlavors {
-        create("apk") {
+        create("github") {
             dimension = "distribution"
+            buildConfigField("String", "CHANNEL", "\"github\"")
+        }
+        create("r2") {
+            dimension = "distribution"
+            buildConfigField("String", "CHANNEL", "\"r2\"")
         }
         create("play") {
             dimension = "distribution"
+            buildConfigField("String", "CHANNEL", "\"play\"")
         }
         create("fdroid") {
             dimension = "distribution"
+            buildConfigField("String", "CHANNEL", "\"fdroid\"")
         }
     }
 
@@ -138,7 +153,9 @@ android {
 }
 
 dependencies {
-    "apkImplementation"(project(":androidLibrary:updater"))
+    // updater 仅 github / r2 两个独立分发渠道需要（play/fdroid 由各自商店管更新）
+    "githubImplementation"(project(":androidLibrary:updater"))
+    "r2Implementation"(project(":androidLibrary:updater"))
     implementation(project(":androidLibrary:chat"))
     implementation(libs.aptabase)
     implementation(libs.androidx.lifecycle.process)

--- a/androidApp/src/apk/kotlin/whl/trending/ai/UpdateWrapper.kt
+++ b/androidApp/src/apk/kotlin/whl/trending/ai/UpdateWrapper.kt
@@ -1,9 +1,0 @@
-package whl.trending.ai
-
-import androidx.compose.runtime.Composable
-import whl.trending.updater.UpdateAwareContent
-
-@Composable
-fun UpdateWrapper(content: @Composable () -> Unit) {
-    UpdateAwareContent(content)
-}

--- a/androidApp/src/github/kotlin/whl/trending/ai/UpdateWrapper.kt
+++ b/androidApp/src/github/kotlin/whl/trending/ai/UpdateWrapper.kt
@@ -1,0 +1,12 @@
+package whl.trending.ai
+
+import androidx.compose.runtime.Composable
+import whl.trending.ai.core.Constants
+import whl.trending.updater.UpdateAwareContent
+
+// github 渠道：更新弹窗「下载」跳 GitHub Release 页，用户在此下载的仍是 github 包，
+// 保证 channel 归因跨更新稳定（不会因走官网而漂移成 r2）。
+@Composable
+fun UpdateWrapper(content: @Composable () -> Unit) {
+    UpdateAwareContent(downloadUrl = Constants.RELEASES_URL, content = content)
+}

--- a/androidApp/src/main/kotlin/whl/trending/ai/TrendingApplication.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/TrendingApplication.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.aptabase.Aptabase
+import whl.trending.ai.core.platform.ChannelHolder
 import whl.trending.ai.core.platform.trackEvent
 
 class TrendingApplication : Application(), DefaultLifecycleObserver {
@@ -12,10 +13,13 @@ class TrendingApplication : Application(), DefaultLifecycleObserver {
 
     override fun onCreate() {
         super<Application>.onCreate()
+        // 写入分发渠道（须在任何 trackEvent / 网络请求之前），供 shared 埋点与 UA 统一打标
+        ChannelHolder.set(BuildConfig.CHANNEL)
+
         // Initialize Aptabase with the provided App Key
         Aptabase.instance.initialize(this, "A-US-1808698868")
-        
-        // Track app launch（经 shared trackEvent 统一注入 install_id）
+
+        // Track app launch（经 shared trackEvent 统一注入 install_id + channel）
         trackEvent("app_started")
 
         // Register lifecycle observer

--- a/androidApp/src/r2/kotlin/whl/trending/ai/UpdateWrapper.kt
+++ b/androidApp/src/r2/kotlin/whl/trending/ai/UpdateWrapper.kt
@@ -1,0 +1,12 @@
+package whl.trending.ai
+
+import androidx.compose.runtime.Composable
+import whl.trending.ai.core.Constants
+import whl.trending.updater.UpdateAwareContent
+
+// r2 渠道：更新弹窗「下载」跳官网（官网分发 R2 包），用户更新后仍是 r2 包，
+// 保证 channel 归因跨更新稳定。
+@Composable
+fun UpdateWrapper(content: @Composable () -> Unit) {
+    UpdateAwareContent(downloadUrl = Constants.OFFICIAL_WEBSITE_URL, content = content)
+}

--- a/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateAwareContent.kt
+++ b/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateAwareContent.kt
@@ -5,16 +5,24 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.compose.viewModel
+import whl.trending.ai.core.Constants
 import whl.trending.ai.update.globalUpdateChecker
 
+/**
+ * @param downloadUrl 更新弹窗「下载」按钮的跳转地址，由各分发渠道（github / r2）按需注入，
+ *   以保证 channel 归因跨更新稳定；默认官网。库本身保持渠道无关。
+ */
 @Composable
-fun UpdateAwareContent(content: @Composable () -> Unit) {
+fun UpdateAwareContent(
+    downloadUrl: String = Constants.OFFICIAL_WEBSITE_URL,
+    content: @Composable () -> Unit
+) {
     val updateViewModel: UpdateViewModel = viewModel()
     SideEffect { globalUpdateChecker = updateViewModel }
 
     val updateInfo by updateViewModel.updateInfo.collectAsState()
     updateInfo?.let {
-        UpdateDialog(it, onDismiss = { updateViewModel.dismissUpdate() })
+        UpdateDialog(it, downloadUrl = downloadUrl, onDismiss = { updateViewModel.dismissUpdate() })
     }
 
     content()

--- a/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateAwareContent.kt
+++ b/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateAwareContent.kt
@@ -5,16 +5,15 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.compose.viewModel
-import whl.trending.ai.core.Constants
 import whl.trending.ai.update.globalUpdateChecker
 
 /**
- * @param downloadUrl 更新弹窗「下载」按钮的跳转地址，由各分发渠道（github / r2）按需注入，
- *   以保证 channel 归因跨更新稳定；默认官网。库本身保持渠道无关。
+ * @param downloadUrl 更新弹窗「下载」按钮的跳转地址，由各分发渠道（github / r2）显式注入，
+ *   以保证 channel 归因跨更新稳定。库本身对渠道无感，不内置默认值。
  */
 @Composable
 fun UpdateAwareContent(
-    downloadUrl: String = Constants.OFFICIAL_WEBSITE_URL,
+    downloadUrl: String,
     content: @Composable () -> Unit
 ) {
     val updateViewModel: UpdateViewModel = viewModel()

--- a/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateDialog.kt
+++ b/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateDialog.kt
@@ -10,7 +10,7 @@ import whl.trending.ai.core.Constants
 import whl.trending.ai.core.platform.openUrl
 
 @Composable
-fun UpdateDialog(updateInfo: UpdateInfo, onDismiss: () -> Unit) {
+fun UpdateDialog(updateInfo: UpdateInfo, downloadUrl: String, onDismiss: () -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
         title = {
@@ -21,7 +21,7 @@ fun UpdateDialog(updateInfo: UpdateInfo, onDismiss: () -> Unit) {
         },
         confirmButton = {
             TextButton(onClick = {
-                openUrl(Constants.OFFICIAL_WEBSITE_URL)
+                openUrl(downloadUrl)
                 onDismiss()
             }) {
                 Text(stringResource(R.string.update_dialog_download))

--- a/shared/src/androidMain/kotlin/whl/trending/ai/core/platform/Platform.android.kt
+++ b/shared/src/androidMain/kotlin/whl/trending/ai/core/platform/Platform.android.kt
@@ -87,5 +87,5 @@ actual fun getUserAgent(): String {
     val osVersion = Build.VERSION.RELEASE
     val model = Build.MODEL
     val channel = ChannelHolder.get()
-    return "TrendingAI/$appVersion (Android $osVersion; $model; $channel)"
+    return "TrendingAI/$appVersion (Android $osVersion; $model; channel=$channel)"
 }

--- a/shared/src/androidMain/kotlin/whl/trending/ai/core/platform/Platform.android.kt
+++ b/shared/src/androidMain/kotlin/whl/trending/ai/core/platform/Platform.android.kt
@@ -86,5 +86,6 @@ actual fun getUserAgent(): String {
     val appVersion = getAppVersion()
     val osVersion = Build.VERSION.RELEASE
     val model = Build.MODEL
-    return "TrendingAI/$appVersion (Android $osVersion; $model)"
+    val channel = ChannelHolder.get()
+    return "TrendingAI/$appVersion (Android $osVersion; $model; $channel)"
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/ChannelHolder.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/ChannelHolder.kt
@@ -1,0 +1,22 @@
+package whl.trending.ai.core.platform
+
+/**
+ * 分发渠道承接点。
+ *
+ * 渠道值（github / r2 / play / fdroid）来自 androidApp 的 `BuildConfig.CHANNEL`，属 Android 平台专有，
+ * shared（commonMain）无法直接引用。因此由 Android 在启动时（[whl.trending.ai.TrendingApplication]）
+ * 写入此处，shared 侧的埋点（[trackEvent]）与请求 UA（[getUserAgent]）再统一读取。
+ *
+ * 其他平台（iOS）不写入，保持默认 [UNKNOWN]。set 一次发生在任何读取之前，无并发问题。
+ */
+object ChannelHolder {
+    const val UNKNOWN: String = "unknown"
+
+    private var channel: String = UNKNOWN
+
+    fun set(value: String) {
+        channel = value
+    }
+
+    fun get(): String = channel
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
@@ -31,7 +31,13 @@ expect fun getUserAgent(): String
  * 留存/回访改以 install_id 为口径（安装日 = 该 install_id 首次出现的日期）。
  */
 fun trackEvent(name: String, props: Map<String, Any> = emptyMap()) {
-    platformTrackEvent(name, props + ("install_id" to globalSettingsManager.getOrCreateInstallId()))
+    platformTrackEvent(
+        name,
+        props + mapOf(
+            "install_id" to globalSettingsManager.getOrCreateInstallId(),
+            "channel" to ChannelHolder.get()
+        )
+    )
 }
 
 /** 平台真正的事件上报实现（Android 接 Aptabase，iOS 暂为空）。 */

--- a/shared/src/iosMain/kotlin/whl/trending/ai/core/platform/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/whl/trending/ai/core/platform/Platform.ios.kt
@@ -71,5 +71,5 @@ actual fun getUserAgent(): String {
     val osVersion = device.systemVersion
     val model = device.model
     val channel = ChannelHolder.get()
-    return "TrendingAI/$appVersion (iOS $osVersion; $model; $channel)"
+    return "TrendingAI/$appVersion (iOS $osVersion; $model; channel=$channel)"
 }

--- a/shared/src/iosMain/kotlin/whl/trending/ai/core/platform/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/whl/trending/ai/core/platform/Platform.ios.kt
@@ -70,5 +70,6 @@ actual fun getUserAgent(): String {
     val device = UIDevice.currentDevice
     val osVersion = device.systemVersion
     val model = device.model
-    return "TrendingAI/$appVersion (iOS $osVersion; $model)"
+    val channel = ChannelHolder.get()
+    return "TrendingAI/$appVersion (iOS $osVersion; $model; $channel)"
 }


### PR DESCRIPTION
## 背景

原 `apk` flavor 同时承担 GitHub Release 与 R2/官网两条分发，无法区分安装来源。本次将其一拆为二（`github` / `r2`），并为含 `play` / `fdroid` 在内的四个渠道统一注入 `channel`，打通埋点归因。

## 关键澄清

核对 updater 后发现：**它不在 app 内下载 APK**，只是检查 GitHub Release 版本后用 `openUrl` 跳转下载页。因此原设计里「github 包拉 R2 导致 channel 漂移」前提不成立——两个 flavor 的检查逻辑天然一致，唯一需分渠道的是更新弹窗「下载」按钮的跳转目标：

- `github` → GitHub Release 页（下 github 包）
- `r2` → 官网（下 R2 包）

由此保证 channel 归因跨更新稳定，且无需共享源目录，两个 `UpdateWrapper.kt` 各 6 行。

## 改动

- **build.gradle.kts**：开启 `buildConfig`；flavor 删 `apk`、加 `github`/`r2`，四渠道各注入 `CHANNEL`；updater 依赖 `apkImplementation` → `github`/`r2Implementation`
- **ChannelHolder**（shared/commonMain）：承接 android-only 的 `BuildConfig.CHANNEL`，由 `TrendingApplication` 启动时写入；`trackEvent` 与两端 `getUserAgent` 统一打标，其他平台默认 `unknown`
- **updater 库**：`UpdateAwareContent`/`UpdateDialog` 新增 `downloadUrl` 参数（默认官网，库保持渠道无关）
- **CI**：构建 `assembleGithubRelease` + `assembleR2Release` + `bundlePlayRelease`；GitHub Release / diffuse 取 github 包，R2 上传取 r2 包

四渠道 `applicationId` / `versionCode` / `versionName` / 签名完全一致，可互相覆盖升级。

## 验证

- ✅ 四 flavor Kotlin 编译通过
- ✅ `assembleGithubRelease` / `assembleR2Release` 打包成功，产物路径与 CI 取包路径一致
- ✅ 四个 `BuildConfig.CHANNEL` 值正确（github / r2 / play / fdroid）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

将 Android APK 分发拆分为独立的 github 和 r2 风味版本，并在各平台之间引入统一的渠道字段，用于统计分析和用户代理。

New Features:
- 引入独立的 github 和 r2 Android 产品风味版本，与现有的 play 和 fdroid 风味版本并存，并为每个风味设置一个 `BuildConfig.CHANNEL` 值。
- 添加共享的 `ChannelHolder` 机制，使 Android 在启动时写入分发渠道，以便共享的统计分析和用户代理中能够包含该渠道信息。
- 允许更新器 UI 接受可配置的下载 URL，从而使不同的分发渠道可以控制更新下载的目标地址。

Enhancements:
- 更新 Android 和 iOS 上的用户代理字符串，在可用时包含分发渠道信息。
- 将应用启动时的统计分析接线为自动在所有上报事件中包含 `install_id` 和 `channel`。

CI:
- 调整 Android 发布的 GitHub Actions 工作流，以分别构建 github 和 r2 的发布 APK，使用 github APK 用于 GitHub Releases，使用 r2 APK 用于 R2 上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split the Android apk distribution into separate github and r2 flavors and introduce a unified channel field for analytics and user agents across platforms.

New Features:
- Introduce distinct github and r2 Android product flavors, alongside existing play and fdroid flavors, each with a BuildConfig.CHANNEL value.
- Add a shared ChannelHolder mechanism so Android writes the distribution channel at startup and shared analytics and user agents can include it.
- Allow the updater UI to accept a configurable download URL so different distribution channels can control where update downloads are directed.

Enhancements:
- Update Android user agent strings on both Android and iOS to include the distribution channel where available.
- Wire app startup analytics to automatically include both install_id and channel in all tracked events.

CI:
- Adjust Android release GitHub Actions workflow to build github and r2 release APKs separately, use the github APK for GitHub Releases, and use the r2 APK for R2 uploads.

</details>