### PR TITLE
feat: Logto GitHub 登录 + Profile 页（Phase 1 客户端）

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -169,5 +169,6 @@ dependencies {
     implementation(project(":androidLibrary:chat"))
     implementation(libs.aptabase)
     implementation(libs.androidx.lifecycle.process)
+    implementation(libs.logto.android)
     debugImplementation(libs.compose.uiTooling)
 }

--- a/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
@@ -30,6 +30,7 @@ class MainActivity : AppCompatActivity() {
         whl.trending.ai.core.platform.AndroidContextHolder.initialize(this)
 
         // 注入 Logto 登录实现（仿 globalChatScreen 的依赖反转；配置变更重建时重新绑定 activity）
+        (whl.trending.ai.auth.globalAuthManager as? whl.trending.ai.auth.LogtoAuthManager)?.close()
         whl.trending.ai.auth.globalAuthManager = whl.trending.ai.auth.LogtoAuthManager(this)
 
         // 注册 Android-only 的 ChatScreen 到 CMP 导航 slot（仿 UpdateWrapper 的依赖反转）

--- a/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
@@ -29,6 +29,9 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         whl.trending.ai.core.platform.AndroidContextHolder.initialize(this)
 
+        // 注入 Logto 登录实现（仿 globalChatScreen 的依赖反转；配置变更重建时重新绑定 activity）
+        whl.trending.ai.auth.globalAuthManager = whl.trending.ai.auth.LogtoAuthManager(this)
+
         // 注册 Android-only 的 ChatScreen 到 CMP 导航 slot（仿 UpdateWrapper 的依赖反转）
         globalChatScreen = { context, onBack ->
             ChatScreen(initialContext = context, onBack = onBack)

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -8,6 +8,7 @@ import kotlin.coroutines.resume
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -72,6 +73,11 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
                 cont.resume(accessToken?.token)
             }
         }
+
+    /** 实例被替换前调用（如配置变更重建 Activity），取消后台协程避免旧实例残留任务 */
+    fun close() {
+        scope.cancel()
+    }
 
     companion object {
         private const val LOGTO_ENDPOINT = "https://28bniv.logto.app"

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -1,0 +1,83 @@
+package whl.trending.ai.auth
+
+import android.app.Activity
+import io.logto.sdk.android.LogtoClient
+import io.logto.sdk.android.type.LogtoConfig
+import java.lang.ref.WeakReference
+import kotlin.coroutines.resume
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import whl.trending.ai.BuildConfig
+import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.repository.UserRepository
+
+/**
+ * Logto 实现：OIDC PKCE 登录，token 存储/刷新由 SDK 托管。
+ * scope 额外加 identities——Worker 经 userinfo 取 GitHub 数字 ID 建档。
+ */
+class LogtoAuthManager(activity: Activity) : AuthManager {
+    private val activityRef = WeakReference(activity)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val logtoClient = LogtoClient(
+        LogtoConfig(
+            endpoint = LOGTO_ENDPOINT,
+            appId = LOGTO_APP_ID,
+            scopes = listOf("identities"),
+            resources = null,
+            usingPersistStorage = true,
+        ),
+        activity.application,
+    )
+
+    private val _authState = MutableStateFlow<AuthState>(
+        if (logtoClient.isAuthenticated) AuthState.LoggedIn else AuthState.LoggedOut
+    )
+    override val authState: StateFlow<AuthState> = _authState.asStateFlow()
+    override val isSupported: Boolean = true
+
+    override fun signIn() {
+        val activity = activityRef.get() ?: return
+        _authState.value = AuthState.LoggingIn
+        logtoClient.signIn(activity, REDIRECT_URI) { logtoException ->
+            if (logtoException == null && logtoClient.isAuthenticated) {
+                _authState.value = AuthState.LoggedIn
+                trackEvent("sign_in_success")
+                // 登录即建档：失败静默，打开 Profile 时会重试
+                scope.launch { UserRepository().syncMe(getAccessToken()) }
+            } else {
+                _authState.value = AuthState.LoggedOut
+                if (logtoException != null) trackEvent("sign_in_failed")
+            }
+        }
+    }
+
+    override fun signOut() {
+        logtoClient.signOut { /* 本地凭证已清除即视为登出，远端失败不阻塞 */ }
+        globalSettingsManager.setUserAvatarUrl(null)
+        _authState.value = AuthState.LoggedOut
+        trackEvent("sign_out")
+    }
+
+    override suspend fun getAccessToken(): String? =
+        suspendCancellableCoroutine { cont ->
+            logtoClient.getAccessToken { _, accessToken ->
+                cont.resume(accessToken?.token)
+            }
+        }
+
+    companion object {
+        private const val LOGTO_ENDPOINT = "https://28bniv.logto.app"
+        private const val LOGTO_APP_ID = "lasqslwwdjbim73vgkapj"
+
+        /** release: cn.trendingai://whl.trending.ai/callback；debug 包名带 .debug，两条均已在 Logto 注册 */
+        private val REDIRECT_URI = "cn.trendingai://${BuildConfig.APPLICATION_ID}/callback"
+    }
+}

--- a/docs/superpowers/plans/2026-06-10-logto-auth-phase1.md
+++ b/docs/superpowers/plans/2026-06-10-logto-auth-phase1.md
@@ -1,0 +1,1299 @@
+# Logto GitHub 登录 Phase 1 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** TrendingAI Android 接入 Logto GitHub 登录，登录后在 Worker 建档（`app_users`），并提供极简 Profile 页（头像/昵称/login/bio/跳 GitHub/登出）。
+
+**Architecture:** 客户端用 Logto Android SDK（OIDC PKCE）登录拿 opaque access token；Worker 端 `requireAuth` 调 Logto userinfo 在线校验（10 分钟内存缓存），`GET /api/me` 据 claims upsert `app_users`（内部 `user_id` 主键 + `logto_sub`/`github_user_id` 映射列）。shared 层只看 `AuthManager` 抽象，Logto SDK 仅存在于 androidApp。
+
+**Tech Stack:** Kotlin Multiplatform + Compose Multiplatform（jetbrains navigation3、Ktor、coil3、multiplatform-settings）、io.logto.sdk:android 1.1.3、Cloudflare Worker + D1、vitest。
+
+**涉及两个仓库**（各自独立提交，使用 `git -C <repo>`）：
+- 后端：`/Users/wanghl/TrendingProjects/github-ai-trending-api`（Task 1-6）
+- 客户端：`/Users/wanghl/TrendingProjects/TrendingAI`（Task 7-13）
+
+**关键既有事实**（执行者无须再探查）：
+- Worker 路由是 `src/index.js` 里的 `if (pathname === ...)` 平铺分支；D1 binding 名 `DB`；响应辅助在 `src/lib/http.js`（`jsonOk(data, maxAge)` / `jsonError(msg, status)` / `handlePreflight()`）；测试用 vitest，mock 模式参考 `tests/api/subscribe.test.js`；migrations 最新编号 014
+- 客户端无 DI 框架：全局单例 + 构造函数默认参数注入；ViewModel 用 `androidx.lifecycle.ViewModel` + `viewModel { }`；导航是 `App.kt` 的 `backStack` + `entryProvider`；字符串在 `shared/src/commonMain/composeResources/values{,-zh}/strings.xml`（撇号必须写 `&apos;`，占位符必须 `%1$s`）；coil3 已在 shared commonMain 可用
+- Logto 配置（已在控制台完成）：endpoint `https://28bniv.logto.app`，App ID `lasqslwwdjbim73vgkapj`，redirect `cn.trendingai://<applicationId>/callback`（release/debug 两条均已注册）；GitHub 连接器 Store tokens 已开
+- Logto userinfo 端点：`GET https://28bniv.logto.app/oidc/me`（Bearer 用户 token）；`identities` claim 需客户端登录 scope 含 `identities` 才返回，结构 `{ github: { userId: "<GitHub数字ID字符串>", details: { ..., rawData: {<GitHub /user 原始JSON>} } } }`
+
+---
+
+## Part A：后端（github-ai-trending-api）
+
+### Task 1: `app_users` 迁移
+
+**Files:**
+- Create: `migrations/015_add_app_users.sql`
+
+- [ ] **Step 1: 写迁移文件**
+
+```sql
+-- 用户建档表：业务数据唯一锚点是内部 user_id（UUID）；
+-- logto_sub 是当前 IdP 的映射列（换 IdP 时整列替换）；
+-- github_user_id 是 GitHub 数字 ID（永不变），跨身份系统对账的耐久锚点。
+CREATE TABLE IF NOT EXISTS app_users (
+    user_id        TEXT PRIMARY KEY,
+    logto_sub      TEXT    NOT NULL UNIQUE,
+    github_user_id INTEGER UNIQUE,
+    github_login   TEXT,
+    display_name   TEXT,
+    avatar_url     TEXT,
+    bio            TEXT,
+    html_url       TEXT,
+    raw_profile    TEXT,
+    created_at     TEXT    NOT NULL DEFAULT (datetime('now')),
+    last_login_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_users_github_user_id ON app_users(github_user_id);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/wanghl/TrendingProjects/github-ai-trending-api add migrations/015_add_app_users.sql
+git -C /Users/wanghl/TrendingProjects/github-ai-trending-api commit -m "feat: app_users 建档表迁移（内部 user_id 主键 + logto_sub/github_user_id 映射）"
+```
+
+> 注意：迁移此时只提交不执行，远端 apply 统一放在 Task 6（项目规则：必须 `npx wrangler d1 migrations apply trending --remote`）。
+
+---
+
+### Task 2: CORS 允许 Authorization 头
+
+**Files:**
+- Modify: `src/lib/http.js`（`CORS_HEADERS` 常量）
+
+- [ ] **Step 1: 修改 Allow-Headers**
+
+把：
+```javascript
+'Access-Control-Allow-Headers': 'Content-Type',
+```
+改为：
+```javascript
+'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+```
+
+- [ ] **Step 2: 跑现有测试确认无回归**
+
+Run: `cd /Users/wanghl/TrendingProjects/github-ai-trending-api && npm test`
+Expected: 全部 PASS（现有 5 个测试文件不断言 Allow-Headers 的具体值）
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/wanghl/TrendingProjects/github-ai-trending-api add src/lib/http.js
+git -C /Users/wanghl/TrendingProjects/github-ai-trending-api commit -m "feat: CORS 允许 Authorization 头（为带 token 的 /api/me 预检放行）"
+```
+
+---
+
+### Task 3: `logto-auth.js`（userinfo 校验 + 缓存）
+
+**Files:**
+- Create: `src/lib/logto-auth.js`
+- Test: `tests/api/logto-auth.test.js`
+
+- [ ] **Step 1: 写失败测试**
+
+```javascript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { requireAuth, clearAuthCache } from '../../src/lib/logto-auth.js';
+
+const ENV = { LOGTO_ENDPOINT: 'https://logto.example' };
+
+const CLAIMS = { sub: 'logto_user_1', name: 'Harlon' };
+
+function makeRequest(authHeader) {
+    const headers = authHeader ? { Authorization: authHeader } : {};
+    return new Request('https://api.trendingai.cn/api/me', { headers });
+}
+
+describe('requireAuth', () => {
+    beforeEach(() => {
+        clearAuthCache();
+        vi.restoreAllMocks();
+    });
+
+    it('无 Authorization 头返回 401', async () => {
+        const { claims, errorResponse } = await requireAuth(makeRequest(null), ENV);
+        expect(claims).toBeUndefined();
+        expect(errorResponse.status).toBe(401);
+    });
+
+    it('非 Bearer 格式返回 401', async () => {
+        const { errorResponse } = await requireAuth(makeRequest('Basic abc'), ENV);
+        expect(errorResponse.status).toBe(401);
+    });
+
+    it('userinfo 200 时返回 claims，且调用了正确端点', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(CLAIMS), { status: 200 })
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const { claims, errorResponse } = await requireAuth(makeRequest('Bearer token-a'), ENV);
+        expect(errorResponse).toBeUndefined();
+        expect(claims.sub).toBe('logto_user_1');
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://logto.example/oidc/me',
+            expect.objectContaining({ headers: { Authorization: 'Bearer token-a' } })
+        );
+    });
+
+    it('userinfo 401 时返回 401 且不缓存', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 401 }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const first = await requireAuth(makeRequest('Bearer bad'), ENV);
+        expect(first.errorResponse.status).toBe(401);
+
+        const second = await requireAuth(makeRequest('Bearer bad'), ENV);
+        expect(second.errorResponse.status).toBe(401);
+        expect(fetchMock).toHaveBeenCalledTimes(2); // 失败结果不缓存
+    });
+
+    it('同一 token 第二次命中缓存，不再调 userinfo', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(CLAIMS), { status: 200 })
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        await requireAuth(makeRequest('Bearer token-a'), ENV);
+        const { claims } = await requireAuth(makeRequest('Bearer token-a'), ENV);
+        expect(claims.sub).toBe('logto_user_1');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+});
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `cd /Users/wanghl/TrendingProjects/github-ai-trending-api && npx vitest run tests/api/logto-auth.test.js`
+Expected: FAIL —— `Cannot find module '../../src/lib/logto-auth.js'`
+
+- [ ] **Step 3: 实现 `src/lib/logto-auth.js`**
+
+```javascript
+import { jsonError } from './http.js';
+
+// Logto Free 档无 API 资源 → access token 是 opaque token，无法 JWKS 离线验签。
+// 改为调 userinfo 在线校验，并按 token 哈希做 isolate 内存缓存（设计稿 §5）。
+const CACHE_TTL_MS = 10 * 60 * 1000;
+const CACHE_MAX_ENTRIES = 1000;
+const authCache = new Map();
+
+/** 仅供测试重置模块级缓存 */
+export function clearAuthCache() {
+    authCache.clear();
+}
+
+async function sha256Hex(text) {
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(text));
+    return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * 校验 Bearer token 并返回 Logto userinfo claims。
+ * 成功：{ claims }；失败：{ errorResponse }（直接 return 给调用方）。
+ */
+export async function requireAuth(request, env) {
+    const header = request.headers.get('Authorization') || '';
+    if (!header.startsWith('Bearer ')) {
+        return { errorResponse: jsonError('Unauthorized', 401) };
+    }
+    const token = header.slice(7).trim();
+    if (!token) {
+        return { errorResponse: jsonError('Unauthorized', 401) };
+    }
+
+    const key = await sha256Hex(token);
+    const cached = authCache.get(key);
+    if (cached && cached.expiresAt > Date.now()) {
+        return { claims: cached.claims };
+    }
+    authCache.delete(key);
+
+    const res = await fetch(`${env.LOGTO_ENDPOINT}/oidc/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+        return { errorResponse: jsonError('Unauthorized', 401) };
+    }
+
+    const claims = await res.json();
+    if (authCache.size >= CACHE_MAX_ENTRIES) {
+        authCache.delete(authCache.keys().next().value); // 简单 FIFO 淘汰
+    }
+    authCache.set(key, { claims, expiresAt: Date.now() + CACHE_TTL_MS });
+    return { claims };
+}
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `npx vitest run tests/api/logto-auth.test.js`
+Expected: 5 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/wanghl/TrendingProjects/github-ai-trending-api add src/lib/logto-auth.js tests/api/logto-auth.test.js
+git -C /Users/wanghl/TrendingProjects/github-ai-trending-api commit -m "feat: requireAuth——Logto userinfo 在线校验 + 10 分钟内存缓存"
+```
+
+---
+
+### Task 4: `GET /api/me`（建档 upsert）
+
+**Files:**
+- Create: `src/api/me.js`
+- Test: `tests/api/me.test.js`
+
+- [ ] **Step 1: 写失败测试**
+
+```javascript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleMe } from '../../src/api/me.js';
+import { clearAuthCache } from '../../src/lib/logto-auth.js';
+
+const CLAIMS = {
+    sub: 'logto_user_1',
+    name: 'Harlon',
+    username: null,
+    picture: 'https://avatars.githubusercontent.com/u/123456',
+    identities: {
+        github: {
+            userId: '123456',
+            details: {
+                rawData: {
+                    login: 'HarlonWang',
+                    bio: 'Android dev',
+                    html_url: 'https://github.com/HarlonWang',
+                },
+            },
+        },
+    },
+};
+
+const DB_ROW = {
+    user_id: 'uuid-1',
+    github_user_id: 123456,
+    github_login: 'HarlonWang',
+    display_name: 'Harlon',
+    avatar_url: 'https://avatars.githubusercontent.com/u/123456',
+    bio: 'Android dev',
+    html_url: 'https://github.com/HarlonWang',
+    created_at: '2026-06-10 00:00:00',
+};
+
+const makeDB = () => ({
+    prepare: vi.fn().mockReturnThis(),
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(DB_ROW),
+});
+
+const makeEnv = () => ({ DB: makeDB(), LOGTO_ENDPOINT: 'https://logto.example' });
+
+const makeRequest = (method = 'GET', authHeader = 'Bearer token-a') => {
+    const headers = authHeader ? { Authorization: authHeader } : {};
+    return new Request('https://api.trendingai.cn/api/me', { method, headers });
+};
+
+function stubUserinfo(status = 200, body = CLAIMS) {
+    const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(body), { status })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+}
+
+describe('GET /api/me', () => {
+    beforeEach(() => {
+        clearAuthCache();
+        vi.restoreAllMocks();
+        vi.stubGlobal('crypto', {
+            ...crypto,
+            randomUUID: vi.fn().mockReturnValue('uuid-1'),
+            subtle: crypto.subtle,
+        });
+    });
+
+    it('OPTIONS 预检返回 CORS 头（含 Authorization）', async () => {
+        const res = await handleMe(makeRequest('OPTIONS'), makeEnv());
+        expect(res.status).toBe(200);
+        expect(res.headers.get('Access-Control-Allow-Headers')).toContain('Authorization');
+    });
+
+    it('非 GET 返回 405', async () => {
+        const res = await handleMe(makeRequest('POST'), makeEnv());
+        expect(res.status).toBe(405);
+    });
+
+    it('无 token 返回 401，且不触发 DB 写入', async () => {
+        const env = makeEnv();
+        const res = await handleMe(makeRequest('GET', null), env);
+        expect(res.status).toBe(401);
+        expect(env.DB.prepare).not.toHaveBeenCalled();
+    });
+
+    it('userinfo 校验失败返回 401', async () => {
+        stubUserinfo(401, {});
+        const res = await handleMe(makeRequest(), makeEnv());
+        expect(res.status).toBe(401);
+    });
+
+    it('有效 token：upsert app_users 并返回 user', async () => {
+        stubUserinfo();
+        const env = makeEnv();
+        const res = await handleMe(makeRequest(), env);
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+        expect(body.user.user_id).toBe('uuid-1');
+        expect(body.user.github_login).toBe('HarlonWang');
+
+        const sql = env.DB.prepare.mock.calls[0][0];
+        expect(sql).toContain('INSERT INTO app_users');
+        expect(sql).toContain('ON CONFLICT(logto_sub)');
+
+        const bound = env.DB.bind.mock.calls[0];
+        expect(bound[1]).toBe('logto_user_1');  // logto_sub
+        expect(bound[2]).toBe(123456);          // github_user_id（已转数字）
+        expect(bound[3]).toBe('HarlonWang');    // github_login
+    });
+
+    it('identities 缺失时仍能建档（github 字段为 null）', async () => {
+        stubUserinfo(200, { sub: 'logto_user_2', name: 'NoGithub', picture: null });
+        const env = makeEnv();
+        const res = await handleMe(makeRequest('GET', 'Bearer token-b'), env);
+        expect(res.status).toBe(200);
+
+        const bound = env.DB.bind.mock.calls[0];
+        expect(bound[1]).toBe('logto_user_2');
+        expect(bound[2]).toBeNull(); // github_user_id
+        expect(bound[3]).toBeNull(); // github_login
+    });
+});
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `npx vitest run tests/api/me.test.js`
+Expected: FAIL —— `Cannot find module '../../src/api/me.js'`
+
+- [ ] **Step 3: 实现 `src/api/me.js`**
+
+```javascript
+import { handlePreflight, jsonOk, jsonError } from '../lib/http.js';
+import { requireAuth } from '../lib/logto-auth.js';
+
+/**
+ * 从 Logto userinfo claims 提取建档字段。
+ * github 基础资料来自 identities claim（客户端登录 scope 须含 identities），
+ * rawData 是 GitHub /user 的原始 JSON，字段可能缺失，全部做空值兜底。
+ */
+function extractProfile(claims) {
+    const github = claims.identities?.github;
+    const raw = github?.details?.rawData ?? {};
+    const parsedId = github?.userId != null ? Number(github.userId) : NaN;
+    const githubUserId = Number.isFinite(parsedId) ? parsedId : null;
+    const githubLogin = raw.login ?? claims.username ?? null;
+    return {
+        logtoSub: claims.sub,
+        githubUserId,
+        githubLogin,
+        displayName: claims.name ?? githubLogin,
+        avatarUrl: claims.picture ?? raw.avatar_url ?? null,
+        bio: raw.bio ?? null,
+        htmlUrl: raw.html_url ?? (githubLogin ? `https://github.com/${githubLogin}` : null),
+    };
+}
+
+export async function handleMe(request, env) {
+    if (request.method === 'OPTIONS') return handlePreflight();
+    if (request.method !== 'GET') return jsonError('Method not allowed', 405);
+
+    const { claims, errorResponse } = await requireAuth(request, env);
+    if (errorResponse) return errorResponse;
+    if (!claims?.sub) return jsonError('Unauthorized', 401);
+
+    const p = extractProfile(claims);
+    const user = await env.DB.prepare(
+        `INSERT INTO app_users
+            (user_id, logto_sub, github_user_id, github_login, display_name,
+             avatar_url, bio, html_url, raw_profile, last_login_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+         ON CONFLICT(logto_sub) DO UPDATE SET
+            github_user_id = excluded.github_user_id,
+            github_login   = excluded.github_login,
+            display_name   = excluded.display_name,
+            avatar_url     = excluded.avatar_url,
+            bio            = excluded.bio,
+            html_url       = excluded.html_url,
+            raw_profile    = excluded.raw_profile,
+            last_login_at  = excluded.last_login_at
+         RETURNING user_id, github_user_id, github_login, display_name,
+                   avatar_url, bio, html_url, created_at`
+    ).bind(
+        crypto.randomUUID(),
+        p.logtoSub,
+        p.githubUserId,
+        p.githubLogin,
+        p.displayName,
+        p.avatarUrl,
+        p.bio,
+        p.htmlUrl,
+        JSON.stringify(claims)
+    ).first();
+
+    return jsonOk({ user }, 0);
+}
+```
+
+> 已知边界（接受）：若同一 GitHub 账号对应的 Logto 用户被删后重建（logto_sub 变了），`github_user_id` UNIQUE 会使 INSERT 失败返回 500。Phase 1 不处理，出现时人工清理旧行。
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `npx vitest run tests/api/me.test.js`
+Expected: 6 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/wanghl/TrendingProjects/github-ai-trending-api add src/api/me.js tests/api/me.test.js
+git -C /Users/wanghl/TrendingProjects/github-ai-trending-api commit -m "feat: GET /api/me——凭 Logto token 建档/刷新 app_users 并返回 profile"
+```
+
+---
+
+### Task 5: 路由注册 + LOGTO_ENDPOINT 变量
+
+**Files:**
+- Modify: `src/index.js`（import 区 + 路由分支区）
+- Modify: `wrangler.toml`
+
+- [ ] **Step 1: `src/index.js` 加路由**
+
+在文件顶部 import 区（与其他 `handleXxx` import 并列）加：
+```javascript
+import { handleMe } from './api/me.js';
+```
+在 fetch handler 的路由分支区（与 `/api/feedback` 等并列）加：
+```javascript
+if (pathname === '/api/me') return handleMe(request, env);
+```
+
+- [ ] **Step 2: `wrangler.toml` 加 vars**
+
+在 `[observability]` 块之前加（公开端点，非机密，不用 secret）：
+```toml
+[vars]
+LOGTO_ENDPOINT = "https://28bniv.logto.app"
+```
+
+- [ ] **Step 3: 全量测试**
+
+Run: `npm test`
+Expected: 全部 PASS（7 个测试文件）
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/wanghl/TrendingProjects/github-ai-trending-api add src/index.js wrangler.toml
+git -C /Users/wanghl/TrendingProjects/github-ai-trending-api commit -m "feat: 注册 /api/me 路由 + LOGTO_ENDPOINT 配置"
+```
+
+---
+
+### Task 6: 迁移 apply + 部署 + 烟测
+
+- [ ] **Step 1: 远端执行迁移**（项目规则：必须用 migrations apply）
+
+Run: `cd /Users/wanghl/TrendingProjects/github-ai-trending-api && npx wrangler d1 migrations apply trending --remote`
+Expected: `015_add_app_users.sql` 执行成功
+
+- [ ] **Step 2: 部署 Worker**
+
+Run: `npm run deploy`
+Expected: deploy 成功，输出版本号
+
+- [ ] **Step 3: 烟测（无 token 应 401）**
+
+Run: `curl -s -i https://api.trendingai.cn/api/me | head -5`
+Expected: `HTTP/2 401`，body `{"error":"Unauthorized"}`（具体格式以 jsonError 实现为准）
+
+- [ ] **Step 4: 推送**
+
+```bash
+git -C /Users/wanghl/TrendingProjects/github-ai-trending-api push
+```
+
+---
+
+## Part B：客户端（TrendingAI）
+
+### Task 7: 依赖（version catalog + androidApp）
+
+**Files:**
+- Modify: `gradle/libs.versions.toml`
+- Modify: `androidApp/build.gradle.kts`（dependencies 块）
+
+- [ ] **Step 1: catalog 声明**（项目规则：禁止硬编码坐标）
+
+`[versions]` 区加：
+```toml
+logto = "1.1.3"
+```
+`[libraries]` 区加：
+```toml
+logto-android = { module = "io.logto.sdk:android", version.ref = "logto" }
+```
+
+- [ ] **Step 2: androidApp 引用**
+
+`androidApp/build.gradle.kts` 的 `dependencies` 块加（所有 flavor 共用，Logto SDK 来自 mavenCentral 且开源，fdroid flavor 无障碍）：
+```kotlin
+implementation(libs.logto.android)
+```
+
+- [ ] **Step 3: 验证可编译**
+
+Run: `cd /Users/wanghl/TrendingProjects/TrendingAI && ./gradlew :androidApp:assembleGithubDebug -q`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/wanghl/TrendingProjects/TrendingAI add gradle/libs.versions.toml androidApp/build.gradle.kts
+git -C /Users/wanghl/TrendingProjects/TrendingAI commit -m "feat: 引入 Logto Android SDK 1.1.3（version catalog）"
+```
+
+---
+
+### Task 8: shared 层 `AuthManager` 抽象
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/whl/trending/ai/auth/AuthManager.kt`
+
+- [ ] **Step 1: 写抽象（无平台依赖）**
+
+```kotlin
+package whl.trending.ai.auth
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+sealed interface AuthState {
+    data object LoggedOut : AuthState
+    data object LoggingIn : AuthState
+    data object LoggedIn : AuthState
+}
+
+/**
+ * 登录态抽象：shared/UI 只依赖本接口，Logto SDK 只存在于 androidApp。
+ * iOS 未接入前使用 NoopAuthManager（isSupported=false，UI 隐藏登录入口）。
+ */
+interface AuthManager {
+    val isSupported: Boolean
+    val authState: StateFlow<AuthState>
+    fun signIn()
+    fun signOut()
+    suspend fun getAccessToken(): String?
+}
+
+object NoopAuthManager : AuthManager {
+    override val isSupported: Boolean = false
+    override val authState: StateFlow<AuthState> = MutableStateFlow(AuthState.LoggedOut)
+    override fun signIn() {}
+    override fun signOut() {}
+    override suspend fun getAccessToken(): String? = null
+}
+
+/** 仿 globalChatScreen 的依赖反转：Android 在 MainActivity.onCreate 注入实现 */
+var globalAuthManager: AuthManager = NoopAuthManager
+```
+
+- [ ] **Step 2: 编译验证**
+
+Run: `./gradlew :shared:compileDebugKotlinAndroid -q`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/wanghl/TrendingProjects/TrendingAI add shared/src/commonMain/kotlin/whl/trending/ai/auth/AuthManager.kt
+git -C /Users/wanghl/TrendingProjects/TrendingAI commit -m "feat: AuthManager 登录态抽象（shared 不依赖 Logto SDK）"
+```
+
+---
+
+### Task 9: Me 模型 + API + Repository + 头像缓存（TDD）
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/whl/trending/ai/data/model/Me.kt`
+- Modify: `shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt`（类内追加方法）
+- Create: `shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt`
+- Modify: `shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt`
+- Test: `shared/src/commonTest/kotlin/whl/trending/ai/data/model/MeResponseTest.kt`
+- Test: 扩展 `shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt`
+
+- [ ] **Step 1: 写失败测试 `MeResponseTest.kt`**
+
+```kotlin
+package whl.trending.ai.data.model
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MeResponseTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decode_full_payload() {
+        val payload = """
+            {"user":{"user_id":"uuid-1","github_user_id":123456,"github_login":"HarlonWang",
+            "display_name":"Harlon","avatar_url":"https://a.png","bio":"dev",
+            "html_url":"https://github.com/HarlonWang","created_at":"2026-06-10 00:00:00"}}
+        """.trimIndent()
+        val me = json.decodeFromString<MeResponse>(payload)
+        assertEquals("uuid-1", me.user.userId)
+        assertEquals(123456L, me.user.githubUserId)
+        assertEquals("HarlonWang", me.user.githubLogin)
+        assertEquals("https://a.png", me.user.avatarUrl)
+    }
+
+    @Test
+    fun decode_minimal_payload_with_nulls() {
+        val payload = """{"user":{"user_id":"uuid-2"}}"""
+        val me = json.decodeFromString<MeResponse>(payload)
+        assertEquals("uuid-2", me.user.userId)
+        assertNull(me.user.githubLogin)
+        assertNull(me.user.avatarUrl)
+    }
+}
+```
+
+并在 `SettingsManagerTest.kt` 追加（沿用现有 MapSettings + setUp 结构）：
+```kotlin
+@Test
+fun userAvatarUrl_set_and_clear() = runTest {
+    manager.setUserAvatarUrl("https://a.png")
+    assertEquals("https://a.png", settings.getStringOrNull("prefs_user_avatar_url"))
+    manager.setUserAvatarUrl(null)
+    assertEquals(null, settings.getStringOrNull("prefs_user_avatar_url"))
+}
+```
+（若该文件未导入 `runTest`，加 `import kotlinx.coroutines.test.runTest`；若断言不需要挂起则可去掉 runTest 直接写普通 @Test。）
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `./gradlew shared:test --tests "*MeResponseTest*" 2>&1 | tail -20`
+Expected: 编译失败（MeResponse 不存在）
+
+- [ ] **Step 3: 实现 `Me.kt`**
+
+```kotlin
+package whl.trending.ai.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeResponse(val user: MeUser)
+
+@Serializable
+data class MeUser(
+    @SerialName("user_id") val userId: String,
+    @SerialName("github_user_id") val githubUserId: Long? = null,
+    @SerialName("github_login") val githubLogin: String? = null,
+    @SerialName("display_name") val displayName: String? = null,
+    @SerialName("avatar_url") val avatarUrl: String? = null,
+    val bio: String? = null,
+    @SerialName("html_url") val htmlUrl: String? = null,
+    @SerialName("created_at") val createdAt: String? = null,
+)
+```
+
+- [ ] **Step 4: `TrendingApi` 追加 fetchMe**
+
+在 `TrendingApi` 类内（与 `fetchTrending` 并列）追加；文件顶部需要 `import io.ktor.client.request.header` 与 `import io.ktor.http.HttpHeaders`（若已存在则跳过）：
+
+```kotlin
+open suspend fun fetchMe(accessToken: String): MeResponse {
+    val response = client.get("$baseHost/api/me") {
+        header(HttpHeaders.Authorization, "Bearer $accessToken")
+    }
+    return response.body<MeResponse>()
+}
+```
+
+- [ ] **Step 5: `SettingsManager` 追加头像缓存**
+
+在 key 常量区追加：
+```kotlin
+private val USER_AVATAR_KEY = "prefs_user_avatar_url"
+```
+在类内（subscribedEmail 旁）追加：
+```kotlin
+/** 已登录用户头像 URL 缓存：TopBar 入口同步展示用；登出时清空 */
+val userAvatarUrl: Flow<String?> = settings.getStringOrNullFlow(USER_AVATAR_KEY)
+
+fun setUserAvatarUrl(url: String?) {
+    if (url.isNullOrBlank()) {
+        settings.remove(USER_AVATAR_KEY)
+    } else {
+        settings.putString(USER_AVATAR_KEY, url)
+    }
+}
+```
+
+- [ ] **Step 6: 实现 `UserRepository.kt`**
+
+```kotlin
+package whl.trending.ai.data.repository
+
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.model.MeUser
+import whl.trending.ai.data.remote.TrendingApi
+
+class UserRepository(private val api: TrendingApi = TrendingApi()) {
+
+    suspend fun fetchMe(accessToken: String): MeUser = api.fetchMe(accessToken).user
+
+    /**
+     * 登录成功/应用启动（已登录）时调用：服务端建档 + 刷新 last_login_at，并缓存头像。
+     * 失败静默——下次打开 Profile 仍会重试，不阻塞登录主流程。
+     */
+    suspend fun syncMe(accessToken: String?): MeUser? {
+        if (accessToken == null) return null
+        return try {
+            val user = fetchMe(accessToken)
+            globalSettingsManager.setUserAvatarUrl(user.avatarUrl)
+            user
+        } catch (_: Exception) {
+            null
+        }
+    }
+}
+```
+
+- [ ] **Step 7: 运行测试确认通过**
+
+Run: `./gradlew shared:test 2>&1 | tail -5`
+Expected: BUILD SUCCESSFUL（含 MeResponseTest 2 个、SettingsManagerTest 新增 1 个）
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C /Users/wanghl/TrendingProjects/TrendingAI add shared/src/commonMain/kotlin/whl/trending/ai/data shared/src/commonTest
+git -C /Users/wanghl/TrendingProjects/TrendingAI commit -m "feat: /api/me 客户端模型与 UserRepository + 头像缓存"
+```
+
+---
+
+### Task 10: androidApp `LogtoAuthManager`
+
+**Files:**
+- Create: `androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt`
+- Modify: `androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt`（onCreate）
+
+- [ ] **Step 1: 实现 `LogtoAuthManager.kt`**
+
+```kotlin
+package whl.trending.ai.auth
+
+import android.app.Activity
+import io.logto.sdk.android.LogtoClient
+import io.logto.sdk.android.type.LogtoConfig
+import java.lang.ref.WeakReference
+import kotlin.coroutines.resume
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import whl.trending.ai.BuildConfig
+import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.repository.UserRepository
+
+/**
+ * Logto 实现：OIDC PKCE 登录，token 存储/刷新由 SDK 托管。
+ * scope 额外加 identities——Worker 经 userinfo 取 GitHub 数字 ID 建档（设计稿 §7.2/§7.3）。
+ */
+class LogtoAuthManager(activity: Activity) : AuthManager {
+    private val activityRef = WeakReference(activity)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val logtoClient = LogtoClient(
+        LogtoConfig(
+            endpoint = LOGTO_ENDPOINT,
+            appId = LOGTO_APP_ID,
+            scopes = listOf("identities"),
+            resources = null,
+            usingPersistStorage = true,
+        ),
+        activity.application,
+    )
+
+    private val _authState = MutableStateFlow<AuthState>(
+        if (logtoClient.isAuthenticated) AuthState.LoggedIn else AuthState.LoggedOut
+    )
+    override val authState: StateFlow<AuthState> = _authState.asStateFlow()
+    override val isSupported: Boolean = true
+
+    override fun signIn() {
+        val activity = activityRef.get() ?: return
+        _authState.value = AuthState.LoggingIn
+        logtoClient.signIn(activity, REDIRECT_URI) { logtoException ->
+            if (logtoException == null && logtoClient.isAuthenticated) {
+                _authState.value = AuthState.LoggedIn
+                trackEvent("sign_in_success")
+                // 登录即建档：失败静默，打开 Profile 时会重试
+                scope.launch { UserRepository().syncMe(getAccessToken()) }
+            } else {
+                _authState.value = AuthState.LoggedOut
+                if (logtoException != null) trackEvent("sign_in_failed")
+            }
+        }
+    }
+
+    override fun signOut() {
+        logtoClient.signOut { /* 本地凭证已清除即视为登出，远端失败不阻塞 */ }
+        globalSettingsManager.setUserAvatarUrl(null)
+        _authState.value = AuthState.LoggedOut
+        trackEvent("sign_out")
+    }
+
+    override suspend fun getAccessToken(): String? =
+        suspendCancellableCoroutine { cont ->
+            logtoClient.getAccessToken { _, accessToken ->
+                cont.resume(accessToken?.token)
+            }
+        }
+
+    companion object {
+        private const val LOGTO_ENDPOINT = "https://28bniv.logto.app"
+        private const val LOGTO_APP_ID = "lasqslwwdjbim73vgkapj"
+
+        /** release: cn.trendingai://whl.trending.ai/callback；debug 包名带 .debug，两条均已在 Logto 注册 */
+        private val REDIRECT_URI = "cn.trendingai://${BuildConfig.APPLICATION_ID}/callback"
+    }
+}
+```
+
+> 若编译时 SDK 回调签名不符（`getAccessToken`/`signIn` 的参数个数），以 `io.logto.sdk.android.LogtoClient` 的实际签名为准微调 lambda 参数——SDK 1.1.3 的 Completion 回调形如 `(logtoException, result) -> Unit`，signIn 完成回调只有 `(logtoException) -> Unit`。
+> AndroidManifest 无需新增配置（SDK 通过内置 WebView 拦截自定义 scheme 回跳，quickstart 仅要求 INTERNET 权限，项目已有）。若真机实测登录后未回跳，再按 SDK README 排查。
+
+- [ ] **Step 2: MainActivity 注册**
+
+在 `MainActivity.onCreate` 中，`AndroidContextHolder.initialize(this)` 之后追加：
+```kotlin
+// 注入 Logto 登录实现（仿 globalChatScreen 的依赖反转；配置变更重建时重新绑定 activity）
+whl.trending.ai.auth.globalAuthManager = whl.trending.ai.auth.LogtoAuthManager(this)
+```
+
+- [ ] **Step 3: 编译验证**
+
+Run: `./gradlew :androidApp:assembleGithubDebug -q`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/wanghl/TrendingProjects/TrendingAI add androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
+git -C /Users/wanghl/TrendingProjects/TrendingAI commit -m "feat: LogtoAuthManager——Android 端 Logto 登录实现并注入 globalAuthManager"
+```
+
+---
+
+### Task 11: Profile 页（ViewModel + Screen + 文案）
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt`
+- Create: `shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt`
+- Modify: `shared/src/commonMain/composeResources/values/strings.xml`
+- Modify: `shared/src/commonMain/composeResources/values-zh/strings.xml`
+
+- [ ] **Step 1: 文案**
+
+`values/strings.xml` 追加：
+```xml
+<string name="profile_title">Profile</string>
+<string name="sign_in">Sign in</string>
+<string name="sign_out">Sign out</string>
+<string name="profile_open_github">Open on GitHub</string>
+<string name="profile_load_failed">Failed to load profile</string>
+<string name="profile_retry">Retry</string>
+```
+`values-zh/strings.xml` 追加：
+```xml
+<string name="profile_title">个人主页</string>
+<string name="sign_in">登录</string>
+<string name="sign_out">退出登录</string>
+<string name="profile_open_github">在 GitHub 打开</string>
+<string name="profile_load_failed">加载失败</string>
+<string name="profile_retry">重试</string>
+```
+
+- [ ] **Step 2: `ProfileViewModel.kt`**
+
+```kotlin
+package whl.trending.ai.ui.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import whl.trending.ai.auth.AuthManager
+import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.data.model.MeUser
+import whl.trending.ai.data.repository.UserRepository
+
+data class ProfileUiState(
+    val isLoading: Boolean = true,
+    val user: MeUser? = null,
+    val isError: Boolean = false,
+)
+
+class ProfileViewModel(
+    private val repository: UserRepository = UserRepository(),
+    private val authManager: AuthManager = globalAuthManager,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(ProfileUiState())
+    val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.value = ProfileUiState(isLoading = true)
+            val token = authManager.getAccessToken()
+            if (token == null) {
+                _uiState.value = ProfileUiState(isLoading = false, isError = true)
+                return@launch
+            }
+            runCatching { repository.fetchMe(token) }
+                .onSuccess { _uiState.value = ProfileUiState(isLoading = false, user = it) }
+                .onFailure { _uiState.value = ProfileUiState(isLoading = false, isError = true) }
+        }
+    }
+
+    fun signOut() = authManager.signOut()
+}
+```
+
+- [ ] **Step 3: `ProfileScreen.kt`**
+
+```kotlin
+package whl.trending.ai.ui.profile
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil3.compose.AsyncImage
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.profile_load_failed
+import trendingai.shared.generated.resources.profile_open_github
+import trendingai.shared.generated.resources.profile_retry
+import trendingai.shared.generated.resources.profile_title
+import trendingai.shared.generated.resources.sign_out
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(onBack: () -> Unit) {
+    val viewModel: ProfileViewModel = viewModel { ProfileViewModel() }
+    val uiState by viewModel.uiState.collectAsState()
+    val uriHandler = LocalUriHandler.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(Res.string.profile_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            when {
+                uiState.isLoading -> CircularProgressIndicator(Modifier.padding(top = 48.dp))
+
+                uiState.isError -> {
+                    Text(
+                        text = stringResource(Res.string.profile_load_failed),
+                        modifier = Modifier.padding(top = 48.dp)
+                    )
+                    Button(onClick = { viewModel.load() }) {
+                        Text(stringResource(Res.string.profile_retry))
+                    }
+                }
+
+                else -> uiState.user?.let { user ->
+                    AsyncImage(
+                        model = user.avatarUrl,
+                        contentDescription = null,
+                        modifier = Modifier.size(96.dp).clip(CircleShape)
+                    )
+                    Text(
+                        text = user.displayName ?: user.githubLogin.orEmpty(),
+                        style = MaterialTheme.typography.titleLarge
+                    )
+                    user.githubLogin?.let {
+                        Text(
+                            text = "@$it",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    user.bio?.takeIf { it.isNotBlank() }?.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    user.htmlUrl?.let { url ->
+                        Button(
+                            onClick = { uriHandler.openUri(url) },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(stringResource(Res.string.profile_open_github))
+                        }
+                    }
+                    OutlinedButton(
+                        onClick = {
+                            viewModel.signOut()
+                            onBack()
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(Res.string.sign_out))
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: 编译验证**
+
+Run: `./gradlew :androidApp:assembleGithubDebug -q`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/wanghl/TrendingProjects/TrendingAI add shared/src/commonMain/kotlin/whl/trending/ai/ui/profile shared/src/commonMain/composeResources
+git -C /Users/wanghl/TrendingProjects/TrendingAI commit -m "feat: Profile 页——头像/昵称/login/bio + 跳 GitHub + 登出"
+```
+
+---
+
+### Task 12: 导航 + TopBar 登录入口
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt`
+- Modify: `shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt`
+
+- [ ] **Step 1: `App.kt` 注册 Profile 路由**
+
+路由声明区（`data object Favorites` 旁）加：
+```kotlin
+data object Profile
+```
+import 区加：
+```kotlin
+import whl.trending.ai.ui.profile.ProfileScreen
+```
+`entryProvider` 的 `when` 中（`is Favorites` 分支旁）加：
+```kotlin
+is Profile -> NavEntry(key) {
+    ProfileScreen(onBack = { backStack.safePop() })
+}
+```
+`is Home` 分支的 `HomeScreen(...)` 调用追加参数：
+```kotlin
+onNavigateToProfile = {
+    backStack.add(Profile)
+},
+```
+
+- [ ] **Step 2: `HomeScreen.kt` 接线**
+
+(a) 函数签名追加参数（`onOpenUrl` 旁）：
+```kotlin
+onNavigateToProfile: () -> Unit = {}
+```
+
+(b) 函数体内（`val scrollBehavior = ...` 之前）追加：
+```kotlin
+val authManager = globalAuthManager
+val authState by authManager.authState.collectAsState()
+val userAvatarUrl by globalSettingsManager.userAvatarUrl.collectAsState(null)
+
+// 应用启动且已登录：服务端建档/刷新 last_login_at + 同步头像（幂等，失败静默）
+LaunchedEffect(authState) {
+    if (authState is AuthState.LoggedIn) {
+        UserRepository().syncMe(authManager.getAccessToken())
+    }
+}
+```
+需要的新增 import：
+```kotlin
+import androidx.compose.runtime.LaunchedEffect
+import whl.trending.ai.auth.AuthState
+import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.repository.UserRepository
+```
+
+(c) `TrendingTopBar(...)` 调用处追加实参：
+```kotlin
+showAuthEntry = authManager.isSupported,
+authState = authState,
+userAvatarUrl = userAvatarUrl,
+onProfileClick = {
+    if (authState is AuthState.LoggedIn) onNavigateToProfile() else authManager.signIn()
+},
+```
+
+(d) `TrendingTopBar` 定义：签名追加参数（`onNavigateToSettings` 旁）：
+```kotlin
+showAuthEntry: Boolean,
+authState: AuthState,
+userAvatarUrl: String?,
+onProfileClick: () -> Unit,
+```
+`actions = { ... }` 块开头（History 按钮之前）插入：
+```kotlin
+if (showAuthEntry) {
+    IconButton(onClick = onProfileClick, enabled = authState !is AuthState.LoggingIn) {
+        when {
+            authState is AuthState.LoggedIn && userAvatarUrl != null -> AsyncImage(
+                model = userAvatarUrl,
+                contentDescription = stringResource(Res.string.profile_title),
+                modifier = Modifier.size(28.dp).clip(CircleShape)
+            )
+            authState is AuthState.LoggingIn -> CircularProgressIndicator(
+                modifier = Modifier.size(20.dp),
+                strokeWidth = 2.dp
+            )
+            else -> Icon(
+                Icons.Default.AccountCircle,
+                contentDescription = stringResource(Res.string.sign_in)
+            )
+        }
+    }
+}
+```
+需要的新增 import（已有的跳过）：
+```kotlin
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.ui.draw.clip
+import coil3.compose.AsyncImage
+import trendingai.shared.generated.resources.profile_title
+import trendingai.shared.generated.resources.sign_in
+```
+（该文件的 Res 字符串多为通配 import `trendingai.shared.generated.resources.*` 风格则无需逐条加，以现有 import 风格为准。）
+
+- [ ] **Step 3: 编译 + 全量 shared 测试**
+
+Run: `./gradlew :androidApp:assembleGithubDebug shared:test 2>&1 | tail -5`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/wanghl/TrendingProjects/TrendingAI add shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+git -C /Users/wanghl/TrendingProjects/TrendingAI commit -m "feat: GitHub 页 TopBar 登录入口 + Profile 导航接线"
+```
+
+---
+
+### Task 13: 端到端手工验证
+
+- [ ] **Step 1: 安装到模拟器/真机**
+
+Run: `./gradlew :androidApp:installGithubDebug`
+
+- [ ] **Step 2: 按设计稿 §11 验证清单逐项检查**
+
+1. GitHub Tab 右上角出现登录图标 → 点击拉起 Logto 登录页 → 「Continue with GitHub」→ GitHub 授权 → 回跳 App，图标变为头像
+2. 点头像进 Profile：头像/昵称/@login/bio 正确展示；「在 GitHub 打开」跳转浏览器
+3. 后端建档核对：
+   `cd /Users/wanghl/TrendingProjects/github-ai-trending-api && npx wrangler d1 execute trending --remote --command "SELECT user_id, logto_sub, github_user_id, github_login, last_login_at FROM app_users"`
+   Expected: 一行记录，`github_user_id` 为你的 GitHub 数字 ID
+4. 登出 → 回到首页，图标恢复为未登录态；再次登录 → app_users 仍为同一行（`user_id` 不变，`last_login_at` 更新）
+5. 取消登录（登录页直接返回）→ 状态回到未登录，无崩溃
+6. 杀进程重启 → 仍为登录态（SDK 持久化），TopBar 直接显示头像
+
+- [ ] **Step 3: 推送客户端提交**
+
+```bash
+git -C /Users/wanghl/TrendingProjects/TrendingAI push
+```
+
+> 发现问题时：UI/交互问题就地修复后补充 commit；SDK 行为与计划假设不符（回调签名、回跳方式）以 SDK 实际为准修正 Task 10 的实现。
+
+---
+
+## Phase 1 不做（防 scope 蔓延）
+
+- 不接 Account API / 不取 GitHub token / 不做 feed（Phase 2）
+- 不做 followers/following/repos 计数（需 GitHub token，Phase 2）
+- 不做 iOS UI（NoopAuthManager 隐藏入口）
+- 不绑自定义域名 `auth.trendingai.cn`、不做国内可达性实测自动化（上线前人工验证）

--- a/docs/superpowers/specs/2026-06-09-trendingai-logto-auth-design.md
+++ b/docs/superpowers/specs/2026-06-09-trendingai-logto-auth-design.md
@@ -1,0 +1,240 @@
+# TrendingAI 接入 Logto：GitHub 登录 + 个人主页 + 动态流（设计文档）
+
+> 日期：2026-06-09　修订：2026-06-10（按最新官方资料逐项核实后修正，修正记录见 §12）
+> 范围：仅 TrendingAI（不涉及 Tono 或其他 App）
+> 状态：设计稿 v2，待评审
+
+## 一、背景与目标
+
+TrendingAI 当前是一个无登录态的内容浏览产品（Daily Picks + 三源浏览）。本次要新增**用户体系的第一块**：
+
+- 接入 **GitHub 登录**
+- 登录后展示用户的 **GitHub 个人主页（Profile）**
+- 展示用户的 **GitHub 动态流（Feed）** = GitHub Dashboard 风格的"关注的人/仓库动态"
+
+**战略意图**：表面是"加个人主页 + feed"，真实目的是**先把"用户"这个实体在产品里立起来**，为后续的 AI chat、订阅收费打地基。
+
+**关键决策**：用户体系不自建，**接入 Logto Cloud（Free 档）作为身份基础设施**。本次按"Logto Cloud 国内可达"假设推进（见 §9 风险）。
+
+## 二、为什么用 Logto，而不是自建
+
+1. **自建身份服务（OAuth 流程、邮箱 OTP、session 轮换、token 加密、限频、发信）是一个完整的新子系统**，且安全细节多、容易做错、需长期自维护。
+2. Logto 把这些**全部内置**：GitHub 社交登录、邮箱 OTP、OIDC/PKCE、token 签发与刷新、Secret Vault（替你存 GitHub access token）、Account API。
+3. Logto Cloud **Free 档**（已核实，2026-06）：50K MAU、**50K access token/月**（refresh token 不计费）、3 应用、3 社交连接器、1 M2M 应用、1 个自定义域名、Account API、Secret Vault，无需信用卡。远超 TrendingAI 当前体量。
+4. **Free 档不含 API 资源（API resources）**——这是 2025-09 调价后的新规则，导致 Worker 验证方式与初稿不同（见 §5）。
+5. 接入后 TrendingAI 自己的代码只剩两件事：**客户端拉起登录拿 token**、**后端校验 token 取用户 ID**。
+
+> Logto 是标准 OIDC，未来若新增其他 App 可复用同一租户实现"一个账号通用"，但**本设计不为此做任何额外工作**。
+> 开发期可使用 Logto **dev tenant**（自带全部 Pro 特性，不可用于生产）先行开发，生产用 Free 档正式租户。
+
+## 三、范围
+
+### 本次要做（完整方案）
+- TrendingAI Android 接入 Logto 登录（GitHub）
+- 登录入口放在 **GitHub 页 TopAppBar 右上角头像**
+- 登录后：Profile 展示 + Feed 动态流（全量活动流）
+- Worker 端：校验 Logto token + 用户建档表（`/api/me`）
+
+### 推荐的实施分期（见 §8）
+- **Phase 1**：登录 + 建档 + 极简 Profile（验证用户体系脊柱）
+- **Phase 2**：Feed 动态流（**纯客户端工作**，经 Account API 取 GitHub token 直调 GitHub）
+
+### 明确不做（Non-goals）
+- 不做 AI chat、订阅收费（仅留好挂载点：业务/会员按 `logto_sub` 挂在 D1，不依赖 Logto 付费特性）
+- 不做 iOS UI（KMP shared 层就绪，后续接）
+- **不碰 Tono 或任何其他项目**
+- 不做密码登录（Logto 邮箱方式走 OTP）
+- 本次登录方式只启用 **GitHub**；邮箱 OTP 可在 Logto 控制台随时开启，无需改代码（但仅 GitHub 登录的用户有 feed，见 §6）
+
+## 四、整体架构
+
+```
+                ┌──────────────────────────────────────────────┐
+                │            Logto Cloud（Free 档租户）           │
+                │  连接器：GitHub 社交（store tokens 开启）          │
+                │  应用：TrendingAI-Android（Native）              │
+                │  Account API：启用（客户端取 GitHub token）        │
+                │  自定义域名：auth.trendingai.cn（推荐）             │
+                └──────────────────────────────────────────────┘
+        ▲ OIDC 登录(Custom Tab)     ▲ Account API        ▲ userinfo 校验
+        │                          │ 取 GitHub token     │ (opaque token→sub)
+ ┌────────────────┐                │            ┌──────────────────────┐
+ │ TrendingAI      │ ── access token ──────────▶│ Cloudflare Worker     │
+ │ Android(KMP)    │                            │ userinfo→sub→建档      │
+ │                 │ ── GitHub token 直调 ──┐    │ app_users(logto_sub)  │
+ └────────────────┘                        │    │ /api/me               │
+                                           ▼    └──────────────────────┘
+                                    api.github.com
+                                 (profile 计数 / received_events)
+```
+
+**身份职责切分**：
+- **Logto** 拥有"你是谁"（identity、登录、token、GitHub 授权与 token 保管）
+- **TrendingAI Worker** 拥有"你在本 App 是什么"（按 `logto_sub` 挂的业务数据、未来会员）
+- **GitHub 数据（profile 计数、feed）由客户端直连 GitHub API**，Worker 不经手（原因见 §6）
+
+## 五、登录与 Worker 校验（OIDC Authorization Code + PKCE）
+
+```
+① App 点 TopAppBar 头像（未登录）
+② Logto Android SDK 拉起 Logto 托管登录页（Custom Tab）
+③ 用户点「使用 GitHub 登录」
+④ 【Logto 内部】完成 GitHub OAuth 授权（GitHub secret 由 Logto 连接器持有）
+⑤ Logto 回跳 App（自定义 scheme，如 cn.trendingai://<package>/callback）带 code
+⑥ SDK 用 PKCE 换取 id_token + access_token + refresh_token，并安全存储
+⑦ App 用 access_token 调 api.trendingai.cn
+⑧ Worker 拿该 token 调 Logto userinfo 端点换取 sub → upsert 建档 → 放行
+```
+
+**关键点（v2 修正）**：
+
+- **Free 档无 API 资源 → access token 是 opaque token，无法 JWKS 离线验签**。Worker 改为调 Logto **userinfo 端点**在线校验（`GET <logto-endpoint>/oidc/me`，Bearer 带用户 token），返回 sub 与基础 claims。
+- **校验结果按 token 做短期缓存**（isolate 内存，key 为 token 哈希，TTL ≤ 10 分钟），多数请求不产生额外往返。
+- **升级路径**：未来订阅收费上线、升 Pro（$24/月）后，注册 `https://api.trendingai.cn` API 资源，切换为 JWT + JWKS 离线验签；改动局限在 `logto-auth.js` 一个文件，客户端只需在 LogtoConfig 加 `resources`。
+- Native app 是 OIDC public client，PKCE 免 client_secret；token 存储与刷新由 SDK 托管（SDK 默认请求 `openid profile offline_access`）。
+- Redirect 用 Logto SDK 的自定义 scheme 方案（`$(SCHEME)://$(PACKAGE)/callback`），无需 App Links 服务端配置。
+
+## 六、Feed 数据方案（v2 重写）
+
+- **数据源**：GitHub `GET /users/{login}/received_events`（最接近 Dashboard Feed 的官方端点）
+- **硬限制（已按 2026-06 官方文档核实，如实告知用户/UI 兜底）**：
+  - 最多约 **300 条、仅最近 30 天**（旧资料的"90 天"已失效）
+  - 事件**非实时**，延迟 30 秒 ~ 6 小时
+  - 用本人 token 调用时**含私有事件**（比初稿假设的"仅公开"更丰富；私有可见范围受 OAuth scope 约束，`read:user` 下以公开为主）
+- **GitHub token 链路（核心修正）**：Logto Secret Vault 中的第三方 token **只能由终端用户经 Account API 取回**（`GET /my-account/identities/github/access-token`，凭用户自己的 Logto token）；**后端 Management API 只能读元数据、拿不到 token 本体**。因此：
+  - **客户端**经 Account API 取 GitHub token → **直调 GitHub API**（profile 计数 + feed）
+  - Worker 的 feed/profile 代理层**整个取消**——既不可行也不再需要
+  - GitHub OAuth App 的 access token **永不过期**（无 refresh token，连接器 scope 切勿加 `offline_access`），客户端可长期缓存，失效（用户撤销授权）时经 Logto Social Verification API 重新授权
+- **展示形态**：**全量活动流**——Release / PullRequest(开·合) / Push(commit) / Watch(star) / Fork / Create(建仓·分支) / Issues / IssueComment 等全部按时间倒序渲染（事件归一化逻辑从 Worker 移至 KMP shared 层）
+- **scope**：Logto GitHub 连接器留空即默认 `read:user`，够用
+- **缓存/配额**：received_events 按用户 5000 次/小时，远够用；客户端用 ETag 轮询命中 304 时不计配额
+
+> 仅通过邮箱 OTP 登录（未来若开启）的用户没有 GitHub token → 无 feed。本次只启用 GitHub 登录，不存在此情况。
+> 若实测国内直连 `api.github.com` 不稳，兜底方案：客户端把 GitHub token 放请求头，经 Worker 纯透传代理（Worker 不存 token），见 §9。
+
+## 七、详细设计
+
+### 7.1 Logto 一次性配置（控制台）
+
+1. 创建租户（Cloud Free 档；开发期可先用 dev tenant）
+2. **GitHub 社交连接器**：填 GitHub OAuth App 的 client_id/secret；Scopes 留空（默认 `read:user`）；开启 **Store tokens for persistent API access**；profile 同步策略选 "Always sync at sign-in"
+3. **登录体验**：启用「GitHub」登录方式，配品牌与中英文案
+4. **注册应用**：`TrendingAI-Android`（Native 类型）→ 拿 app_id，配 redirect URI（自定义 scheme）
+5. **启用 Account API**：Console > Sign-in & Account > Account center（客户端取 GitHub token 的前提）
+6. **（推荐）绑定自定义域名** `auth.trendingai.cn`：与 `api.trendingai.cn` 同走 Cloudflare 边缘，降低国内可达性风险
+7. ~~注册 API 资源~~（Free 档不可用，升 Pro 后再做）
+
+### 7.2 客户端（KMP / Android）
+
+- `androidApp` 接入 **Logto 官方 Android SDK**（`io.logto.sdk:android:1.1.3`，minSdk 24，满足现状）；用 `expect/actual` 或接口把"登录态 + 当前 access token + Account API 调用"暴露给 `shared`。iOS 后续接 Logto Swift SDK，`shared` 不变。
+- **shared 层**（现在写好，跨平台）：
+  - `AuthState`：LoggedOut / LoggingIn / LoggedIn（封装 SDK，业务页面只看状态）
+  - Ktor `ApiClient`：自动在请求头挂 Logto access token，调 `api.trendingai.cn`
+  - `GithubClient`：持有经 Account API 取回的 GitHub token，直调 `api.github.com`（带 ETag 缓存）
+  - `ProfileRepository`、`FeedRepository`（分页 + 事件归一化：type / actor / repo / 一句话摘要 / created_at / target_url）
+- **Android UI**：
+  - GitHub 页 `TrendingTopBar`（`HomeScreen.kt` 的 `actions` 区）新增**头像/登录 IconButton**
+    - 未登录：显示登录图标，点击 → SDK 拉起 Logto 登录
+    - 已登录：显示用户头像，点击 → 进入 Profile
+  - **Profile 页**：头像 / 昵称 / GitHub login / bio / followers·following·repos 计数（直调 GitHub `GET /user`）/ 跳 GitHub / 登出
+  - **Feed 列表**：分页、下拉刷新、按事件类型渲染、点击用 Custom Tab 打开 GitHub 原页；空态/错误/加载态；触达 30 天/300 条上限时展示"已到底"提示
+- 登录为**可选加法**：现有 Daily Picks / 三源浏览 / 历史保持免登录可用，登录只解锁 Profile + Feed。
+
+### 7.3 后端（Cloudflare Worker）
+
+现有后端是手写 if 路由 + D1（无框架、无 KV）。改动**与现有 trending/picks/feed 业务零交叉**，且比初稿进一步缩小。
+
+**新增文件**：
+- `src/lib/logto-auth.js`：
+  - `requireAuth(request, env)`：取 Bearer token → 查 isolate 内存缓存 → 未命中则调 Logto userinfo 端点校验并缓存（TTL ≤ 10 分钟）→ 返回 `{ sub, name, picture, ... }`，401 兜底
+  - 不依赖 `jose`（无 JWT 验签；该依赖留到升 Pro 切 JWKS 时再加）
+- `src/api/auth.js`：
+  - `GET /api/me`：凭 token 取/建当前用户，返回 profile 快照
+
+**新增迁移 `migrations/015_app_users.sql`**：
+```sql
+CREATE TABLE IF NOT EXISTS app_users (
+  logto_sub    TEXT PRIMARY KEY,   -- Logto 用户 ID（身份锚点）
+  github_login TEXT,
+  display_name TEXT,
+  avatar_url   TEXT,
+  bio          TEXT,
+  html_url     TEXT,
+  raw_profile  TEXT,               -- 最近一次 profile 快照 JSON
+  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  last_login_at TEXT
+  -- 未来：订阅/会员 entitlement 按 logto_sub 挂（本表扩列或独立表）
+);
+```
+首次带 token 访问 `/api/me` 时 upsert（或后续接 Logto webhook 建档，Free 档含 1 个 webhook）。
+
+**改动现有文件**：
+- `src/index.js`：加 1 条路由 `if`（`/api/me`）
+- vars：Logto endpoint（租户域名或 `auth.trendingai.cn`）；无需 M2M secret（Phase 1/2 都用不到 Management API）
+
+**初稿中已取消的部分**：~~`src/lib/logto-vault.js`~~、~~`src/api/github-proxy.js`~~（Secret Vault 后端取不到 token，GitHub 数据改由客户端直连，见 §6）
+
+### 7.4 相对 DIY 方案，后端被省掉的部分
+
+- ❌ OAuth start/callback/session/logout 端点
+- ❌ `sessions` / `login_sessions` 表与 session 轮换
+- ❌ `email_otp` 表 + OTP 生成/限频/发信
+- ❌ token 加密（`crypto.js`）—— 改由 Logto Secret Vault 托管
+- ❌ feed/profile 代理与事件归一化（移至客户端）
+
+后端从"一个新子系统"缩成"**一次 userinfo 校验 + 一张表**"。
+
+## 八、推荐的实施分期
+
+| 阶段 | 内容 | 理由 |
+|---|---|---|
+| **Phase 1** | 登录 + 建档(`app_users`) + 极简 Profile（TopAppBar 头像入口） | 用最小 UI 验证"身份脊柱"端到端跑通；后端只需 `logto-auth.js` + `/api/me` + 一张表 |
+| **Phase 2** | Feed 动态流（Account API 取 token + 客户端直调 received_events + 事件归一化） | **纯客户端工作，后端零改动**；脊柱稳了再投入 |
+
+> Phase 1 的 Profile 基础字段（头像/昵称/login/bio）直接来自 Logto 身份声明（id_token/userinfo，社交连接器登录时已带回），落库到 `app_users` 即可，无需调 GitHub。需要 GitHub token 的部分（关注/仓库计数的实时刷新、feed）全部推迟到 Phase 2。
+
+## 九、风险与待办
+
+1. **国内可达性（唯一硬阻断，当前按"通"假设）** ⚠️
+   开发机有 TUN 全局代理，**无法在本机实测**。缓解与验证：
+   - Free 档含 1 个自定义域名 → 绑 `auth.trendingai.cn`，与已验证国内可用的 `api.trendingai.cn` 同走 Cloudflare 边缘，风险显著低于直连 `*.logto.app`
+   - 上线前用无代理的国内真机实测登录页 / userinfo / token 端点
+   - 不通的出路：自建 Logto OSS（Docker + PostgreSQL，破坏纯 serverless）或本功能延后
+2. **客户端直连 `api.github.com` 的国内可达性**：feed/计数走客户端直连，国内偶有不稳。兜底：Worker 加纯透传代理（客户端把 GitHub token 放头里，Worker 不存储），改动很小。
+3. **供应商依赖**：auth 在关键路径。userinfo 在线校验意味着 Logto 故障时新 token 无法校验（缓存内的不受影响）；升 Pro 切离线验签后此依赖消失。
+4. **Free 档 50K access token/月**：当前体量绰绰有余；用户量上来后监控用量，超限即是该升 Pro 的信号（届时也该切 JWT 验签）。
+5. **Secret Vault 取 token 仅限客户端**：这是 Logto 当前产品设计（开发者只能读元数据）。若未来后端确需代调 GitHub，用兜底透传方案，不依赖 Logto 改产品。
+6. **Account API 细节**：客户端调 `/my-account/identities/github/access-token` 所需的 token 形态与 scope，接入时按文档确认（控制台需先启用 Account center）。
+
+## 十、已对齐的决策清单
+
+- 用户体系：接入 Logto Cloud Free 档，不自建 ✅
+- Worker 校验方式：**opaque token + userinfo 在线校验（短缓存）**；升 Pro 后切 JWT 离线验签 ✅（2026-06-10 拍板）
+- 登录即在身份层建立用户（`logto_sub` 为锚点），后端 `app_users` 建档 ✅
+- 登录方式：本次仅 GitHub；邮箱 OTP 留作 Logto 侧可开关 ✅
+- GitHub 权限：默认 `read:user`（最小化）✅
+- 登录定位：可选加法，不拦截现有内容 ✅
+- 登录入口：GitHub 页 TopAppBar 右上角头像 ✅
+- Feed：全量活动流，源自 received_events，**客户端直连 GitHub** ✅
+- 端范围：仅 Android（KMP shared 跨平台就绪）✅
+- 不碰 Tono ✅
+
+## 十一、验证方式
+
+1. **Logto 配置**：控制台完成 GitHub 连接器（含 Store tokens）+ 应用 + Account center 启用
+2. **客户端**：Android 模拟器走通 登录→拿 token→Profile 展示；登出；Account API 取到 GitHub token 并成功直调 GitHub
+3. **后端**：本地/远端 Worker 用真实 Logto token 经 userinfo 校验通过，`/api/me` 正确建档；缓存生效（同 token 第二次请求不打 userinfo）
+4. **边界**：取消登录、access token 过期自动刷新、feed 为空态、received_events 到达 30 天/300 条上限停止分页、GitHub token 被用户撤销后的重授权
+5. **国内可达性**：上线前对 Logto 登录页与 OIDC 端点（含自定义域名）做无代理国内真机实测
+
+## 十二、v2 修订记录（2026-06-10，基于最新官方资料核实）
+
+| # | 初稿假设 | 核实结果 | 设计影响 |
+|---|---|---|---|
+| 1 | Free 档可注册 API 资源，JWT + JWKS 离线验签 | **2025-09 调价后 Free 档 API 资源为 0**（Pro $24/月含 3 个）；Free 档另有 50K access token/月计量 | Worker 改为 userinfo 在线校验 + 短缓存；升 Pro 后再切离线验签 |
+| 2 | Worker 用 M2M 凭据从 Secret Vault 取 GitHub token 代理 feed | **token 本体只有终端用户经 Account API 能取**，后端只能读元数据 | 客户端直调 GitHub；Worker 代理层取消，Phase 2 后端零改动 |
+| 3 | received_events 约 90 天窗口、仅公开事件 | **30 天**/300 条；本人 token 可见私有事件；延迟 30s~6h | UI 文案与分页到底逻辑按 30 天；feed 内容比预期更丰富 |
+| 4 | 回跳用 App Links | SDK 标准方案为自定义 scheme | 接入更简单，无需服务端 App Links 配置 |
+| 5 | GitHub token 需关注过期刷新 | GitHub OAuth App token **永不过期**（勿加 `offline_access`） | 客户端可长期缓存，仅需处理用户主动撤销 |
+
+主要依据：[Logto Pricing](https://logto.io/pricing)、[2025-09 调价公告](https://blog.logto.io/pricing-sep-2025)、[计费文档](https://docs.logto.io/logto-cloud/billing-and-pricing)、[Secret Vault / 第三方 token](https://docs.logto.io/secret-vault/federated-token-set)、[GitHub 连接器](https://docs.logto.io/integrations/github)、[Android SDK 快速入门](https://docs.logto.io/quick-starts/android)、[GitHub Events API](https://docs.github.com/en/rest/activity/events)

--- a/docs/superpowers/specs/2026-06-09-trendingai-logto-auth-design.md
+++ b/docs/superpowers/specs/2026-06-09-trendingai-logto-auth-design.md
@@ -124,6 +124,24 @@ TrendingAI 当前是一个无登录态的内容浏览产品（Daily Picks + 三�
 6. **（推荐）绑定自定义域名** `auth.trendingai.cn`：与 `api.trendingai.cn` 同走 Cloudflare 边缘，降低国内可达性风险
 7. ~~注册 API 资源~~（Free 档不可用，升 Pro 后再做）
 
+### 7.1.1 已完成的配置产出（2026-06-10 实操记录）
+
+§7.1 的控制台配置已全部完成，参数如下（均为客户端公开参数，secret 仅存于 Logto/GitHub 后台）：
+
+| 项 | 值 |
+|---|---|
+| Logto 租户 | `TrendingAI`（ID `28bniv`，US 区域，产品类型，Free 档） |
+| Logto Endpoint | `https://28bniv.logto.app` |
+| 应用（Native） | `TrendingAI-Android`，App ID `lasqslwwdjbim73vgkapj` |
+| Redirect URIs | `cn.trendingai://whl.trending.ai/callback`、`cn.trendingai://whl.trending.ai.debug/callback` |
+| GitHub 连接器 | ID `0xb17od4fhlnc4z1wmo8m`；Scope 留空（默认 `read:user`）；Store tokens ✅；每次登录同步资料 ✅ |
+| GitHub OAuth App | `TrendingAI`（HarlonWang 名下，应用 ID 3656545），Client ID `Ov23liJ06uldRD2ZUKce` |
+| 登录体验 | 仅 GitHub 社交登录（邮箱/密码注册与登录已移除） |
+| Account center | 已启用，"第三方访问令牌获取"已自动开启（Phase 2 取 GitHub token 的前提） |
+| 演示连接器 | Discord/GitHub/Google demo 已全部删除 |
+
+待办：自定义域名 `auth.trendingai.cn`（上线前绑定）；无代理国内真机实测可达性。
+
 ### 7.2 客户端（KMP / Android）
 
 - `androidApp` 接入 **Logto 官方 Android SDK**（`io.logto.sdk:android:1.1.3`，minSdk 24，满足现状）；用 `expect/actual` 或接口把"登录态 + 当前 access token + Account API 调用"暴露给 `shared`。iOS 后续接 Logto Swift SDK，`shared` 不变。

--- a/docs/superpowers/specs/2026-06-09-trendingai-logto-auth-design.md
+++ b/docs/superpowers/specs/2026-06-09-trendingai-logto-auth-design.md
@@ -40,7 +40,7 @@ TrendingAI 当前是一个无登录态的内容浏览产品（Daily Picks + 三�
 - **Phase 2**：Feed 动态流（**纯客户端工作**，经 Account API 取 GitHub token 直调 GitHub）
 
 ### 明确不做（Non-goals）
-- 不做 AI chat、订阅收费（仅留好挂载点：业务/会员按 `logto_sub` 挂在 D1，不依赖 Logto 付费特性）
+- 不做 AI chat、订阅收费（仅留好挂载点：业务/会员按内部 `user_id` 挂在 D1，不依赖 Logto 付费特性）
 - 不做 iOS UI（KMP shared 层就绪，后续接）
 - **不碰 Tono 或任何其他项目**
 - 不做密码登录（Logto 邮箱方式走 OTP）
@@ -70,7 +70,7 @@ TrendingAI 当前是一个无登录态的内容浏览产品（Daily Picks + 三�
 
 **身份职责切分**：
 - **Logto** 拥有"你是谁"（identity、登录、token、GitHub 授权与 token 保管）
-- **TrendingAI Worker** 拥有"你在本 App 是什么"（按 `logto_sub` 挂的业务数据、未来会员）
+- **TrendingAI Worker** 拥有"你在本 App 是什么"（按内部 `user_id` 挂的业务数据、未来会员；`logto_sub`/`github_user_id` 仅是身份映射列）
 - **GitHub 数据（profile 计数、feed）由客户端直连 GitHub API**，Worker 不经手（原因见 §6）
 
 ## 五、登录与 Worker 校验（OIDC Authorization Code + PKCE）
@@ -129,6 +129,7 @@ TrendingAI 当前是一个无登录态的内容浏览产品（Daily Picks + 三�
 - `androidApp` 接入 **Logto 官方 Android SDK**（`io.logto.sdk:android:1.1.3`，minSdk 24，满足现状）；用 `expect/actual` 或接口把"登录态 + 当前 access token + Account API 调用"暴露给 `shared`。iOS 后续接 Logto Swift SDK，`shared` 不变。
 - **shared 层**（现在写好，跨平台）：
   - `AuthState`：LoggedOut / LoggingIn / LoggedIn（封装 SDK，业务页面只看状态）
+  - LogtoConfig 的 `scopes` 加 `identities`（让 userinfo 返回 GitHub 数字 user id，供建档落 `github_user_id`）
   - Ktor `ApiClient`：自动在请求头挂 Logto access token，调 `api.trendingai.cn`
   - `GithubClient`：持有经 Account API 取回的 GitHub token，直调 `api.github.com`（带 ETag 缓存）
   - `ProfileRepository`、`FeedRepository`（分页 + 事件归一化：type / actor / repo / 一句话摘要 / created_at / target_url）
@@ -154,19 +155,21 @@ TrendingAI 当前是一个无登录态的内容浏览产品（Daily Picks + 三�
 **新增迁移 `migrations/015_app_users.sql`**：
 ```sql
 CREATE TABLE IF NOT EXISTS app_users (
-  logto_sub    TEXT PRIMARY KEY,   -- Logto 用户 ID（身份锚点）
-  github_login TEXT,
-  display_name TEXT,
-  avatar_url   TEXT,
-  bio          TEXT,
-  html_url     TEXT,
-  raw_profile  TEXT,               -- 最近一次 profile 快照 JSON
-  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
-  last_login_at TEXT
-  -- 未来：订阅/会员 entitlement 按 logto_sub 挂（本表扩列或独立表）
+  user_id        TEXT PRIMARY KEY,          -- 内部用户 ID（UUID），业务数据的唯一锚点
+  logto_sub      TEXT NOT NULL UNIQUE,      -- Logto 用户 ID（当前 IdP 的映射，可整体替换）
+  github_user_id INTEGER UNIQUE,            -- GitHub 数字 ID（永不变，跨 IdP 对账的耐久锚点）
+  github_login   TEXT,                      -- GitHub login（可改名，仅展示用）
+  display_name   TEXT,
+  avatar_url     TEXT,
+  bio            TEXT,
+  html_url       TEXT,
+  raw_profile    TEXT,                      -- 最近一次 profile 快照 JSON
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  last_login_at  TEXT
+  -- 未来：订阅/会员 entitlement 一律挂内部 user_id（与 IdP 解耦），不挂 logto_sub
 );
 ```
-首次带 token 访问 `/api/me` 时 upsert（或后续接 Logto webhook 建档，Free 档含 1 个 webhook）。
+首次带 token 访问 `/api/me` 时 upsert（或后续接 Logto webhook 建档，Free 档含 1 个 webhook）。`github_user_id` 从 userinfo 的 `identities` claim 取（客户端登录 scope 需加 `identities`，见 7.2）。
 
 **改动现有文件**：
 - `src/index.js`：加 1 条路由 `if`（`/api/me`）
@@ -174,7 +177,25 @@ CREATE TABLE IF NOT EXISTS app_users (
 
 **初稿中已取消的部分**：~~`src/lib/logto-vault.js`~~、~~`src/api/github-proxy.js`~~（Secret Vault 后端取不到 token，GitHub 数据改由客户端直连，见 §6）
 
-### 7.4 相对 DIY 方案，后端被省掉的部分
+### 7.4 IdP 解耦与迁移路径（退出成本）
+
+本设计刻意把"迁离 Logto"的成本压到最低，三道隔离已内置：
+
+1. **数据层**：`app_users` 主键是内部 `user_id`，业务/订阅数据只挂它；`logto_sub` 仅是当前 IdP 的映射列，`github_user_id`（GitHub 数字 ID，永不变）是跨身份系统对账的耐久锚点
+2. **后端**：IdP 校验收敛在 `logto-auth.js` 单文件，换 IdP 只改它
+3. **客户端**：shared 层只看抽象 `AuthState`，换登录 SDK 不动业务
+
+**若日后迁移**（自建 Logto OSS / 其他 IdP / 完全自建），步骤为：
+
+1. Logto Management API 分页导出全部用户（profile + identities 含 GitHub user id）；Cloud→OSS 无自助整体迁移，必要时可联系官方导出
+2. 新系统导入用户并预绑定 GitHub identity（按 `github_user_id`）
+3. D1 把 `logto_sub` 列替换为新系统的 sub 映射（主键与业务外键不动）
+4. 换 `logto-auth.js` 实现 + 客户端换 SDK
+5. 用户下次打开 App 重新走一次 GitHub 登录，按 `github_user_id` 自动对回原账号（无密码可迁，社交登录用户无感）
+
+**唯一迁不走的**：Secret Vault 里的 GitHub token（加密不可导出）——用户重新登录时自动重建，无实际损失。
+
+### 7.5 相对 DIY 方案，后端被省掉的部分
 
 - ❌ OAuth start/callback/session/logout 端点
 - ❌ `sessions` / `login_sessions` 表与 session 轮换
@@ -210,7 +231,7 @@ CREATE TABLE IF NOT EXISTS app_users (
 
 - 用户体系：接入 Logto Cloud Free 档，不自建 ✅
 - Worker 校验方式：**opaque token + userinfo 在线校验（短缓存）**；升 Pro 后切 JWT 离线验签 ✅（2026-06-10 拍板）
-- 登录即在身份层建立用户（`logto_sub` 为锚点），后端 `app_users` 建档 ✅
+- 登录即在身份层建立用户，后端 `app_users` 建档；**主键用内部 `user_id`，`logto_sub` 仅作映射列，另存 `github_user_id` 作迁移锚点** ✅（2026-06-10 拍板）
 - 登录方式：本次仅 GitHub；邮箱 OTP 留作 Logto 侧可开关 ✅
 - GitHub 权限：默认 `read:user`（最小化）✅
 - 登录定位：可选加法，不拦截现有内容 ✅
@@ -236,5 +257,6 @@ CREATE TABLE IF NOT EXISTS app_users (
 | 3 | received_events 约 90 天窗口、仅公开事件 | **30 天**/300 条；本人 token 可见私有事件；延迟 30s~6h | UI 文案与分页到底逻辑按 30 天；feed 内容比预期更丰富 |
 | 4 | 回跳用 App Links | SDK 标准方案为自定义 scheme | 接入更简单，无需服务端 App Links 配置 |
 | 5 | GitHub token 需关注过期刷新 | GitHub OAuth App token **永不过期**（勿加 `offline_access`） | 客户端可长期缓存，仅需处理用户主动撤销 |
+| 6 | `logto_sub` 直接做 `app_users` 主键 | Cloud↔OSS 无自助迁移；Management API 可自助导出用户与 identities | 主键改内部 `user_id` + 增 `github_user_id` 锚点列，IdP 解耦（见 7.4） |
 
 主要依据：[Logto Pricing](https://logto.io/pricing)、[2025-09 调价公告](https://blog.logto.io/pricing-sep-2025)、[计费文档](https://docs.logto.io/logto-cloud/billing-and-pricing)、[Secret Vault / 第三方 token](https://docs.logto.io/secret-vault/federated-token-set)、[GitHub 连接器](https://docs.logto.io/integrations/github)、[Android SDK 快速入门](https://docs.logto.io/quick-starts/android)、[GitHub Events API](https://docs.github.com/en/rest/activity/events)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ coil = "3.4.0"
 material-kolor = "4.1.1"
 commonmark = "0.28.0"
 kmp-webview = "0.1.1"
+logto = "1.1.3"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -65,6 +66,7 @@ material-kolor = { module = "com.materialkolor:material-kolor", version.ref = "m
 commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" }
 commonmark-ext-gfm-tables = { module = "org.commonmark:commonmark-ext-gfm-tables", version.ref = "commonmark" }
 kmp-webview = { module = "wang.harlon:kmp-webview", version.ref = "kmp-webview" }
+logto-android = { module = "io.logto.sdk:android", version.ref = "logto" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -120,4 +120,10 @@
     <string name="theme_color_pink">粉</string>
     <string name="whats_new_title">🎉 新版本 %1$s</string>
     <string name="whats_new_got_it">知道了</string>
+    <string name="profile_title">个人主页</string>
+    <string name="sign_in">登录</string>
+    <string name="sign_out">退出登录</string>
+    <string name="profile_open_github">在 GitHub 打开</string>
+    <string name="profile_load_failed">加载失败</string>
+    <string name="profile_retry">重试</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -120,4 +120,10 @@
     <string name="theme_color_pink">Pink</string>
     <string name="whats_new_title">🎉 What&apos;s New in %1$s</string>
     <string name="whats_new_got_it">Got it</string>
+    <string name="profile_title">Profile</string>
+    <string name="sign_in">Sign in</string>
+    <string name="sign_out">Sign out</string>
+    <string name="profile_open_github">Open on GitHub</string>
+    <string name="profile_load_failed">Failed to load profile</string>
+    <string name="profile_retry">Retry</string>
 </resources>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/auth/AuthManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/auth/AuthManager.kt
@@ -1,0 +1,33 @@
+package whl.trending.ai.auth
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+sealed interface AuthState {
+    data object LoggedOut : AuthState
+    data object LoggingIn : AuthState
+    data object LoggedIn : AuthState
+}
+
+/**
+ * 登录态抽象：shared/UI 只依赖本接口，Logto SDK 只存在于 androidApp。
+ * iOS 未接入前使用 NoopAuthManager（isSupported=false，UI 隐藏登录入口）。
+ */
+interface AuthManager {
+    val isSupported: Boolean
+    val authState: StateFlow<AuthState>
+    fun signIn()
+    fun signOut()
+    suspend fun getAccessToken(): String?
+}
+
+object NoopAuthManager : AuthManager {
+    override val isSupported: Boolean = false
+    override val authState: StateFlow<AuthState> = MutableStateFlow(AuthState.LoggedOut)
+    override fun signIn() {}
+    override fun signOut() {}
+    override suspend fun getAccessToken(): String? = null
+}
+
+/** 仿 globalChatScreen 的依赖反转：Android 在 MainActivity.onCreate 注入实现 */
+var globalAuthManager: AuthManager = NoopAuthManager

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
@@ -4,6 +4,7 @@ import whl.trending.ai.ui.detail.ReadmeScreen
 import whl.trending.ai.ui.favorites.FavoriteListScreen
 import whl.trending.ai.ui.feedback.FeedbackScreen
 import whl.trending.ai.ui.home.HomeScreen
+import whl.trending.ai.ui.profile.ProfileScreen
 import whl.trending.ai.ui.settings.SettingsScreen
 import whl.trending.ai.ui.subscribe.SubscribeScreen
 import whl.trending.ai.ui.theme.TrendingTheme
@@ -27,6 +28,7 @@ data object Subscribe
 data class RepoDetail(val owner: String, val repo: String)
 data class WebPage(val url: String, val title: String)
 data object Favorites
+data object Profile
 data class Chat(val context: ChatContext?)
 
 /**
@@ -64,7 +66,10 @@ fun App() {
                             },
                             onOpenUrl = { url ->
                                 backStack.add(WebPage(url, ""))
-                            }
+                            },
+                            onNavigateToProfile = {
+                                backStack.add(Profile)
+                            },
                         )
                     }
 
@@ -122,6 +127,10 @@ fun App() {
                                 backStack.add(WebPage(url, ""))
                             }
                         )
+                    }
+
+                    is Profile -> NavEntry(key) {
+                        ProfileScreen(onBack = { backStack.safePop() })
                     }
 
                     is RepoDetail -> NavEntry(key) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -37,6 +37,7 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val FAVORITES_KEY = "prefs_favorites"
     private val SUBSCRIBED_EMAIL_KEY = "prefs_subscribed_email"
     private val INSTALL_ID_KEY = "prefs_install_id"
+    private val USER_AVATAR_KEY = "prefs_user_avatar_url"
 
     /**
      * 安装级匿名标识：首次访问时生成并持久化，之后保持不变（卸载重装才会重新生成）。
@@ -117,6 +118,17 @@ class SettingsManager(private val settings: ObservableSettings) {
     private fun getCurrentFavorites(): List<FavoriteItem> {
         val json = settings.getStringOrNull(FAVORITES_KEY) ?: return emptyList()
         return runCatching { Json.decodeFromString<List<FavoriteItem>>(json) }.getOrElse { emptyList() }
+    }
+
+    /** 已登录用户头像 URL 缓存：TopBar 入口同步展示用；登出时清空 */
+    val userAvatarUrl: Flow<String?> = settings.getStringOrNullFlow(USER_AVATAR_KEY)
+
+    fun setUserAvatarUrl(url: String?) {
+        if (url.isNullOrBlank()) {
+            settings.remove(USER_AVATAR_KEY)
+        } else {
+            settings.putString(USER_AVATAR_KEY, url)
+        }
     }
 
     val subscribedEmail: Flow<String?> = settings.getStringOrNullFlow(SUBSCRIBED_EMAIL_KEY)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/Me.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/Me.kt
@@ -1,0 +1,19 @@
+package whl.trending.ai.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeResponse(val user: MeUser)
+
+@Serializable
+data class MeUser(
+    @SerialName("user_id") val userId: String,
+    @SerialName("github_user_id") val githubUserId: Long? = null,
+    @SerialName("github_login") val githubLogin: String? = null,
+    @SerialName("display_name") val displayName: String? = null,
+    @SerialName("avatar_url") val avatarUrl: String? = null,
+    val bio: String? = null,
+    @SerialName("html_url") val htmlUrl: String? = null,
+    @SerialName("created_at") val createdAt: String? = null,
+)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -138,6 +138,9 @@ open class TrendingApi {
         val response = client.get("$baseHost/api/me") {
             header(HttpHeaders.Authorization, "Bearer $accessToken")
         }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
         return response.body<MeResponse>()
     }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -2,6 +2,7 @@ package whl.trending.ai.data.remote
 
 import whl.trending.ai.core.platform.getUserAgent
 import whl.trending.ai.data.model.FeedResponse
+import whl.trending.ai.data.model.MeResponse
 import whl.trending.ai.data.model.PicksResponse
 import whl.trending.ai.data.model.ReadmeResponse
 import whl.trending.ai.data.model.SubscribeResponse
@@ -131,6 +132,13 @@ open class TrendingApi {
             if (e is kotlinx.coroutines.CancellationException) throw e
             Result.failure(e)
         }
+    }
+
+    open suspend fun fetchMe(accessToken: String): MeResponse {
+        val response = client.get("$baseHost/api/me") {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+        }
+        return response.body<MeResponse>()
     }
 
     open suspend fun cancelSubscribe(email: String): Result<SubscribeResponse> {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
@@ -18,7 +18,8 @@ class UserRepository(private val api: TrendingApi = TrendingApi()) {
             val user = fetchMe(accessToken)
             globalSettingsManager.setUserAvatarUrl(user.avatarUrl)
             user
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
             null
         }
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
@@ -1,0 +1,25 @@
+package whl.trending.ai.data.repository
+
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.model.MeUser
+import whl.trending.ai.data.remote.TrendingApi
+
+class UserRepository(private val api: TrendingApi = TrendingApi()) {
+
+    suspend fun fetchMe(accessToken: String): MeUser = api.fetchMe(accessToken).user
+
+    /**
+     * 登录成功/应用启动（已登录）时调用：服务端建档 + 刷新 last_login_at，并缓存头像。
+     * 失败静默——下次打开 Profile 仍会重试，不阻塞登录主流程。
+     */
+    suspend fun syncMe(accessToken: String?): MeUser? {
+        if (accessToken == null) return null
+        return try {
+            val user = fetchMe(accessToken)
+            globalSettingsManager.setUserAvatarUrl(user.avatarUrl)
+            user
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -2,18 +2,21 @@ package whl.trending.ai.ui.home
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.automirrored.filled.TrendingUp
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -26,6 +29,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,10 +38,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil3.compose.AsyncImage
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.GitHub_Invertocat_Black
@@ -56,6 +62,12 @@ import trendingai.shared.generated.resources.period_daily
 import trendingai.shared.generated.resources.period_monthly
 import trendingai.shared.generated.resources.period_weekly
 import trendingai.shared.generated.resources.settings
+import trendingai.shared.generated.resources.profile_title
+import trendingai.shared.generated.resources.sign_in
+import whl.trending.ai.auth.AuthState
+import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.repository.UserRepository
 import whl.trending.ai.ui.feed.FeedScreen
 import whl.trending.ai.ui.feed.FeedViewModel
 import whl.trending.ai.ui.picks.PicksScreen
@@ -74,7 +86,8 @@ fun HomeScreen(
     onNavigateToSettings: () -> Unit,
     onNavigateToDetail: (owner: String, repo: String) -> Unit,
     onNavigateToChat: () -> Unit = {},
-    onOpenUrl: (url: String) -> Unit = {}
+    onOpenUrl: (url: String) -> Unit = {},
+    onNavigateToProfile: () -> Unit = {}
 ) {
     var selectedTabName by rememberSaveable { mutableStateOf(HomeTab.GitHub.name) }
     val selectedTab = HomeTab.valueOf(selectedTabName)
@@ -90,6 +103,18 @@ fun HomeScreen(
     } else null
     val picksUiState = picksViewModel?.uiState?.collectAsState()?.value
 
+    val authManager = globalAuthManager
+    val authState by authManager.authState.collectAsState()
+    val userAvatarUrl by globalSettingsManager.userAvatarUrl.collectAsState(null)
+
+    // 应用启动且已登录：服务端建档/刷新 last_login_at + 同步头像（幂等，失败静默）
+    LaunchedEffect(authState) {
+        val state = authState
+        if (state is AuthState.LoggedIn) {
+            UserRepository().syncMe(authManager.getAccessToken())
+        }
+    }
+
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
@@ -104,7 +129,13 @@ fun HomeScreen(
                     scrollBehavior = scrollBehavior,
                     onTitleClick = { showFilterSheet = true },
                     onHistoryClick = { showHistorySheet = true },
-                    onNavigateToSettings = onNavigateToSettings
+                    onNavigateToSettings = onNavigateToSettings,
+                    showAuthEntry = authManager.isSupported,
+                    authState = authState,
+                    userAvatarUrl = userAvatarUrl,
+                    onProfileClick = {
+                        if (authState is AuthState.LoggedIn) onNavigateToProfile() else authManager.signIn()
+                    },
                 )
                 HomeTab.Picks -> PicksTopBar(
                     date = picksUiState?.picks?.metadata?.date,
@@ -239,7 +270,11 @@ private fun TrendingTopBar(
     scrollBehavior: androidx.compose.material3.TopAppBarScrollBehavior,
     onTitleClick: () -> Unit,
     onHistoryClick: () -> Unit,
-    onNavigateToSettings: () -> Unit
+    onNavigateToSettings: () -> Unit,
+    showAuthEntry: Boolean,
+    authState: AuthState,
+    userAvatarUrl: String?,
+    onProfileClick: () -> Unit,
 ) {
     val isDarkTheme = MaterialTheme.colorScheme.background.luminance() < 0.5f
     val periodLabel = when (selectedPeriod) {
@@ -299,6 +334,25 @@ private fun TrendingTopBar(
             }
         },
         actions = {
+            if (showAuthEntry) {
+                IconButton(onClick = onProfileClick, enabled = authState !is AuthState.LoggingIn) {
+                    when {
+                        authState is AuthState.LoggedIn && userAvatarUrl != null -> AsyncImage(
+                            model = userAvatarUrl,
+                            contentDescription = stringResource(Res.string.profile_title),
+                            modifier = Modifier.size(28.dp).clip(CircleShape)
+                        )
+                        authState is AuthState.LoggingIn -> CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp
+                        )
+                        else -> Icon(
+                            Icons.Default.AccountCircle,
+                            contentDescription = stringResource(Res.string.sign_in)
+                        )
+                    }
+                }
+            }
             IconButton(onClick = onHistoryClick) {
                 Icon(Icons.Default.DateRange, contentDescription = stringResource(Res.string.history_trending))
             }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -1,0 +1,126 @@
+package whl.trending.ai.ui.profile
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil3.compose.AsyncImage
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.profile_load_failed
+import trendingai.shared.generated.resources.profile_open_github
+import trendingai.shared.generated.resources.profile_retry
+import trendingai.shared.generated.resources.profile_title
+import trendingai.shared.generated.resources.sign_out
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(onBack: () -> Unit) {
+    val viewModel: ProfileViewModel = viewModel { ProfileViewModel() }
+    val uiState by viewModel.uiState.collectAsState()
+    val uriHandler = LocalUriHandler.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(Res.string.profile_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            when {
+                uiState.isLoading -> CircularProgressIndicator(Modifier.padding(top = 48.dp))
+
+                uiState.isError -> {
+                    Text(
+                        text = stringResource(Res.string.profile_load_failed),
+                        modifier = Modifier.padding(top = 48.dp)
+                    )
+                    Button(onClick = { viewModel.load() }) {
+                        Text(stringResource(Res.string.profile_retry))
+                    }
+                }
+
+                else -> uiState.user?.let { user ->
+                    AsyncImage(
+                        model = user.avatarUrl,
+                        contentDescription = null,
+                        modifier = Modifier.size(96.dp).clip(CircleShape)
+                    )
+                    Text(
+                        text = user.displayName ?: user.githubLogin.orEmpty(),
+                        style = MaterialTheme.typography.titleLarge
+                    )
+                    user.githubLogin?.let {
+                        Text(
+                            text = "@$it",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    user.bio?.takeIf { it.isNotBlank() }?.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    user.htmlUrl?.let { url ->
+                        Button(
+                            onClick = { uriHandler.openUri(url) },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(stringResource(Res.string.profile_open_github))
+                        }
+                    }
+                    OutlinedButton(
+                        onClick = {
+                            viewModel.signOut()
+                            onBack()
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(Res.string.sign_out))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -1,0 +1,50 @@
+package whl.trending.ai.ui.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import whl.trending.ai.auth.AuthManager
+import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.data.model.MeUser
+import whl.trending.ai.data.repository.UserRepository
+
+data class ProfileUiState(
+    val isLoading: Boolean = true,
+    val user: MeUser? = null,
+    val isError: Boolean = false,
+)
+
+class ProfileViewModel(
+    private val repository: UserRepository = UserRepository(),
+    private val authManager: AuthManager = globalAuthManager,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(ProfileUiState())
+    val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.value = ProfileUiState(isLoading = true)
+            val token = authManager.getAccessToken()
+            if (token == null) {
+                _uiState.value = ProfileUiState(isLoading = false, isError = true)
+                return@launch
+            }
+            try {
+                val user = repository.fetchMe(token)
+                _uiState.value = ProfileUiState(isLoading = false, user = user)
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                _uiState.value = ProfileUiState(isLoading = false, isError = true)
+            }
+        }
+    }
+
+    fun signOut() = authManager.signOut()
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt
@@ -74,4 +74,12 @@ class SettingsManagerTest {
         assertEquals(0xFFC2185BL, manager.seedColor.first())
         assertEquals(ThemeMode.LIGHT, manager.themeMode.first())
     }
+
+    @Test
+    fun userAvatarUrl_set_and_clear() {
+        manager.setUserAvatarUrl("https://a.png")
+        assertEquals("https://a.png", settings.getStringOrNull("prefs_user_avatar_url"))
+        manager.setUserAvatarUrl(null)
+        assertEquals(null, settings.getStringOrNull("prefs_user_avatar_url"))
+    }
 }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/model/MeResponseTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/model/MeResponseTest.kt
@@ -1,0 +1,33 @@
+package whl.trending.ai.data.model
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MeResponseTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decode_full_payload() {
+        val payload = """
+            {"user":{"user_id":"uuid-1","github_user_id":123456,"github_login":"HarlonWang",
+            "display_name":"Harlon","avatar_url":"https://a.png","bio":"dev",
+            "html_url":"https://github.com/HarlonWang","created_at":"2026-06-10 00:00:00"}}
+        """.trimIndent()
+        val me = json.decodeFromString<MeResponse>(payload)
+        assertEquals("uuid-1", me.user.userId)
+        assertEquals(123456L, me.user.githubUserId)
+        assertEquals("HarlonWang", me.user.githubLogin)
+        assertEquals("https://a.png", me.user.avatarUrl)
+    }
+
+    @Test
+    fun decode_minimal_payload_with_nulls() {
+        val payload = """{"user":{"user_id":"uuid-2"}}"""
+        val me = json.decodeFromString<MeResponse>(payload)
+        assertEquals("uuid-2", me.user.userId)
+        assertNull(me.user.githubLogin)
+        assertNull(me.user.avatarUrl)
+    }
+}


### PR DESCRIPTION
## Summary
- 接入 Logto Android SDK 1.1.3（OIDC PKCE，scope 含 `identities`），GitHub 页 TopBar 新增登录入口（未登录图标 / 登录中转圈 / 已登录头像）
- shared 层 `AuthManager` 抽象（Logto SDK 只在 androidApp，iOS NoopAuthManager 隐藏入口），登录即调 `/api/me` 建档 + 头像缓存
- 新增 Profile 页：头像/昵称/@login/bio + 在 GitHub 打开 + 登出；中英文案

## Test Plan
- [x] shared 单测全绿（MeResponse 解析、SettingsManager 头像缓存等）
- [x] 模拟器端到端：登录 → TopBar 头像 → Profile 展示 → 登出恢复 → 杀进程重启保持登录态
- [x] D1 建档核验：`github_user_id`/`github_login`/bio 字段齐全，重复登录幂等同一行

设计文档：`docs/superpowers/specs/2026-06-09-trendingai-logto-auth-design.md`（本 PR 含其 v2 修订）
配套后端 PR：HarlonWang/github-ai-trending-api#10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在 Android 上集成基于 Logto 的 GitHub 身份验证，并新增一个最小化的个人资料体验，与现有导航和后端打通。

新功能：
- 添加共享的 `AuthManager` 抽象，并在 Android 中实现 `LogtoAuthManager`，以通过 Logto 支持 GitHub 登录。
- 暴露新的 `/api/me` 端点和 `MeResponse` 模型，用于在认证后从后端获取并持久化基础用户资料数据。
- 引入 Profile（个人资料）界面和对应的导航路由，展示用户的 GitHub 身份信息（头像、姓名、登录名、简介），并提供“在 GitHub 上打开”和“登出”等操作。

增强：
- 扩展 GitHub 首页顶部栏，增加一个认证入口，根据登录状态展示不同的状态（图标、加载指示器或头像），并可导航到 Profile 界面或触发登录。
- 将已登录用户的头像 URL 持久化到设置中，以便顶部栏在多次应用启动之间都能立即显示头像。
- 在新的设计文档和执行计划文档中记录 Logto GitHub 认证的架构和实现方案。

构建：
- 通过版本目录和 `androidApp` 模块配置，引入 Logto Android SDK 依赖。

测试：
- 为 `MeResponse` 的 JSON 解码以及 `SettingsManager` 中新的用户头像 URL 持久化逻辑添加测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Logto-based GitHub authentication on Android and add a minimal profile experience wired into the existing navigation and backend.

New Features:
- Add a shared AuthManager abstraction with an Android LogtoAuthManager implementation to support GitHub sign-in using Logto.
- Expose a new /api/me endpoint and MeResponse model to fetch and persist basic user profile data from the backend after authentication.
- Introduce a Profile screen and navigation route showing the user’s GitHub identity (avatar, name, login, bio) with actions to open on GitHub and sign out.

Enhancements:
- Extend the GitHub home top bar with an authentication entry that reflects login state (icon, loading spinner, or avatar) and navigates to the Profile screen or triggers sign-in.
- Persist the logged-in user’s avatar URL in settings so the top bar can display it immediately across app launches.
- Document the Logto GitHub authentication architecture and implementation plan in new design and execution-plan docs.

Build:
- Add the Logto Android SDK dependency via the version catalog and androidApp module configuration.

Tests:
- Add tests for MeResponse JSON decoding and for the new user avatar URL persistence in SettingsManager.

</details>