### PR TITLE
feat: GitHub 动态流 + Profile 计数（Logto Phase 2）

### DIFF
--- a/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
@@ -30,7 +30,6 @@ class MainActivity : AppCompatActivity() {
         whl.trending.ai.core.platform.AndroidContextHolder.initialize(this)
 
         // 注入 Logto 登录实现（仿 globalChatScreen 的依赖反转；配置变更重建时重新绑定 activity）
-        (whl.trending.ai.auth.globalAuthManager as? whl.trending.ai.auth.LogtoAuthManager)?.close()
         whl.trending.ai.auth.globalAuthManager = whl.trending.ai.auth.LogtoAuthManager(this)
 
         // 注册 Android-only 的 ChatScreen 到 CMP 导航 slot（仿 UpdateWrapper 的依赖反转）

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -55,6 +55,7 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         logtoClient.signOut { /* 本地凭证已清除即视为登出，远端失败不阻塞 */ }
         globalSettingsManager.setUserAvatarUrl(null)
         GithubTokenProvider.shared.clear()
+        FollowingProvider.shared.clear()
         _authState.value = AuthState.LoggedOut
         trackEvent("sign_out")
     }

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import whl.trending.ai.BuildConfig
+import whl.trending.ai.auth.LOGTO_ENDPOINT
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
 
@@ -54,6 +55,7 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
     override fun signOut() {
         logtoClient.signOut { /* 本地凭证已清除即视为登出，远端失败不阻塞 */ }
         globalSettingsManager.setUserAvatarUrl(null)
+        GithubTokenProvider.shared.clear()
         _authState.value = AuthState.LoggedOut
         trackEvent("sign_out")
     }
@@ -66,7 +68,6 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         }
 
     companion object {
-        private const val LOGTO_ENDPOINT = "https://28bniv.logto.app"
         private const val LOGTO_APP_ID = "lasqslwwdjbim73vgkapj"
 
         /** release: cn.trendingai://whl.trending.ai/callback；debug 包名带 .debug，两条均已在 Logto 注册 */

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -5,19 +5,13 @@ import io.logto.sdk.android.LogtoClient
 import io.logto.sdk.android.type.LogtoConfig
 import java.lang.ref.WeakReference
 import kotlin.coroutines.resume
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import whl.trending.ai.BuildConfig
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
-import whl.trending.ai.data.repository.UserRepository
 
 /**
  * Logto 实现：OIDC PKCE 登录，token 存储/刷新由 SDK 托管。
@@ -25,7 +19,6 @@ import whl.trending.ai.data.repository.UserRepository
  */
 class LogtoAuthManager(activity: Activity) : AuthManager {
     private val activityRef = WeakReference(activity)
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private val logtoClient = LogtoClient(
         LogtoConfig(
@@ -51,8 +44,6 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
             if (logtoException == null && logtoClient.isAuthenticated) {
                 _authState.value = AuthState.LoggedIn
                 trackEvent("sign_in_success")
-                // 登录即建档：失败静默，打开 Profile 时会重试
-                scope.launch { UserRepository().syncMe(getAccessToken()) }
             } else {
                 _authState.value = AuthState.LoggedOut
                 if (logtoException != null) trackEvent("sign_in_failed")
@@ -73,11 +64,6 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
                 cont.resume(accessToken?.token)
             }
         }
-
-    /** 实例被替换前调用（如配置变更重建 Activity），取消后台协程避免旧实例残留任务 */
-    fun close() {
-        scope.cancel()
-    }
 
     companion object {
         private const val LOGTO_ENDPOINT = "https://28bniv.logto.app"

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import whl.trending.ai.BuildConfig
-import whl.trending.ai.auth.LOGTO_ENDPOINT
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
 

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -56,6 +56,7 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         globalSettingsManager.setUserAvatarUrl(null)
         GithubTokenProvider.shared.clear()
         FollowingProvider.shared.clear()
+        OwnRepoEventsProvider.shared.clear()
         _authState.value = AuthState.LoggedOut
         trackEvent("sign_out")
     }

--- a/docs/superpowers/plans/2026-06-10-logto-auth-phase2.md
+++ b/docs/superpowers/plans/2026-06-10-logto-auth-phase2.md
@@ -1,0 +1,1181 @@
+# Logto Phase 2：GitHub Feed 动态流 + Profile 完善 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Profile 页一体化升级——头部展示 GitHub 计数（followers/following/repos），下方接 GitHub Dashboard 风格动态流（received_events）；同时清掉 Phase 1 遗留的双 syncMe、UserRepository 构造位置与错误态无登出问题。
+
+**Architecture:** 纯客户端工作（Worker 零改动）。客户端经 Logto Account API（`GET /api/my-account/identities/github/access-token`，凭现有 opaque token）取出 Secret Vault 里的 GitHub access token（GitHub OAuth App token 永不过期，会话内存缓存），直调 `api.github.com`：`/user` 取计数、`/users/{login}/received_events` 取动态（仅最近 30 天/最多 300 条，30s~6h 延迟）。事件归一化为结构化 `GithubFeedItem`（kind 枚举 + 参数），文案由 UI 层 stringResource 拼装（i18n）。
+
+**Tech Stack:** Kotlin Multiplatform、Ktor、kotlinx-serialization（payload 用 JsonObject 弹性解析）、Compose Multiplatform LazyColumn、coil3。
+
+**仓库：** 仅 `/Users/wanghl/TrendingProjects/TrendingAI`，新分支 `feat/logto-phase2-feed`（从 main 切出）。
+
+**已核实的事实（执行者无须再查）：**
+- Account API：`GET https://28bniv.logto.app/api/my-account/identities/github/access-token`，Bearer 用现有 `AuthManager.getAccessToken()` 的 opaque token（登录 scope 已含 `identities` 满足要求）；200 响应 `{"access_token": "...", "scope": ..., "token_type": ..., "expires_in": ...}`；404=未存 token；401=token 过期
+- GitHub events：`GET https://api.github.com/users/{login}/received_events?per_page=30&page=N`，Bearer GitHub token；事件结构 `{id, type, actor:{login, avatar_url}, repo:{name}, payload:{...按 type 不同}, created_at, public}`；上限 300 条/30 天，翻页超界返回空数组
+- 现有代码锚点：`ui/feed/` 已被 HN/PH 占用（**勿放新文件**）；`DateTimeUtils.formatToLocalTime(utcString)` 已有（绝对时间展示，不做相对时间）；`ApiException(statusCode, body)` 在 `data/remote/` 已有；ProfileScreen/ProfileViewModel 在 `ui/profile/`；strings 在 `composeResources/values{,-zh}/strings.xml`（撇号 `&apos;`、占位符必须 `%1$s` 位置形式）
+- Phase 1 遗留现状：`LogtoAuthManager.signIn` 回调里有 `scope.launch { UserRepository().syncMe(...) }`（与 HomeScreen LaunchedEffect 重复）；`close()`/`scope` 仅为该 launch 存在；HomeScreen LaunchedEffect 内裸构造 `UserRepository()`
+
+---
+
+### Task 1: 分支 + 重构收拢（消双 syncMe / 移除 scope / remember 仓库实例）
+
+**Files:**
+- Modify: `androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt`
+- Modify: `androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt`
+- Modify: `shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt`
+
+- [ ] **Step 1: 切分支**
+
+```bash
+cd /Users/wanghl/TrendingProjects/TrendingAI && git checkout main && git pull && git checkout -b feat/logto-phase2-feed
+```
+
+- [ ] **Step 2: LogtoAuthManager 删除冗余 syncMe 与 scope**
+
+原理：登录成功 → `_authState` 变 `LoggedIn` → HomeScreen 的 `LaunchedEffect(authState)` 必然触发 syncMe，回调内再调一次是纯重复。删除后 `scope`/`close()` 失去存在意义，一并移除（比"记得 cancel"更优的修法）。
+
+具体改动：
+1. `signIn` 成功分支删掉 `scope.launch { UserRepository().syncMe(getAccessToken()) }` 及其注释行（保留 `_authState.value = ...` 与 `trackEvent`）
+2. 删除字段 `private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)`
+3. 删除 `close()` 方法
+4. 删除因此失效的 import：`CoroutineScope`、`Dispatchers`、`SupervisorJob`、`launch`、`cancel`、`UserRepository`
+
+- [ ] **Step 3: MainActivity 删除 close() 调用**
+
+删掉这一行（注入行保留）：
+```kotlin
+(whl.trending.ai.auth.globalAuthManager as? whl.trending.ai.auth.LogtoAuthManager)?.close()
+```
+
+- [ ] **Step 4: HomeScreen 把 UserRepository 提为 remember**
+
+在 `val authManager = globalAuthManager` 旁加：
+```kotlin
+val userRepository = remember { UserRepository() }
+```
+`LaunchedEffect` 内 `UserRepository().syncMe(...)` 改为 `userRepository.syncMe(...)`。
+需要 import `androidx.compose.runtime.remember`（该文件已有则跳过）。
+
+- [ ] **Step 5: 编译 + 测试**
+
+Run: `./gradlew :androidApp:assembleGithubDebug shared:testAndroidHostTest 2>&1 | tail -3`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "refactor: 收拢 syncMe 单触发点，移除 LogtoAuthManager 冗余 scope
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Profile 错误态加登出出口
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt`
+
+- [ ] **Step 1: error 分支追加登出按钮**
+
+在 `uiState.isError ->` 分支的重试 `Button` 之后追加（解决 refresh token 永久失效时用户卡死在"重试"循环的问题）：
+
+```kotlin
+OutlinedButton(onClick = {
+    viewModel.signOut()
+    onBack()
+}) {
+    Text(stringResource(Res.string.sign_out))
+}
+```
+
+- [ ] **Step 2: 编译验证**
+
+Run: `./gradlew :androidApp:assembleGithubDebug -q`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+git commit -m "fix: Profile 加载失败时提供登出出口，避免凭证失效后卡死重试
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: GitHub token 链路（Account API + 会话缓存，TDD）
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/whl/trending/ai/auth/AuthManager.kt`（追加常量）
+- Create: `shared/src/commonMain/kotlin/whl/trending/ai/data/remote/LogtoAccountApi.kt`
+- Create: `shared/src/commonMain/kotlin/whl/trending/ai/auth/GithubTokenProvider.kt`
+- Modify: `androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt`（endpoint 常量改引用 shared + 登出清缓存）
+- Test: `shared/src/commonTest/kotlin/whl/trending/ai/data/remote/LogtoAccountApiTest.kt`
+
+- [ ] **Step 1: 写失败测试（响应模型解析）**
+
+```kotlin
+package whl.trending.ai.data.remote
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LogtoAccountApiTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decode_github_token_response() {
+        val payload = """{"access_token":"gho_abc123","scope":"read:user","token_type":"bearer"}"""
+        val resp = json.decodeFromString<GithubTokenResponse>(payload)
+        assertEquals("gho_abc123", resp.accessToken)
+    }
+
+    @Test
+    fun decode_minimal_response() {
+        val payload = """{"access_token":"gho_x"}"""
+        val resp = json.decodeFromString<GithubTokenResponse>(payload)
+        assertEquals("gho_x", resp.accessToken)
+    }
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `./gradlew shared:testAndroidHostTest --tests "*LogtoAccountApiTest*" 2>&1 | tail -5`
+Expected: 编译失败（GithubTokenResponse 不存在）
+
+- [ ] **Step 3: shared 加 LOGTO_ENDPOINT 常量**
+
+`AuthManager.kt` 文件末尾追加：
+```kotlin
+/** Logto 租户端点：客户端 SDK 与 Account API 共用 */
+const val LOGTO_ENDPOINT = "https://28bniv.logto.app"
+```
+
+- [ ] **Step 4: 实现 `LogtoAccountApi.kt`**
+
+```kotlin
+package whl.trending.ai.data.remote
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import whl.trending.ai.auth.LOGTO_ENDPOINT
+
+@Serializable
+data class GithubTokenResponse(
+    @SerialName("access_token") val accessToken: String,
+)
+
+/**
+ * Logto Account API：从 Secret Vault 取回用户的第三方（GitHub）access token。
+ * 凭据是用户自己的 Logto opaque access token（登录 scope 已含 identities）。
+ */
+open class LogtoAccountApi {
+    private val client = HttpClient {
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
+        install(HttpTimeout) {
+            requestTimeoutMillis = 15000
+            connectTimeoutMillis = 15000
+            socketTimeoutMillis = 15000
+        }
+    }
+
+    /**
+     * 取 GitHub access token。404=该用户未存 token（如撤销过授权），返回 null；
+     * 其余非 2xx 抛 ApiException（401 含 token 过期，调用方决定重试/登出）。
+     */
+    open suspend fun fetchGithubToken(logtoAccessToken: String): String? {
+        val response = client.get("$LOGTO_ENDPOINT/api/my-account/identities/github/access-token") {
+            header(HttpHeaders.Authorization, "Bearer $logtoAccessToken")
+        }
+        if (response.status.value == 404) return null
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<GithubTokenResponse>().accessToken
+    }
+}
+```
+（`Json`、`bodyAsText` 需对应 import：`kotlinx.serialization.json.Json`、`io.ktor.client.statement.bodyAsText`。`ApiException` 复用 `data/remote` 现有定义——若它在 `TrendingApi.kt` 内部且不可见，将其提升为同包顶层类，注意保持既有调用点编译通过。）
+
+- [ ] **Step 5: 实现 `GithubTokenProvider.kt`**
+
+```kotlin
+package whl.trending.ai.auth
+
+import whl.trending.ai.data.remote.LogtoAccountApi
+
+/**
+ * GitHub token 会话级缓存。GitHub OAuth App 的 access token 永不过期
+ * （用户主动撤销授权才失效），进程内取一次即可；不落盘，避免明文持久化第三方凭据。
+ */
+open class GithubTokenProvider(
+    private val accountApi: LogtoAccountApi = LogtoAccountApi(),
+    private val authManager: () -> AuthManager = { globalAuthManager },
+) {
+    private var cached: String? = null
+
+    open suspend fun get(): String? {
+        cached?.let { return it }
+        val logtoToken = authManager().getAccessToken() ?: return null
+        return try {
+            accountApi.fetchGithubToken(logtoToken)?.also { cached = it }
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            null
+        }
+    }
+
+    fun clear() {
+        cached = null
+    }
+
+    companion object {
+        /** 全局共享实例：登出时由 LogtoAuthManager 清空 */
+        val shared = GithubTokenProvider()
+    }
+}
+```
+
+- [ ] **Step 6: LogtoAuthManager 接线**
+
+1. companion 里删除 `private const val LOGTO_ENDPOINT = ...`，改 import shared 的 `whl.trending.ai.auth.LOGTO_ENDPOINT`（LogtoConfig 的 endpoint 参数引用它）
+2. `signOut()` 中 `setUserAvatarUrl(null)` 旁追加：`GithubTokenProvider.shared.clear()`
+
+- [ ] **Step 7: 测试 + 编译**
+
+Run: `./gradlew shared:testAndroidHostTest :androidApp:assembleGithubDebug 2>&1 | tail -3`
+Expected: BUILD SUCCESSFUL（新增 2 个解析测试通过）
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/whl/trending/ai shared/src/commonTest androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+git commit -m "feat: GithubTokenProvider——经 Logto Account API 取 GitHub token 并做会话缓存
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: GithubApi + 事件 DTO（TDD）
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt`
+- Test: `shared/src/commonTest/kotlin/whl/trending/ai/data/remote/GithubApiModelsTest.kt`
+
+- [ ] **Step 1: 写失败测试**
+
+```kotlin
+package whl.trending.ai.data.remote
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GithubApiModelsTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decode_github_user() {
+        val payload = """
+            {"login":"HarlonWang","followers":491,"following":81,"public_repos":24,"name":"Harlon"}
+        """.trimIndent()
+        val user = json.decodeFromString<GithubUser>(payload)
+        assertEquals("HarlonWang", user.login)
+        assertEquals(491, user.followers)
+        assertEquals(81, user.following)
+        assertEquals(24, user.publicRepos)
+    }
+
+    @Test
+    fun decode_event_with_payload_kept_raw() {
+        val payload = """
+            [{"id":"22249084947","type":"WatchEvent",
+              "actor":{"id":1,"login":"octocat","avatar_url":"https://a.png"},
+              "repo":{"id":2,"name":"octocat/Hello-World"},
+              "payload":{"action":"started"},
+              "public":true,"created_at":"2026-06-09T12:47:28Z"}]
+        """.trimIndent()
+        val events = json.decodeFromString<List<GithubEventDto>>(payload)
+        assertEquals(1, events.size)
+        assertEquals("WatchEvent", events[0].type)
+        assertEquals("octocat", events[0].actor.login)
+        assertEquals("octocat/Hello-World", events[0].repo.name)
+        assertEquals("started", events[0].payload?.jsonObject?.get("action")?.jsonPrimitive?.content)
+    }
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `./gradlew shared:testAndroidHostTest --tests "*GithubApiModelsTest*" 2>&1 | tail -5`
+Expected: 编译失败
+
+- [ ] **Step 3: 实现 `GithubApi.kt`**
+
+```kotlin
+package whl.trending.ai.data.remote
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+@Serializable
+data class GithubUser(
+    val login: String,
+    val followers: Int = 0,
+    val following: Int = 0,
+    @SerialName("public_repos") val publicRepos: Int = 0,
+)
+
+@Serializable
+data class GithubEventActor(
+    val login: String,
+    @SerialName("avatar_url") val avatarUrl: String? = null,
+)
+
+@Serializable
+data class GithubEventRepo(
+    val name: String,
+)
+
+@Serializable
+data class GithubEventDto(
+    val id: String,
+    val type: String,
+    val actor: GithubEventActor,
+    val repo: GithubEventRepo,
+    /** 各事件类型 payload 结构不同，保留原始 JSON 由 mapper 弹性提取 */
+    val payload: JsonElement? = null,
+    @SerialName("created_at") val createdAt: String,
+)
+
+/** GitHub REST 直连：feed 与计数。token 来自 GithubTokenProvider（Secret Vault 取回）。 */
+open class GithubApi {
+    private val client = HttpClient {
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
+        install(HttpTimeout) {
+            requestTimeoutMillis = 15000
+            connectTimeoutMillis = 15000
+            socketTimeoutMillis = 15000
+        }
+    }
+
+    private val baseHost = "https://api.github.com"
+
+    open suspend fun fetchUser(githubToken: String): GithubUser {
+        val response = client.get("$baseHost/user") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<GithubUser>()
+    }
+
+    open suspend fun fetchReceivedEvents(
+        githubToken: String,
+        login: String,
+        page: Int,
+        perPage: Int = 30,
+    ): List<GithubEventDto> {
+        val response = client.get("$baseHost/users/$login/received_events") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+            parameter("per_page", perPage)
+            parameter("page", page)
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<List<GithubEventDto>>()
+    }
+}
+```
+
+- [ ] **Step 4: 测试通过 + Commit**
+
+Run: `./gradlew shared:testAndroidHostTest 2>&1 | tail -3` → BUILD SUCCESSFUL
+
+```bash
+git add shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt shared/src/commonTest/kotlin/whl/trending/ai/data/remote/GithubApiModelsTest.kt
+git commit -m "feat: GithubApi——直连 GitHub REST 取用户计数与 received_events
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: 事件归一化 mapper（TDD 重点）
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubFeedItem.kt`
+- Test: `shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/GithubFeedMapperTest.kt`
+
+- [ ] **Step 1: 写失败测试（覆盖全部映射类型 + fallback + 非法 payload）**
+
+```kotlin
+package whl.trending.ai.ui.profile
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import whl.trending.ai.data.remote.GithubEventActor
+import whl.trending.ai.data.remote.GithubEventDto
+import whl.trending.ai.data.remote.GithubEventRepo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GithubFeedMapperTest {
+    private fun event(type: String, payloadJson: String?): GithubEventDto = GithubEventDto(
+        id = "1",
+        type = type,
+        actor = GithubEventActor(login = "octocat", avatarUrl = "https://a.png"),
+        repo = GithubEventRepo(name = "owner/repo"),
+        payload = payloadJson?.let { Json.parseToJsonElement(it) },
+        createdAt = "2026-06-09T12:47:28Z",
+    )
+
+    @Test
+    fun watch_event_maps_to_starred() {
+        val item = event("WatchEvent", """{"action":"started"}""").toFeedItem()
+        assertEquals(GithubFeedKind.STARRED, item.kind)
+        assertEquals("https://github.com/owner/repo", item.targetUrl)
+    }
+
+    @Test
+    fun fork_event() {
+        assertEquals(GithubFeedKind.FORKED, event("ForkEvent", "{}").toFeedItem().kind)
+    }
+
+    @Test
+    fun create_event_branch_and_repo_and_tag() {
+        val branch = event("CreateEvent", """{"ref":"dev","ref_type":"branch"}""").toFeedItem()
+        assertEquals(GithubFeedKind.CREATED_BRANCH, branch.kind)
+        assertEquals("dev", branch.primary)
+
+        val repo = event("CreateEvent", """{"ref":null,"ref_type":"repository"}""").toFeedItem()
+        assertEquals(GithubFeedKind.CREATED_REPO, repo.kind)
+
+        val tag = event("CreateEvent", """{"ref":"v1.0","ref_type":"tag"}""").toFeedItem()
+        assertEquals(GithubFeedKind.CREATED_TAG, tag.kind)
+        assertEquals("v1.0", tag.primary)
+    }
+
+    @Test
+    fun release_event_uses_release_url_and_tag() {
+        val item = event(
+            "ReleaseEvent",
+            """{"action":"published","release":{"tag_name":"v2.1","html_url":"https://github.com/owner/repo/releases/tag/v2.1"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.RELEASED, item.kind)
+        assertEquals("v2.1", item.primary)
+        assertEquals("https://github.com/owner/repo/releases/tag/v2.1", item.targetUrl)
+    }
+
+    @Test
+    fun push_event_counts_commits() {
+        val item = event("PushEvent", """{"size":3,"ref":"refs/heads/main"}""").toFeedItem()
+        assertEquals(GithubFeedKind.PUSHED, item.kind)
+        assertEquals("3", item.primary)
+    }
+
+    @Test
+    fun pull_request_opened_merged_closed() {
+        val opened = event(
+            "PullRequestEvent",
+            """{"action":"opened","number":12,"pull_request":{"merged":false,"html_url":"https://github.com/owner/repo/pull/12"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.PR_OPENED, opened.kind)
+        assertEquals("12", opened.primary)
+        assertEquals("https://github.com/owner/repo/pull/12", opened.targetUrl)
+
+        val merged = event(
+            "PullRequestEvent",
+            """{"action":"closed","number":13,"pull_request":{"merged":true,"html_url":"https://github.com/owner/repo/pull/13"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.PR_MERGED, merged.kind)
+
+        val closed = event(
+            "PullRequestEvent",
+            """{"action":"closed","number":14,"pull_request":{"merged":false,"html_url":"https://github.com/owner/repo/pull/14"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.PR_CLOSED, closed.kind)
+    }
+
+    @Test
+    fun issues_and_comment_events() {
+        val opened = event(
+            "IssuesEvent",
+            """{"action":"opened","issue":{"number":7,"html_url":"https://github.com/owner/repo/issues/7"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.ISSUE_OPENED, opened.kind)
+        assertEquals("7", opened.primary)
+
+        val closed = event(
+            "IssuesEvent",
+            """{"action":"closed","issue":{"number":8,"html_url":"https://github.com/owner/repo/issues/8"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.ISSUE_CLOSED, closed.kind)
+
+        val comment = event(
+            "IssueCommentEvent",
+            """{"action":"created","issue":{"number":9,"html_url":"https://github.com/owner/repo/issues/9"},"comment":{"html_url":"https://github.com/owner/repo/issues/9#issuecomment-1"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.ISSUE_COMMENTED, comment.kind)
+        assertEquals("https://github.com/owner/repo/issues/9#issuecomment-1", comment.targetUrl)
+    }
+
+    @Test
+    fun public_event_and_unknown_fallback() {
+        assertEquals(GithubFeedKind.MADE_PUBLIC, event("PublicEvent", "{}").toFeedItem().kind)
+
+        val other = event("MemberEvent", """{"action":"added"}""").toFeedItem()
+        assertEquals(GithubFeedKind.OTHER, other.kind)
+        assertEquals("Member", other.primary) // type 去掉 Event 后缀作展示
+    }
+
+    @Test
+    fun malformed_payload_does_not_crash() {
+        val item = event("PullRequestEvent", null).toFeedItem()
+        assertEquals(GithubFeedKind.OTHER, item.kind)
+        assertEquals("https://github.com/owner/repo", item.targetUrl)
+    }
+}
+```
+
+- [ ] **Step 2: 运行确认失败** → 编译失败
+
+- [ ] **Step 3: 实现 `GithubFeedItem.kt`**
+
+```kotlin
+package whl.trending.ai.ui.profile
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import whl.trending.ai.data.remote.GithubEventDto
+
+enum class GithubFeedKind {
+    STARRED, FORKED, CREATED_REPO, CREATED_BRANCH, CREATED_TAG, RELEASED,
+    PUSHED, PR_OPENED, PR_MERGED, PR_CLOSED,
+    ISSUE_OPENED, ISSUE_CLOSED, ISSUE_COMMENTED, MADE_PUBLIC, OTHER,
+}
+
+/**
+ * 归一化后的 feed 条目：kind + primary（分支名/tag/编号/提交数/类型名，按 kind 而定），
+ * 文案在 UI 层用 stringResource 按 kind 组装（i18n）。
+ */
+data class GithubFeedItem(
+    val id: String,
+    val actorLogin: String,
+    val actorAvatarUrl: String?,
+    val repoName: String,
+    val kind: GithubFeedKind,
+    val primary: String?,
+    val createdAt: String,
+    val targetUrl: String,
+)
+
+fun GithubEventDto.toFeedItem(): GithubFeedItem {
+    val p = payload as? JsonObject ?: (payload?.let { runCatching { it.jsonObject }.getOrNull() })
+    val repoUrl = "https://github.com/${repo.name}"
+
+    fun str(obj: JsonObject?, key: String): String? =
+        obj?.get(key)?.let { runCatching { it.jsonPrimitive.content }.getOrNull() }
+
+    fun obj(parent: JsonObject?, key: String): JsonObject? =
+        parent?.get(key)?.let { runCatching { it.jsonObject }.getOrNull() }
+
+    var kind = GithubFeedKind.OTHER
+    var primary: String? = type.removeSuffix("Event")
+    var targetUrl = repoUrl
+
+    when (type) {
+        "WatchEvent" -> { kind = GithubFeedKind.STARRED; primary = null }
+        "ForkEvent" -> { kind = GithubFeedKind.FORKED; primary = null }
+        "PublicEvent" -> { kind = GithubFeedKind.MADE_PUBLIC; primary = null }
+        "CreateEvent" -> when (str(p, "ref_type")) {
+            "repository" -> { kind = GithubFeedKind.CREATED_REPO; primary = null }
+            "branch" -> { kind = GithubFeedKind.CREATED_BRANCH; primary = str(p, "ref") }
+            "tag" -> { kind = GithubFeedKind.CREATED_TAG; primary = str(p, "ref") }
+        }
+        "ReleaseEvent" -> {
+            val release = obj(p, "release")
+            kind = GithubFeedKind.RELEASED
+            primary = str(release, "tag_name")
+            str(release, "html_url")?.let { targetUrl = it }
+        }
+        "PushEvent" -> {
+            kind = GithubFeedKind.PUSHED
+            primary = (p?.get("size")?.jsonPrimitive?.intOrNull ?: 1).toString()
+        }
+        "PullRequestEvent" -> {
+            val pr = obj(p, "pull_request")
+            val number = p?.get("number")?.jsonPrimitive?.intOrNull
+            if (pr != null && number != null) {
+                kind = when {
+                    str(p, "action") == "opened" -> GithubFeedKind.PR_OPENED
+                    str(p, "action") == "closed" &&
+                        pr["merged"]?.jsonPrimitive?.booleanOrNull == true -> GithubFeedKind.PR_MERGED
+                    str(p, "action") == "closed" -> GithubFeedKind.PR_CLOSED
+                    else -> GithubFeedKind.OTHER
+                }
+                if (kind != GithubFeedKind.OTHER) {
+                    primary = number.toString()
+                    str(pr, "html_url")?.let { targetUrl = it }
+                }
+            }
+        }
+        "IssuesEvent" -> {
+            val issue = obj(p, "issue")
+            val number = issue?.get("number")?.jsonPrimitive?.intOrNull
+            if (issue != null && number != null) {
+                kind = when (str(p, "action")) {
+                    "opened" -> GithubFeedKind.ISSUE_OPENED
+                    "closed" -> GithubFeedKind.ISSUE_CLOSED
+                    else -> GithubFeedKind.OTHER
+                }
+                if (kind != GithubFeedKind.OTHER) {
+                    primary = number.toString()
+                    str(issue, "html_url")?.let { targetUrl = it }
+                }
+            }
+        }
+        "IssueCommentEvent" -> {
+            val issue = obj(p, "issue")
+            val number = issue?.get("number")?.jsonPrimitive?.intOrNull
+            if (number != null) {
+                kind = GithubFeedKind.ISSUE_COMMENTED
+                primary = number.toString()
+                targetUrl = str(obj(p, "comment"), "html_url")
+                    ?: str(issue, "html_url")
+                    ?: repoUrl
+            }
+        }
+    }
+
+    return GithubFeedItem(
+        id = id,
+        actorLogin = actor.login,
+        actorAvatarUrl = actor.avatarUrl,
+        repoName = repo.name,
+        kind = kind,
+        primary = primary,
+        createdAt = createdAt,
+        targetUrl = targetUrl,
+    )
+}
+```
+
+注意：若实现与测试期望有出入（如 PR 事件 payload 缺失时的 fallback 行为），以测试为准修实现。
+
+- [ ] **Step 4: 测试通过 + Commit**
+
+Run: `./gradlew shared:testAndroidHostTest 2>&1 | tail -3` → BUILD SUCCESSFUL（mapper 9 个测试全过）
+
+```bash
+git add shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubFeedItem.kt shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/GithubFeedMapperTest.kt
+git commit -m "feat: received_events 事件归一化 mapper（14 类事件 + fallback）
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: ProfileViewModel 扩展（计数 + feed 分页）
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt`
+
+- [ ] **Step 1: 重写 ProfileViewModel**
+
+```kotlin
+package whl.trending.ai.ui.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import whl.trending.ai.auth.AuthManager
+import whl.trending.ai.auth.GithubTokenProvider
+import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.data.model.MeUser
+import whl.trending.ai.data.remote.GithubApi
+import whl.trending.ai.data.remote.GithubUser
+import whl.trending.ai.data.repository.UserRepository
+
+private const val FEED_PAGE_SIZE = 30
+private const val FEED_MAX_EVENTS = 300 // GitHub received_events 硬上限
+
+data class ProfileUiState(
+    val isLoading: Boolean = true,
+    val user: MeUser? = null,
+    val isError: Boolean = false,
+    /** GitHub 实时计数；token 不可用或请求失败时为 null（UI 隐藏计数行） */
+    val githubUser: GithubUser? = null,
+    val feedItems: List<GithubFeedItem> = emptyList(),
+    val isFeedLoading: Boolean = false,
+    val feedEndReached: Boolean = false,
+    /** feed 不可用（无 GitHub token / 请求失败），与整页 isError 区分 */
+    val feedUnavailable: Boolean = false,
+)
+
+class ProfileViewModel(
+    private val repository: UserRepository = UserRepository(),
+    private val githubApi: GithubApi = GithubApi(),
+    private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
+    private val authManager: AuthManager = globalAuthManager,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(ProfileUiState())
+    val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
+
+    private var nextFeedPage = 1
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.value = ProfileUiState(isLoading = true)
+            nextFeedPage = 1
+            val token = authManager.getAccessToken()
+            if (token == null) {
+                _uiState.value = ProfileUiState(isLoading = false, isError = true)
+                return@launch
+            }
+            val user = try {
+                repository.fetchMe(token)
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                _uiState.value = ProfileUiState(isLoading = false, isError = true)
+                return@launch
+            }
+            _uiState.value = ProfileUiState(isLoading = false, user = user)
+            loadGithubData(user)
+        }
+    }
+
+    private suspend fun loadGithubData(user: MeUser) {
+        val githubToken = tokenProvider.get()
+        val login = user.githubLogin
+        if (githubToken == null || login == null) {
+            _uiState.value = _uiState.value.copy(feedUnavailable = true)
+            return
+        }
+        try {
+            val githubUser = githubApi.fetchUser(githubToken)
+            _uiState.value = _uiState.value.copy(githubUser = githubUser)
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            // 计数失败不致命，feed 继续尝试
+        }
+        loadMoreFeed()
+    }
+
+    fun loadMoreFeed() {
+        val state = _uiState.value
+        if (state.isFeedLoading || state.feedEndReached || state.feedUnavailable) return
+        val login = state.user?.githubLogin ?: return
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isFeedLoading = true)
+            val githubToken = tokenProvider.get()
+            if (githubToken == null) {
+                _uiState.value = _uiState.value.copy(isFeedLoading = false, feedUnavailable = true)
+                return@launch
+            }
+            try {
+                val events = githubApi.fetchReceivedEvents(githubToken, login, nextFeedPage, FEED_PAGE_SIZE)
+                val newItems = events.map { it.toFeedItem() }
+                val merged = (_uiState.value.feedItems + newItems).distinctBy { it.id }
+                val endReached = events.size < FEED_PAGE_SIZE || merged.size >= FEED_MAX_EVENTS
+                nextFeedPage++
+                _uiState.value = _uiState.value.copy(
+                    feedItems = merged,
+                    isFeedLoading = false,
+                    feedEndReached = endReached,
+                )
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                _uiState.value = _uiState.value.copy(
+                    isFeedLoading = false,
+                    feedUnavailable = _uiState.value.feedItems.isEmpty(),
+                )
+            }
+        }
+    }
+
+    fun signOut() = authManager.signOut()
+}
+```
+
+- [ ] **Step 2: 编译**
+
+Run: `./gradlew :androidApp:assembleGithubDebug -q` → BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+git commit -m "feat: ProfileViewModel 扩展——GitHub 计数 + feed 分页加载
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: ProfileScreen 一体化改造 + 文案
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt`
+- Modify: `shared/src/commonMain/composeResources/values/strings.xml`、`values-zh/strings.xml`
+
+- [ ] **Step 1: 文案**
+
+`values/strings.xml` 追加：
+```xml
+<string name="profile_followers">Followers</string>
+<string name="profile_following">Following</string>
+<string name="profile_repos">Repos</string>
+<string name="feed_starred">Starred %1$s</string>
+<string name="feed_forked">Forked %1$s</string>
+<string name="feed_created_repo">Created repository %1$s</string>
+<string name="feed_created_branch">Created branch %1$s in %2$s</string>
+<string name="feed_created_tag">Created tag %1$s in %2$s</string>
+<string name="feed_released">Released %1$s in %2$s</string>
+<string name="feed_pushed">Pushed %1$s commits to %2$s</string>
+<string name="feed_pr_opened">Opened PR #%1$s in %2$s</string>
+<string name="feed_pr_merged">Merged PR #%1$s in %2$s</string>
+<string name="feed_pr_closed">Closed PR #%1$s in %2$s</string>
+<string name="feed_issue_opened">Opened issue #%1$s in %2$s</string>
+<string name="feed_issue_closed">Closed issue #%1$s in %2$s</string>
+<string name="feed_issue_commented">Commented on #%1$s in %2$s</string>
+<string name="feed_made_public">Open sourced %1$s</string>
+<string name="feed_other">%1$s in %2$s</string>
+<string name="feed_empty">No recent activity</string>
+<string name="feed_end_notice">Only activity from the last 30 days is shown</string>
+<string name="feed_unavailable">Activity feed unavailable</string>
+```
+`values-zh/strings.xml` 追加：
+```xml
+<string name="profile_followers">粉丝</string>
+<string name="profile_following">关注</string>
+<string name="profile_repos">仓库</string>
+<string name="feed_starred">Star 了 %1$s</string>
+<string name="feed_forked">Fork 了 %1$s</string>
+<string name="feed_created_repo">创建了仓库 %1$s</string>
+<string name="feed_created_branch">在 %2$s 创建了分支 %1$s</string>
+<string name="feed_created_tag">在 %2$s 创建了标签 %1$s</string>
+<string name="feed_released">在 %2$s 发布了 %1$s</string>
+<string name="feed_pushed">推送了 %1$s 个提交到 %2$s</string>
+<string name="feed_pr_opened">在 %2$s 开启了 PR #%1$s</string>
+<string name="feed_pr_merged">在 %2$s 合并了 PR #%1$s</string>
+<string name="feed_pr_closed">在 %2$s 关闭了 PR #%1$s</string>
+<string name="feed_issue_opened">在 %2$s 开启了 issue #%1$s</string>
+<string name="feed_issue_closed">在 %2$s 关闭了 issue #%1$s</string>
+<string name="feed_issue_commented">评论了 %2$s 的 #%1$s</string>
+<string name="feed_made_public">开源了 %1$s</string>
+<string name="feed_other">%1$s · %2$s</string>
+<string name="feed_empty">暂无动态</string>
+<string name="feed_end_notice">仅展示最近 30 天的动态</string>
+<string name="feed_unavailable">动态加载不可用</string>
+```
+（两个文件各追加 21 条，key 与条目数一一对应。）
+
+- [ ] **Step 2: 重写 ProfileScreen 为 LazyColumn 一体化**
+
+结构（保持现有 import 风格，新增 LazyColumn/itemsIndexed/HorizontalDivider/coil 等所需 import）：
+
+```kotlin
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(onBack: () -> Unit) {
+    val viewModel: ProfileViewModel = viewModel { ProfileViewModel() }
+    val uiState by viewModel.uiState.collectAsState()
+    val uriHandler = LocalUriHandler.current
+    val listState = rememberLazyListState()
+
+    // 滚动到底部附近时自动加载下一页
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            last >= listState.layoutInfo.totalItemsCount - 3
+        }
+    }
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore) viewModel.loadMoreFeed()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(Res.string.profile_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        when {
+            uiState.isLoading -> Box(
+                Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center
+            ) { CircularProgressIndicator() }
+
+            uiState.isError -> Column(
+                modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(stringResource(Res.string.profile_load_failed), Modifier.padding(top = 48.dp))
+                Button(onClick = { viewModel.load() }) { Text(stringResource(Res.string.profile_retry)) }
+                OutlinedButton(onClick = { viewModel.signOut(); onBack() }) {
+                    Text(stringResource(Res.string.sign_out))
+                }
+            }
+
+            else -> LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize().padding(padding),
+            ) {
+                item(key = "header") {
+                    ProfileHeader(
+                        uiState = uiState,
+                        onOpenGithub = { url -> uriHandler.openUri(url) },
+                        onSignOut = { viewModel.signOut(); onBack() },
+                    )
+                }
+                if (uiState.feedUnavailable && uiState.feedItems.isEmpty()) {
+                    item(key = "feed_unavailable") {
+                        FeedNotice(stringResource(Res.string.feed_unavailable))
+                    }
+                } else if (uiState.feedItems.isEmpty() && uiState.feedEndReached) {
+                    item(key = "feed_empty") {
+                        FeedNotice(stringResource(Res.string.feed_empty))
+                    }
+                }
+                items(uiState.feedItems, key = { it.id }) { item ->
+                    GithubFeedRow(item = item, onClick = { uriHandler.openUri(item.targetUrl) })
+                    HorizontalDivider(thickness = 0.5.dp)
+                }
+                if (uiState.isFeedLoading) {
+                    item(key = "feed_loading") {
+                        Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator(Modifier.size(24.dp), strokeWidth = 2.dp)
+                        }
+                    }
+                }
+                if (uiState.feedEndReached && uiState.feedItems.isNotEmpty()) {
+                    item(key = "feed_end") {
+                        FeedNotice(stringResource(Res.string.feed_end_notice))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProfileHeader(
+    uiState: ProfileUiState,
+    onOpenGithub: (String) -> Unit,
+    onSignOut: () -> Unit,
+) {
+    val user = uiState.user ?: return
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        AsyncImage(
+            model = user.avatarUrl,
+            contentDescription = null,
+            modifier = Modifier.size(96.dp).clip(CircleShape)
+        )
+        Text(user.displayName ?: user.githubLogin.orEmpty(), style = MaterialTheme.typography.titleLarge)
+        user.githubLogin?.let {
+            Text("@$it", style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        user.bio?.takeIf { it.isNotBlank() }?.let {
+            Text(it, style = MaterialTheme.typography.bodyMedium, textAlign = TextAlign.Center)
+        }
+        uiState.githubUser?.let { gh ->
+            Row(horizontalArrangement = Arrangement.spacedBy(24.dp)) {
+                CountCell(gh.followers, stringResource(Res.string.profile_followers))
+                CountCell(gh.following, stringResource(Res.string.profile_following))
+                CountCell(gh.publicRepos, stringResource(Res.string.profile_repos))
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        user.htmlUrl?.let { url ->
+            Button(onClick = { onOpenGithub(url) }, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(Res.string.profile_open_github))
+            }
+        }
+        OutlinedButton(onClick = onSignOut, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(Res.string.sign_out))
+        }
+    }
+}
+
+@Composable
+private fun CountCell(count: Int, label: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(count.toString(), style = MaterialTheme.typography.titleMedium)
+        Text(label, style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun FeedNotice(text: String) {
+    Box(Modifier.fillMaxWidth().padding(24.dp), contentAlignment = Alignment.Center) {
+        Text(text, style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun GithubFeedRow(item: GithubFeedItem, onClick: () -> Unit) {
+    val summary = when (item.kind) {
+        GithubFeedKind.STARRED -> stringResource(Res.string.feed_starred, item.repoName)
+        GithubFeedKind.FORKED -> stringResource(Res.string.feed_forked, item.repoName)
+        GithubFeedKind.CREATED_REPO -> stringResource(Res.string.feed_created_repo, item.repoName)
+        GithubFeedKind.CREATED_BRANCH -> stringResource(Res.string.feed_created_branch, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.CREATED_TAG -> stringResource(Res.string.feed_created_tag, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.RELEASED -> stringResource(Res.string.feed_released, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.PUSHED -> stringResource(Res.string.feed_pushed, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.PR_OPENED -> stringResource(Res.string.feed_pr_opened, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.PR_MERGED -> stringResource(Res.string.feed_pr_merged, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.PR_CLOSED -> stringResource(Res.string.feed_pr_closed, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.ISSUE_OPENED -> stringResource(Res.string.feed_issue_opened, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.ISSUE_CLOSED -> stringResource(Res.string.feed_issue_closed, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.ISSUE_COMMENTED -> stringResource(Res.string.feed_issue_commented, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.MADE_PUBLIC -> stringResource(Res.string.feed_made_public, item.repoName)
+        GithubFeedKind.OTHER -> stringResource(Res.string.feed_other, item.primary.orEmpty(), item.repoName)
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable { onClick() }.padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        AsyncImage(
+            model = item.actorAvatarUrl,
+            contentDescription = null,
+            modifier = Modifier.size(36.dp).clip(CircleShape)
+        )
+        Column(Modifier.weight(1f)) {
+            Text(item.actorLogin, style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(summary, style = MaterialTheme.typography.bodyMedium)
+            Text(
+                DateTimeUtils.formatToLocalTime(item.createdAt),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+```
+
+（`DateTimeUtils` import `whl.trending.ai.core.DateTimeUtils`；若 `formatToLocalTime` 是 object 方法按现状调用。Res 字符串 import 按该文件现有逐条风格补齐全部新 key。）
+
+- [ ] **Step 3: 编译 + 全量测试**
+
+Run: `./gradlew :androidApp:assembleGithubDebug shared:testAndroidHostTest 2>&1 | tail -3` → BUILD SUCCESSFUL
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/whl/trending/ai/ui/profile shared/src/commonMain/composeResources
+git commit -m "feat: Profile 一体化——头部计数 + GitHub 动态流（分页/空态/到底提示）
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: 端到端验证 + 收尾
+
+- [ ] **Step 1: 安装运行**
+
+Run: `./gradlew :androidApp:installGithubDebug && adb shell am start -n whl.trending.ai.debug/whl.trending.ai.MainActivity`
+
+- [ ] **Step 2: 验证清单**
+
+1. 已登录态打开 Profile：头部出现 followers/following/repos 三计数（与 github.com 个人页一致）
+2. 头部下方出现动态流：star/fork/release/push 等事件正确渲染（actor 头像 + 文案 + 时间）
+3. 滚动到底自动翻页；到达末尾显示"仅展示最近 30 天的动态"
+4. 点击条目跳转对应 GitHub 页面（release 跳 release 页、PR 跳 PR 页）
+5. 中文环境文案正确（设置切中文验证 2-3 条）
+6. 登出 → 重新登录 → feed 正常（GithubTokenProvider 缓存清理生效）
+7. 错误态（断网打开 Profile）：显示失败 + 重试 + 登出按钮
+
+- [ ] **Step 3: 推送 + PR**
+
+```bash
+git push -u origin feat/logto-phase2-feed
+gh pr create --title "feat: GitHub 动态流 + Profile 计数（Logto Phase 2）" --body "$(cat <<'EOF'
+## Summary
+- Profile 页一体化：头部新增 followers/following/repos 实时计数，下方接 GitHub Dashboard 风格动态流（received_events，分页加载，14 类事件归一化渲染，30 天/300 条到底提示）
+- GitHub token 链路：经 Logto Account API 从 Secret Vault 取回 GitHub token，会话内存缓存，登出清理（Worker 零改动）
+- Phase 1 遗留清理：收拢双 syncMe 为单触发点、UserRepository 提为 remember、Profile 错误态增加登出出口
+
+## Test Plan
+- [x] shared 单测全绿（Account API/GitHub 模型解析 + mapper 全事件类型覆盖）
+- [x] 模拟器端到端：计数与 github.com 一致、动态流渲染/翻页/到底提示、条目跳转、中英文案、登出重登、断网错误态
+
+设计文档：docs/superpowers/specs/2026-06-09-trendingai-logto-auth-design.md §6/§8
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## 明确不做（Phase 2 范围外）
+
+- 不做 ETag 304 轮询优化（首版直接分页拉取，5000 次/小时配额远够）
+- 不做 feed 本地缓存/离线
+- 不做下拉刷新（返回再进即重新加载；如验证后觉得必要再加）
+- 不做 iOS UI
+- Worker/后端零改动

--- a/docs/superpowers/plans/2026-06-10-logto-auth-phase2.md
+++ b/docs/superpowers/plans/2026-06-10-logto-auth-phase2.md
@@ -1177,5 +1177,5 @@ EOF
 - 不做 ETag 304 轮询优化（首版直接分页拉取，5000 次/小时配额远够）
 - 不做 feed 本地缓存/离线
 - 不做下拉刷新（返回再进即重新加载；如验证后觉得必要再加）
-- 不做 iOS UI
+- 不做 iOS 登录接入（UI 为 CMP 共享代码本就跨端，iOS 缺的只是 AuthManager 的 Logto Swift SDK 实现；未接入前 `isSupported=false` 使登录入口自动隐藏，Profile/Feed 不可达。将来接入仅需：Swift SDK + AuthManager iOS 实现注入 + 控制台加 iOS redirect URI，shared 全部资产零改动复用）
 - Worker/后端零改动

--- a/docs/superpowers/specs/2026-06-09-trendingai-logto-auth-design.md
+++ b/docs/superpowers/specs/2026-06-09-trendingai-logto-auth-design.md
@@ -41,7 +41,7 @@ TrendingAI 当前是一个无登录态的内容浏览产品（Daily Picks + 三�
 
 ### 明确不做（Non-goals）
 - 不做 AI chat、订阅收费（仅留好挂载点：业务/会员按内部 `user_id` 挂在 D1，不依赖 Logto 付费特性）
-- 不做 iOS UI（KMP shared 层就绪，后续接）
+- 不做 iOS 登录接入（UI 为 CMP 共享代码本就跨端；iOS 缺的只是 AuthManager 的 Logto Swift SDK 实现，未接入前 `isSupported=false` 自动隐藏登录入口。后续接入仅需 Swift SDK + iOS 实现注入 + 控制台加 redirect URI，shared 资产零改动复用）
 - **不碰 Tono 或任何其他项目**
 - 不做密码登录（Logto 邮箱方式走 OTP）
 - 本次登录方式只启用 **GitHub**；邮箱 OTP 可在 Logto 控制台随时开启，无需改代码（但仅 GitHub 登录的用户有 feed，见 §6）

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -145,6 +145,8 @@
     <string name="feed_made_public">开源了 %1$s</string>
     <string name="feed_other">%1$s · %2$s</string>
     <string name="feed_empty">暂无动态</string>
-    <string name="feed_end_notice">仅展示最近 30 天的动态</string>
+    <string name="feed_end_notice">已加载全部动态</string>
+    <string name="feed_filter_highlights">精选</string>
+    <string name="feed_filter_all">全部</string>
     <string name="feed_unavailable">动态加载不可用</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -126,4 +126,25 @@
     <string name="profile_open_github">在 GitHub 打开</string>
     <string name="profile_load_failed">加载失败</string>
     <string name="profile_retry">重试</string>
+    <string name="profile_followers">粉丝</string>
+    <string name="profile_following">关注</string>
+    <string name="profile_repos">仓库</string>
+    <string name="feed_starred">Star 了 %1$s</string>
+    <string name="feed_forked">Fork 了 %1$s</string>
+    <string name="feed_created_repo">创建了仓库 %1$s</string>
+    <string name="feed_created_branch">在 %2$s 创建了分支 %1$s</string>
+    <string name="feed_created_tag">在 %2$s 创建了标签 %1$s</string>
+    <string name="feed_released">在 %2$s 发布了 %1$s</string>
+    <string name="feed_pushed">推送了 %1$s 个提交到 %2$s</string>
+    <string name="feed_pr_opened">在 %2$s 开启了 PR #%1$s</string>
+    <string name="feed_pr_merged">在 %2$s 合并了 PR #%1$s</string>
+    <string name="feed_pr_closed">在 %2$s 关闭了 PR #%1$s</string>
+    <string name="feed_issue_opened">在 %2$s 开启了 issue #%1$s</string>
+    <string name="feed_issue_closed">在 %2$s 关闭了 issue #%1$s</string>
+    <string name="feed_issue_commented">评论了 %2$s 的 #%1$s</string>
+    <string name="feed_made_public">开源了 %1$s</string>
+    <string name="feed_other">%1$s · %2$s</string>
+    <string name="feed_empty">暂无动态</string>
+    <string name="feed_end_notice">仅展示最近 30 天的动态</string>
+    <string name="feed_unavailable">动态加载不可用</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -143,6 +143,8 @@
     <string name="feed_issue_closed">在 %2$s 关闭了 issue #%1$s</string>
     <string name="feed_issue_commented">评论了 %2$s 的 #%1$s</string>
     <string name="feed_made_public">开源了 %1$s</string>
+    <string name="feed_starred_your_repo">Star 了你的仓库 %1$s</string>
+    <string name="feed_forked_your_repo">Fork 了你的仓库 %1$s</string>
     <string name="feed_other">%1$s · %2$s</string>
     <string name="feed_empty">暂无动态</string>
     <string name="feed_end_notice">已加载全部动态</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -145,6 +145,8 @@
     <string name="feed_made_public">Open sourced %1$s</string>
     <string name="feed_other">%1$s in %2$s</string>
     <string name="feed_empty">No recent activity</string>
-    <string name="feed_end_notice">Only activity from the last 30 days is shown</string>
+    <string name="feed_end_notice">All activity loaded</string>
+    <string name="feed_filter_highlights">Highlights</string>
+    <string name="feed_filter_all">All</string>
     <string name="feed_unavailable">Activity feed unavailable</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -143,6 +143,8 @@
     <string name="feed_issue_closed">Closed issue #%1$s in %2$s</string>
     <string name="feed_issue_commented">Commented on #%1$s in %2$s</string>
     <string name="feed_made_public">Open sourced %1$s</string>
+    <string name="feed_starred_your_repo">Starred your repository %1$s</string>
+    <string name="feed_forked_your_repo">Forked your repository %1$s</string>
     <string name="feed_other">%1$s in %2$s</string>
     <string name="feed_empty">No recent activity</string>
     <string name="feed_end_notice">All activity loaded</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -126,4 +126,25 @@
     <string name="profile_open_github">Open on GitHub</string>
     <string name="profile_load_failed">Failed to load profile</string>
     <string name="profile_retry">Retry</string>
+    <string name="profile_followers">Followers</string>
+    <string name="profile_following">Following</string>
+    <string name="profile_repos">Repos</string>
+    <string name="feed_starred">Starred %1$s</string>
+    <string name="feed_forked">Forked %1$s</string>
+    <string name="feed_created_repo">Created repository %1$s</string>
+    <string name="feed_created_branch">Created branch %1$s in %2$s</string>
+    <string name="feed_created_tag">Created tag %1$s in %2$s</string>
+    <string name="feed_released">Released %1$s in %2$s</string>
+    <string name="feed_pushed">Pushed %1$s commit(s) to %2$s</string>
+    <string name="feed_pr_opened">Opened PR #%1$s in %2$s</string>
+    <string name="feed_pr_merged">Merged PR #%1$s in %2$s</string>
+    <string name="feed_pr_closed">Closed PR #%1$s in %2$s</string>
+    <string name="feed_issue_opened">Opened issue #%1$s in %2$s</string>
+    <string name="feed_issue_closed">Closed issue #%1$s in %2$s</string>
+    <string name="feed_issue_commented">Commented on #%1$s in %2$s</string>
+    <string name="feed_made_public">Open sourced %1$s</string>
+    <string name="feed_other">%1$s in %2$s</string>
+    <string name="feed_empty">No recent activity</string>
+    <string name="feed_end_notice">Only activity from the last 30 days is shown</string>
+    <string name="feed_unavailable">Activity feed unavailable</string>
 </resources>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/auth/AuthManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/auth/AuthManager.kt
@@ -31,3 +31,6 @@ object NoopAuthManager : AuthManager {
 
 /** 仿 globalChatScreen 的依赖反转：Android 在 MainActivity.onCreate 注入实现 */
 var globalAuthManager: AuthManager = NoopAuthManager
+
+/** Logto 租户端点：客户端 SDK 与 Account API 共用 */
+const val LOGTO_ENDPOINT = "https://28bniv.logto.app"

--- a/shared/src/commonMain/kotlin/whl/trending/ai/auth/FollowingProvider.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/auth/FollowingProvider.kt
@@ -1,0 +1,56 @@
+package whl.trending.ai.auth
+
+import whl.trending.ai.data.remote.GithubApi
+import whl.trending.ai.data.remote.GithubFollowing
+
+data class FollowingInfo(
+    val users: Set<String>,   // 全小写 login
+    val orgs: Set<String>,    // 全小写 login
+)
+
+/**
+ * 关注列表会话级缓存：按 type 分桶（User / Organization），all lowercase。
+ * 任何异常返回 null（CancellationException 透传），null 不缓存。
+ * 登出时由 LogtoAuthManager 调用 clear() 清缓存。
+ */
+open class FollowingProvider(
+    private val githubApi: GithubApi = GithubApi(),
+    private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
+) {
+    private var cached: FollowingInfo? = null
+
+    open suspend fun get(): FollowingInfo? {
+        cached?.let { return it }
+        val token = tokenProvider.get() ?: return null
+        return try {
+            val users = mutableSetOf<String>()
+            val orgs = mutableSetOf<String>()
+            var page = 1
+            val maxPages = 10
+            while (page <= maxPages) {
+                val batch: List<GithubFollowing> = githubApi.fetchFollowing(token, page)
+                if (batch.isEmpty()) break
+                for (item in batch) {
+                    val loginLower = item.login.lowercase()
+                    if (item.type == "Organization") orgs.add(loginLower)
+                    else users.add(loginLower)
+                }
+                if (batch.size < 100) break
+                page++
+            }
+            FollowingInfo(users = users, orgs = orgs).also { cached = it }
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            null
+        }
+    }
+
+    fun clear() {
+        cached = null
+    }
+
+    companion object {
+        /** 全局共享实例：登出时由 LogtoAuthManager 清空 */
+        val shared = FollowingProvider()
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/auth/GithubTokenProvider.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/auth/GithubTokenProvider.kt
@@ -1,0 +1,34 @@
+package whl.trending.ai.auth
+
+import whl.trending.ai.data.remote.LogtoAccountApi
+
+/**
+ * GitHub token 会话级缓存。GitHub OAuth App 的 access token 永不过期
+ * （用户主动撤销授权才失效），进程内取一次即可；不落盘，避免明文持久化第三方凭据。
+ */
+open class GithubTokenProvider(
+    private val accountApi: LogtoAccountApi = LogtoAccountApi(),
+    private val authManager: () -> AuthManager = { globalAuthManager },
+) {
+    private var cached: String? = null
+
+    open suspend fun get(): String? {
+        cached?.let { return it }
+        val logtoToken = authManager().getAccessToken() ?: return null
+        return try {
+            accountApi.fetchGithubToken(logtoToken)?.also { cached = it }
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            null
+        }
+    }
+
+    fun clear() {
+        cached = null
+    }
+
+    companion object {
+        /** 全局共享实例：登出时由 LogtoAuthManager 清空 */
+        val shared = GithubTokenProvider()
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/auth/OwnRepoEventsProvider.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/auth/OwnRepoEventsProvider.kt
@@ -1,0 +1,53 @@
+package whl.trending.ai.auth
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import whl.trending.ai.data.remote.GithubApi
+import whl.trending.ai.data.remote.GithubEventDto
+
+/**
+ * 自有仓库事件会话级缓存（精选档规则3 数据源）：仓库按 pushed 排序取前 N 个，
+ * 并发拉取各仓库 events 后合并。任何异常返回 null（CancellationException 透传），null 不缓存。
+ * 登出时由 LogtoAuthManager 调用 clear() 清缓存。
+ */
+open class OwnRepoEventsProvider(
+    private val githubApi: GithubApi = GithubApi(),
+    private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
+) {
+    private var cached: List<GithubEventDto>? = null
+
+    open suspend fun get(): List<GithubEventDto>? {
+        cached?.let { return it }
+        val token = tokenProvider.get() ?: return null
+        return try {
+            val repoNames = githubApi.fetchOwnRepos(token, perPage = MAX_REPOS)
+            val events = coroutineScope {
+                repoNames.map { fullName ->
+                    async {
+                        runCatching { githubApi.fetchRepoEvents(token, fullName) }
+                            .getOrElse { e ->
+                                if (e is kotlinx.coroutines.CancellationException) throw e
+                                emptyList()
+                            }
+                    }
+                }.map { it.await() }.flatten()
+            }
+            events.also { cached = it }
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            null
+        }
+    }
+
+    fun clear() {
+        cached = null
+    }
+
+    companion object {
+        /** 仓库列表已按 pushed 排序，最近活跃的前 20 个足以覆盖规则3 的 star/fork 来源 */
+        private const val MAX_REPOS = 20
+
+        /** 全局共享实例：登出时由 LogtoAuthManager 清空 */
+        val shared = OwnRepoEventsProvider()
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/DateTimeUtils.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/DateTimeUtils.kt
@@ -27,21 +27,22 @@ object DateTimeUtils {
 
     /**
      * 将 API 返回的 UTC 时间字符串转换为本地时区对应的日期时间字符串。
-     * API 格式: "2026-02-15 00:17:20"
+     * 支持两种格式：
+     * - "2026-02-15 00:17:20"（内部 API 格式）
+     * - "2026-06-09T12:47:28Z"（ISO 8601，GitHub events）
      */
     fun formatToLocalTime(utcString: String): String {
         if (utcString.isEmpty()) return ""
         return try {
-            // 1. 解析为无时区的 LocalDateTime
-            val utcLocalDateTime = LocalDateTime.parse(utcString, dateTimeFormat)
-            
-            // 2. 转换为 UTC 时区的 Instant
-            val instant = utcLocalDateTime.toInstant(TimeZone.UTC)
-            
-            // 3. 转换为本地时区的 LocalDateTime
+            // 优先尝试 ISO 8601（含 T 分隔符）
+            val instant = if (utcString.contains('T')) {
+                kotlin.time.Instant.parse(utcString)
+            } else {
+                // 内部 API 格式：yyyy-MM-dd HH:mm:ss
+                val utcLocalDateTime = LocalDateTime.parse(utcString, dateTimeFormat)
+                utcLocalDateTime.toInstant(TimeZone.UTC)
+            }
             val localDateTime = instant.toLocalDateTime(TimeZone.currentSystemDefault())
-            
-            // 4. 格式化输出
             localDateTime.format(dateTimeFormat)
         } catch (e: Exception) {
             utcString

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -3,6 +3,7 @@ package whl.trending.ai.data.local
 import com.russhwolf.settings.ExperimentalSettingsApi
 import com.russhwolf.settings.ObservableSettings
 import com.russhwolf.settings.Settings
+import com.russhwolf.settings.coroutines.getBooleanFlow
 import com.russhwolf.settings.coroutines.getIntFlow
 import com.russhwolf.settings.coroutines.getLongFlow
 import com.russhwolf.settings.coroutines.getStringOrNullFlow
@@ -38,6 +39,7 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val SUBSCRIBED_EMAIL_KEY = "prefs_subscribed_email"
     private val INSTALL_ID_KEY = "prefs_install_id"
     private val USER_AVATAR_KEY = "prefs_user_avatar_url"
+    private val FEED_HIGHLIGHTS_ONLY_KEY = "prefs_feed_filter_highlights"
 
     /**
      * 安装级匿名标识：首次访问时生成并持久化，之后保持不变（卸载重装才会重新生成）。
@@ -141,6 +143,14 @@ class SettingsManager(private val settings: ObservableSettings) {
         } else {
             settings.putString(SUBSCRIBED_EMAIL_KEY, email)
         }
+    }
+
+    val feedHighlightsOnly: Flow<Boolean> = settings.getBooleanFlow(FEED_HIGHLIGHTS_ONLY_KEY, true)
+
+    fun getFeedHighlightsOnlySync(): Boolean = settings.getBoolean(FEED_HIGHLIGHTS_ONLY_KEY, true)
+
+    fun setFeedHighlightsOnly(value: Boolean) {
+        settings.putBoolean(FEED_HIGHLIGHTS_ONLY_KEY, value)
     }
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
@@ -1,0 +1,91 @@
+package whl.trending.ai.data.remote
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+@Serializable
+data class GithubUser(
+    val login: String,
+    val followers: Int = 0,
+    val following: Int = 0,
+    @SerialName("public_repos") val publicRepos: Int = 0,
+)
+
+@Serializable
+data class GithubEventActor(
+    val login: String,
+    @SerialName("avatar_url") val avatarUrl: String? = null,
+)
+
+@Serializable
+data class GithubEventRepo(
+    val name: String,
+)
+
+@Serializable
+data class GithubEventDto(
+    val id: String,
+    val type: String,
+    val actor: GithubEventActor,
+    val repo: GithubEventRepo,
+    /** 各事件类型 payload 结构不同，保留原始 JSON 由 mapper 弹性提取 */
+    val payload: JsonElement? = null,
+    @SerialName("created_at") val createdAt: String,
+)
+
+/** GitHub REST 直连：feed 与计数。token 来自 GithubTokenProvider（Secret Vault 取回）。 */
+open class GithubApi {
+    private val client = HttpClient {
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
+        install(HttpTimeout) {
+            requestTimeoutMillis = 15000
+            connectTimeoutMillis = 15000
+            socketTimeoutMillis = 15000
+        }
+    }
+
+    private val baseHost = "https://api.github.com"
+
+    open suspend fun fetchUser(githubToken: String): GithubUser {
+        val response = client.get("$baseHost/user") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<GithubUser>()
+    }
+
+    open suspend fun fetchReceivedEvents(
+        githubToken: String,
+        login: String,
+        page: Int,
+        perPage: Int = 30,
+    ): List<GithubEventDto> {
+        val response = client.get("$baseHost/users/$login/received_events") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+            parameter("per_page", perPage)
+            parameter("page", page)
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<List<GithubEventDto>>()
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
@@ -16,6 +16,17 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
 @Serializable
+data class GithubFollowing(
+    val login: String,
+    val type: String = "User",
+)
+
+@Serializable
+private data class GithubRepoDto(
+    @SerialName("full_name") val fullName: String,
+)
+
+@Serializable
 data class GithubUser(
     val login: String,
     val followers: Int = 0,
@@ -82,6 +93,53 @@ open class GithubApi {
             header(HttpHeaders.Accept, "application/vnd.github+json")
             parameter("per_page", perPage)
             parameter("page", page)
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<List<GithubEventDto>>()
+    }
+
+    open suspend fun fetchFollowing(
+        githubToken: String,
+        page: Int,
+        perPage: Int = 100,
+    ): List<GithubFollowing> {
+        val response = client.get("$baseHost/user/following") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+            parameter("per_page", perPage)
+            parameter("page", page)
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<List<GithubFollowing>>()
+    }
+
+    open suspend fun fetchOwnRepos(githubToken: String): List<String> {
+        val response = client.get("$baseHost/user/repos") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+            parameter("per_page", 100)
+            parameter("affiliation", "owner")
+            parameter("sort", "pushed")
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<List<GithubRepoDto>>().map { it.fullName }
+    }
+
+    open suspend fun fetchRepoEvents(
+        githubToken: String,
+        fullName: String,
+        perPage: Int = 30,
+    ): List<GithubEventDto> {
+        val response = client.get("$baseHost/repos/$fullName/events") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+            parameter("per_page", perPage)
         }
         if (response.status.value !in 200..299) {
             throw ApiException(response.status.value, response.bodyAsText())

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
@@ -117,11 +117,11 @@ open class GithubApi {
         return response.body<List<GithubFollowing>>()
     }
 
-    open suspend fun fetchOwnRepos(githubToken: String): List<String> {
+    open suspend fun fetchOwnRepos(githubToken: String, perPage: Int = 100): List<String> {
         val response = client.get("$baseHost/user/repos") {
             header(HttpHeaders.Authorization, "Bearer $githubToken")
             header(HttpHeaders.Accept, "application/vnd.github+json")
-            parameter("per_page", 100)
+            parameter("per_page", perPage)
             parameter("affiliation", "owner")
             parameter("sort", "pushed")
         }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/LogtoAccountApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/LogtoAccountApi.kt
@@ -1,0 +1,52 @@
+package whl.trending.ai.data.remote
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import whl.trending.ai.auth.LOGTO_ENDPOINT
+
+@Serializable
+data class GithubTokenResponse(
+    @SerialName("access_token") val accessToken: String,
+)
+
+/**
+ * Logto Account API：从 Secret Vault 取回用户的第三方（GitHub）access token。
+ * 凭据是用户自己的 Logto opaque access token（登录 scope 已含 identities）。
+ */
+open class LogtoAccountApi {
+    private val client = HttpClient {
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
+        install(HttpTimeout) {
+            requestTimeoutMillis = 15000
+            connectTimeoutMillis = 15000
+            socketTimeoutMillis = 15000
+        }
+    }
+
+    /**
+     * 取 GitHub access token。404=该用户未存 token（如撤销过授权），返回 null；
+     * 其余非 2xx 抛 ApiException（401 含 token 过期，调用方决定重试/登出）。
+     */
+    open suspend fun fetchGithubToken(logtoAccessToken: String): String? {
+        val response = client.get("$LOGTO_ENDPOINT/api/my-account/identities/github/access-token") {
+            header(HttpHeaders.Authorization, "Bearer $logtoAccessToken")
+        }
+        if (response.status.value == 404) return null
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<GithubTokenResponse>().accessToken
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -16,8 +16,9 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.automirrored.filled.TrendingUp
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -262,7 +263,7 @@ fun HomeScreen(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun TrendingTopBar(
     selectedPeriod: String,
@@ -344,9 +345,8 @@ private fun TrendingTopBar(
                             contentDescription = stringResource(Res.string.profile_title),
                             modifier = Modifier.size(28.dp).clip(CircleShape)
                         )
-                        authState is AuthState.LoggingIn -> CircularProgressIndicator(
-                            modifier = Modifier.size(20.dp),
-                            strokeWidth = 2.dp
+                        authState is AuthState.LoggingIn -> LoadingIndicator(
+                            modifier = Modifier.size(24.dp)
                         )
                         else -> Icon(
                             Icons.Default.AccountCircle,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -106,12 +107,13 @@ fun HomeScreen(
     val authManager = globalAuthManager
     val authState by authManager.authState.collectAsState()
     val userAvatarUrl by globalSettingsManager.userAvatarUrl.collectAsState(null)
+    val userRepository = remember { UserRepository() }
 
     // 应用启动且已登录：服务端建档/刷新 last_login_at + 同步头像（幂等，失败静默）
     LaunchedEffect(authState) {
         val state = authState
         if (state is AuthState.LoggedIn) {
-            UserRepository().syncMe(authManager.getAccessToken())
+            userRepository.syncMe(authManager.getAccessToken())
         }
     }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubFeedItem.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubFeedItem.kt
@@ -1,0 +1,119 @@
+package whl.trending.ai.ui.profile
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import whl.trending.ai.data.remote.GithubEventDto
+
+enum class GithubFeedKind {
+    STARRED, FORKED, CREATED_REPO, CREATED_BRANCH, CREATED_TAG, RELEASED,
+    PUSHED, PR_OPENED, PR_MERGED, PR_CLOSED,
+    ISSUE_OPENED, ISSUE_CLOSED, ISSUE_COMMENTED, MADE_PUBLIC, OTHER,
+}
+
+/**
+ * 归一化后的 feed 条目：kind + primary（分支名/tag/编号/提交数/类型名，按 kind 而定），
+ * 文案在 UI 层用 stringResource 按 kind 组装（i18n）。
+ */
+data class GithubFeedItem(
+    val id: String,
+    val actorLogin: String,
+    val actorAvatarUrl: String?,
+    val repoName: String,
+    val kind: GithubFeedKind,
+    val primary: String?,
+    val createdAt: String,
+    val targetUrl: String,
+)
+
+fun GithubEventDto.toFeedItem(): GithubFeedItem {
+    val p = payload as? JsonObject ?: (payload?.let { runCatching { it.jsonObject }.getOrNull() })
+    val repoUrl = "https://github.com/${repo.name}"
+
+    fun str(obj: JsonObject?, key: String): String? =
+        obj?.get(key)?.let { runCatching { it.jsonPrimitive.content }.getOrNull() }
+
+    fun obj(parent: JsonObject?, key: String): JsonObject? =
+        parent?.get(key)?.let { runCatching { it.jsonObject }.getOrNull() }
+
+    var kind = GithubFeedKind.OTHER
+    var primary: String? = type.removeSuffix("Event")
+    var targetUrl = repoUrl
+
+    when (type) {
+        "WatchEvent" -> { kind = GithubFeedKind.STARRED; primary = null }
+        "ForkEvent" -> { kind = GithubFeedKind.FORKED; primary = null }
+        "PublicEvent" -> { kind = GithubFeedKind.MADE_PUBLIC; primary = null }
+        "CreateEvent" -> when (str(p, "ref_type")) {
+            "repository" -> { kind = GithubFeedKind.CREATED_REPO; primary = null }
+            "branch" -> { kind = GithubFeedKind.CREATED_BRANCH; primary = str(p, "ref") }
+            "tag" -> { kind = GithubFeedKind.CREATED_TAG; primary = str(p, "ref") }
+        }
+        "ReleaseEvent" -> {
+            val release = obj(p, "release")
+            kind = GithubFeedKind.RELEASED
+            primary = str(release, "tag_name")
+            str(release, "html_url")?.let { targetUrl = it }
+        }
+        "PushEvent" -> {
+            kind = GithubFeedKind.PUSHED
+            primary = (p?.get("size")?.jsonPrimitive?.intOrNull ?: 1).toString()
+        }
+        "PullRequestEvent" -> {
+            val pr = obj(p, "pull_request")
+            val number = p?.get("number")?.jsonPrimitive?.intOrNull
+            if (pr != null && number != null) {
+                kind = when {
+                    str(p, "action") == "opened" -> GithubFeedKind.PR_OPENED
+                    str(p, "action") == "closed" &&
+                        pr["merged"]?.jsonPrimitive?.booleanOrNull == true -> GithubFeedKind.PR_MERGED
+                    str(p, "action") == "closed" -> GithubFeedKind.PR_CLOSED
+                    else -> GithubFeedKind.OTHER
+                }
+                if (kind != GithubFeedKind.OTHER) {
+                    primary = number.toString()
+                    str(pr, "html_url")?.let { targetUrl = it }
+                }
+            }
+        }
+        "IssuesEvent" -> {
+            val issue = obj(p, "issue")
+            val number = issue?.get("number")?.jsonPrimitive?.intOrNull
+            if (issue != null && number != null) {
+                kind = when (str(p, "action")) {
+                    "opened" -> GithubFeedKind.ISSUE_OPENED
+                    "closed" -> GithubFeedKind.ISSUE_CLOSED
+                    else -> GithubFeedKind.OTHER
+                }
+                if (kind != GithubFeedKind.OTHER) {
+                    primary = number.toString()
+                    str(issue, "html_url")?.let { targetUrl = it }
+                }
+            }
+        }
+        "IssueCommentEvent" -> {
+            val issue = obj(p, "issue")
+            val number = issue?.get("number")?.jsonPrimitive?.intOrNull
+            if (number != null) {
+                kind = GithubFeedKind.ISSUE_COMMENTED
+                primary = number.toString()
+                targetUrl = str(obj(p, "comment"), "html_url")
+                    ?: str(issue, "html_url")
+                    ?: repoUrl
+            }
+        }
+    }
+
+    return GithubFeedItem(
+        id = id,
+        actorLogin = actor.login,
+        actorAvatarUrl = actor.avatarUrl,
+        repoName = repo.name,
+        kind = kind,
+        primary = primary,
+        createdAt = createdAt,
+        targetUrl = targetUrl,
+    )
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubFeedItem.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubFeedItem.kt
@@ -67,6 +67,7 @@ fun GithubEventDto.toFeedItem(): GithubFeedItem {
             if (pr != null && number != null) {
                 kind = when {
                     str(p, "action") == "opened" -> GithubFeedKind.PR_OPENED
+                    str(p, "action") == "merged" -> GithubFeedKind.PR_MERGED
                     str(p, "action") == "closed" &&
                         pr["merged"]?.jsonPrimitive?.booleanOrNull == true -> GithubFeedKind.PR_MERGED
                     str(p, "action") == "closed" -> GithubFeedKind.PR_CLOSED
@@ -117,3 +118,16 @@ fun GithubEventDto.toFeedItem(): GithubFeedItem {
         targetUrl = targetUrl,
     )
 }
+
+/** 精选档保留的高信号事件（与 GitHub 网页 Dashboard 风格对齐；issue/push/review 等不进） */
+val HighlightFeedKinds: Set<GithubFeedKind> = setOf(
+    GithubFeedKind.STARRED,
+    GithubFeedKind.FORKED,
+    GithubFeedKind.RELEASED,
+    GithubFeedKind.CREATED_REPO,
+    GithubFeedKind.MADE_PUBLIC,
+    GithubFeedKind.PR_OPENED,
+    GithubFeedKind.PR_MERGED,
+)
+
+fun GithubFeedItem.isBot(): Boolean = actorLogin.endsWith("[bot]")

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubFeedItem.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubFeedItem.kt
@@ -5,12 +5,15 @@ import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import whl.trending.ai.auth.FollowingInfo
 import whl.trending.ai.data.remote.GithubEventDto
 
 enum class GithubFeedKind {
     STARRED, FORKED, CREATED_REPO, CREATED_BRANCH, CREATED_TAG, RELEASED,
     PUSHED, PR_OPENED, PR_MERGED, PR_CLOSED,
-    ISSUE_OPENED, ISSUE_CLOSED, ISSUE_COMMENTED, MADE_PUBLIC, OTHER,
+    ISSUE_OPENED, ISSUE_CLOSED, ISSUE_COMMENTED, MADE_PUBLIC,
+    STARRED_YOUR_REPO, FORKED_YOUR_REPO,
+    OTHER,
 }
 
 /**
@@ -130,4 +133,27 @@ val HighlightFeedKinds: Set<GithubFeedKind> = setOf(
     GithubFeedKind.PR_MERGED,
 )
 
+/** 组织产出型事件：关注的组织仓库上只保留这些（路人 star/fork 不算产出） */
+val OrgOutputFeedKinds: Set<GithubFeedKind> = setOf(
+    GithubFeedKind.RELEASED,
+    GithubFeedKind.CREATED_REPO,
+    GithubFeedKind.MADE_PUBLIC,
+)
+
 fun GithubFeedItem.isBot(): Boolean = actorLogin.endsWith("[bot]")
+
+/**
+ * 精选档判定：
+ * 规则1 关注的人的高信号动作（滤 bot）；规则2 关注的组织的产出（不滤 bot）。
+ * following 为 null（拉取失败降级）时退回"仅按类型 + 非 bot"的旧行为。
+ */
+fun GithubFeedItem.isHighlight(following: FollowingInfo?): Boolean {
+    if (following == null) return kind in HighlightFeedKinds && !isBot()
+    val actorLower = actorLogin.lowercase()
+    val repoOwnerLower = repoName.substringBefore('/').lowercase()
+    val byFollowedUser = actorLower in following.users &&
+        kind in HighlightFeedKinds && !isBot()
+    val byFollowedOrgOutput = repoOwnerLower in following.orgs &&
+        kind in OrgOutputFeedKinds
+    return byFollowedUser || byFollowedOrgOutput
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -75,6 +75,12 @@ fun ProfileScreen(onBack: () -> Unit) {
                     Button(onClick = { viewModel.load() }) {
                         Text(stringResource(Res.string.profile_retry))
                     }
+                    OutlinedButton(onClick = {
+                        viewModel.signOut()
+                        onBack()
+                    }) {
+                        Text(stringResource(Res.string.sign_out))
+                    }
                 }
 
                 else -> uiState.user?.let { user ->

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -1,19 +1,26 @@
 package whl.trending.ai.ui.profile
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -22,8 +29,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -34,11 +44,33 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.feed_created_branch
+import trendingai.shared.generated.resources.feed_created_repo
+import trendingai.shared.generated.resources.feed_created_tag
+import trendingai.shared.generated.resources.feed_empty
+import trendingai.shared.generated.resources.feed_end_notice
+import trendingai.shared.generated.resources.feed_forked
+import trendingai.shared.generated.resources.feed_issue_closed
+import trendingai.shared.generated.resources.feed_issue_commented
+import trendingai.shared.generated.resources.feed_issue_opened
+import trendingai.shared.generated.resources.feed_made_public
+import trendingai.shared.generated.resources.feed_other
+import trendingai.shared.generated.resources.feed_pr_closed
+import trendingai.shared.generated.resources.feed_pr_merged
+import trendingai.shared.generated.resources.feed_pr_opened
+import trendingai.shared.generated.resources.feed_pushed
+import trendingai.shared.generated.resources.feed_released
+import trendingai.shared.generated.resources.feed_starred
+import trendingai.shared.generated.resources.feed_unavailable
+import trendingai.shared.generated.resources.profile_followers
+import trendingai.shared.generated.resources.profile_following
 import trendingai.shared.generated.resources.profile_load_failed
 import trendingai.shared.generated.resources.profile_open_github
+import trendingai.shared.generated.resources.profile_repos
 import trendingai.shared.generated.resources.profile_retry
 import trendingai.shared.generated.resources.profile_title
 import trendingai.shared.generated.resources.sign_out
+import whl.trending.ai.core.DateTimeUtils
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -46,6 +78,18 @@ fun ProfileScreen(onBack: () -> Unit) {
     val viewModel: ProfileViewModel = viewModel { ProfileViewModel() }
     val uiState by viewModel.uiState.collectAsState()
     val uriHandler = LocalUriHandler.current
+    val listState = rememberLazyListState()
+
+    // 滚动到底部附近时自动加载下一页
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            last >= listState.layoutInfo.totalItemsCount - 3
+        }
+    }
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore) viewModel.loadMoreFeed()
+    }
 
     Scaffold(
         topBar = {
@@ -59,74 +103,179 @@ fun ProfileScreen(onBack: () -> Unit) {
             )
         }
     ) { padding ->
-        Column(
-            modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            when {
-                uiState.isLoading -> CircularProgressIndicator(Modifier.padding(top = 48.dp))
+        when {
+            uiState.isLoading -> Box(
+                Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center
+            ) { CircularProgressIndicator() }
 
-                uiState.isError -> {
-                    Text(
-                        text = stringResource(Res.string.profile_load_failed),
-                        modifier = Modifier.padding(top = 48.dp)
+            uiState.isError -> Column(
+                modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(stringResource(Res.string.profile_load_failed), Modifier.padding(top = 48.dp))
+                Button(onClick = { viewModel.load() }) { Text(stringResource(Res.string.profile_retry)) }
+                OutlinedButton(onClick = { viewModel.signOut(); onBack() }) {
+                    Text(stringResource(Res.string.sign_out))
+                }
+            }
+
+            else -> LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize().padding(padding),
+            ) {
+                item(key = "header") {
+                    ProfileHeader(
+                        uiState = uiState,
+                        onOpenGithub = { url -> uriHandler.openUri(url) },
+                        onSignOut = { viewModel.signOut(); onBack() },
                     )
-                    Button(onClick = { viewModel.load() }) {
-                        Text(stringResource(Res.string.profile_retry))
+                }
+                if (uiState.feedUnavailable && uiState.feedItems.isEmpty()) {
+                    item(key = "feed_unavailable") {
+                        FeedNotice(stringResource(Res.string.feed_unavailable))
                     }
-                    OutlinedButton(onClick = {
-                        viewModel.signOut()
-                        onBack()
-                    }) {
-                        Text(stringResource(Res.string.sign_out))
+                } else if (uiState.feedItems.isEmpty() && uiState.feedEndReached) {
+                    item(key = "feed_empty") {
+                        FeedNotice(stringResource(Res.string.feed_empty))
                     }
                 }
-
-                else -> uiState.user?.let { user ->
-                    AsyncImage(
-                        model = user.avatarUrl,
-                        contentDescription = null,
-                        modifier = Modifier.size(96.dp).clip(CircleShape)
-                    )
-                    Text(
-                        text = user.displayName ?: user.githubLogin.orEmpty(),
-                        style = MaterialTheme.typography.titleLarge
-                    )
-                    user.githubLogin?.let {
-                        Text(
-                            text = "@$it",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    user.bio?.takeIf { it.isNotBlank() }?.let {
-                        Text(
-                            text = it,
-                            style = MaterialTheme.typography.bodyMedium,
-                            textAlign = TextAlign.Center
-                        )
-                    }
-                    Spacer(Modifier.height(12.dp))
-                    user.htmlUrl?.let { url ->
-                        Button(
-                            onClick = { uriHandler.openUri(url) },
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Text(stringResource(Res.string.profile_open_github))
+                items(uiState.feedItems, key = { it.id }) { item ->
+                    GithubFeedRow(item = item, onClick = { uriHandler.openUri(item.targetUrl) })
+                    HorizontalDivider(thickness = 0.5.dp)
+                }
+                if (uiState.isFeedLoading) {
+                    item(key = "feed_loading") {
+                        Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator(Modifier.size(24.dp), strokeWidth = 2.dp)
                         }
                     }
-                    OutlinedButton(
-                        onClick = {
-                            viewModel.signOut()
-                            onBack()
-                        },
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(stringResource(Res.string.sign_out))
+                }
+                if (uiState.feedEndReached && uiState.feedItems.isNotEmpty()) {
+                    item(key = "feed_end") {
+                        FeedNotice(stringResource(Res.string.feed_end_notice))
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun ProfileHeader(
+    uiState: ProfileUiState,
+    onOpenGithub: (String) -> Unit,
+    onSignOut: () -> Unit,
+) {
+    val user = uiState.user ?: return
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        AsyncImage(
+            model = user.avatarUrl,
+            contentDescription = null,
+            modifier = Modifier.size(96.dp).clip(CircleShape)
+        )
+        Text(user.displayName ?: user.githubLogin.orEmpty(), style = MaterialTheme.typography.titleLarge)
+        user.githubLogin?.let {
+            Text(
+                "@$it",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        user.bio?.takeIf { it.isNotBlank() }?.let {
+            Text(it, style = MaterialTheme.typography.bodyMedium, textAlign = TextAlign.Center)
+        }
+        uiState.githubUser?.let { gh ->
+            Row(horizontalArrangement = Arrangement.spacedBy(24.dp)) {
+                CountCell(gh.followers, stringResource(Res.string.profile_followers))
+                CountCell(gh.following, stringResource(Res.string.profile_following))
+                CountCell(gh.publicRepos, stringResource(Res.string.profile_repos))
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        user.htmlUrl?.let { url ->
+            Button(onClick = { onOpenGithub(url) }, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(Res.string.profile_open_github))
+            }
+        }
+        OutlinedButton(onClick = onSignOut, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(Res.string.sign_out))
+        }
+    }
+}
+
+@Composable
+private fun CountCell(count: Int, label: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(count.toString(), style = MaterialTheme.typography.titleMedium)
+        Text(
+            label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun FeedNotice(text: String) {
+    Box(Modifier.fillMaxWidth().padding(24.dp), contentAlignment = Alignment.Center) {
+        Text(
+            text,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun GithubFeedRow(item: GithubFeedItem, onClick: () -> Unit) {
+    val summary = when (item.kind) {
+        GithubFeedKind.STARRED -> stringResource(Res.string.feed_starred, item.repoName)
+        GithubFeedKind.FORKED -> stringResource(Res.string.feed_forked, item.repoName)
+        GithubFeedKind.CREATED_REPO -> stringResource(Res.string.feed_created_repo, item.repoName)
+        GithubFeedKind.CREATED_BRANCH -> stringResource(Res.string.feed_created_branch, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.CREATED_TAG -> stringResource(Res.string.feed_created_tag, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.RELEASED -> stringResource(Res.string.feed_released, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.PUSHED -> stringResource(Res.string.feed_pushed, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.PR_OPENED -> stringResource(Res.string.feed_pr_opened, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.PR_MERGED -> stringResource(Res.string.feed_pr_merged, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.PR_CLOSED -> stringResource(Res.string.feed_pr_closed, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.ISSUE_OPENED -> stringResource(Res.string.feed_issue_opened, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.ISSUE_CLOSED -> stringResource(Res.string.feed_issue_closed, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.ISSUE_COMMENTED -> stringResource(Res.string.feed_issue_commented, item.primary.orEmpty(), item.repoName)
+        GithubFeedKind.MADE_PUBLIC -> stringResource(Res.string.feed_made_public, item.repoName)
+        GithubFeedKind.OTHER -> stringResource(Res.string.feed_other, item.primary.orEmpty(), item.repoName)
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        AsyncImage(
+            model = item.actorAvatarUrl,
+            contentDescription = null,
+            modifier = Modifier.size(36.dp).clip(CircleShape),
+        )
+        Column(Modifier.weight(1f)) {
+            Text(
+                item.actorLogin,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(summary, style = MaterialTheme.typography.bodyMedium)
+            Text(
+                DateTimeUtils.formatToLocalTime(item.createdAt),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -18,9 +18,10 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -72,7 +73,7 @@ import trendingai.shared.generated.resources.profile_title
 import trendingai.shared.generated.resources.sign_out
 import whl.trending.ai.core.DateTimeUtils
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ProfileScreen(onBack: () -> Unit) {
     val viewModel: ProfileViewModel = viewModel { ProfileViewModel() }
@@ -112,7 +113,7 @@ fun ProfileScreen(onBack: () -> Unit) {
             uiState.isLoading -> Box(
                 Modifier.fillMaxSize().padding(padding),
                 contentAlignment = Alignment.Center
-            ) { CircularProgressIndicator() }
+            ) { LoadingIndicator(modifier = Modifier.size(48.dp)) }
 
             uiState.isError -> Column(
                 modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
@@ -153,7 +154,7 @@ fun ProfileScreen(onBack: () -> Unit) {
                 if (uiState.isFeedLoading) {
                     item(key = "feed_loading") {
                         Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
-                            CircularProgressIndicator(Modifier.size(24.dp), strokeWidth = 2.dp)
+                            LoadingIndicator(modifier = Modifier.size(32.dp))
                         }
                     }
                 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.Icon
@@ -50,6 +51,8 @@ import trendingai.shared.generated.resources.feed_created_repo
 import trendingai.shared.generated.resources.feed_created_tag
 import trendingai.shared.generated.resources.feed_empty
 import trendingai.shared.generated.resources.feed_end_notice
+import trendingai.shared.generated.resources.feed_filter_all
+import trendingai.shared.generated.resources.feed_filter_highlights
 import trendingai.shared.generated.resources.feed_forked
 import trendingai.shared.generated.resources.feed_issue_closed
 import trendingai.shared.generated.resources.feed_issue_commented
@@ -137,6 +140,23 @@ fun ProfileScreen(onBack: () -> Unit) {
                         onOpenGithub = { url -> uriHandler.openUri(url) },
                         onSignOut = { viewModel.signOut(); onBack() },
                     )
+                }
+                item(key = "feed_filter") {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        FilterChip(
+                            selected = uiState.highlightsOnly,
+                            onClick = { if (!uiState.highlightsOnly) viewModel.setFeedFilter(true) },
+                            label = { Text(stringResource(Res.string.feed_filter_highlights)) }
+                        )
+                        FilterChip(
+                            selected = !uiState.highlightsOnly,
+                            onClick = { if (uiState.highlightsOnly) viewModel.setFeedFilter(false) },
+                            label = { Text(stringResource(Res.string.feed_filter_all)) }
+                        )
+                    }
                 }
                 if (uiState.feedUnavailable && uiState.feedItems.isEmpty()) {
                     item(key = "feed_unavailable") {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -57,8 +57,10 @@ import trendingai.shared.generated.resources.feed_forked
 import trendingai.shared.generated.resources.feed_issue_closed
 import trendingai.shared.generated.resources.feed_issue_commented
 import trendingai.shared.generated.resources.feed_issue_opened
+import trendingai.shared.generated.resources.feed_forked_your_repo
 import trendingai.shared.generated.resources.feed_made_public
 import trendingai.shared.generated.resources.feed_other
+import trendingai.shared.generated.resources.feed_starred_your_repo
 import trendingai.shared.generated.resources.feed_pr_closed
 import trendingai.shared.generated.resources.feed_pr_merged
 import trendingai.shared.generated.resources.feed_pr_opened
@@ -275,6 +277,8 @@ private fun GithubFeedRow(item: GithubFeedItem, onClick: () -> Unit) {
         GithubFeedKind.ISSUE_CLOSED -> stringResource(Res.string.feed_issue_closed, item.primary.orEmpty(), item.repoName)
         GithubFeedKind.ISSUE_COMMENTED -> stringResource(Res.string.feed_issue_commented, item.primary.orEmpty(), item.repoName)
         GithubFeedKind.MADE_PUBLIC -> stringResource(Res.string.feed_made_public, item.repoName)
+        GithubFeedKind.STARRED_YOUR_REPO -> stringResource(Res.string.feed_starred_your_repo, item.repoName)
+        GithubFeedKind.FORKED_YOUR_REPO -> stringResource(Res.string.feed_forked_your_repo, item.repoName)
         GithubFeedKind.OTHER -> stringResource(Res.string.feed_other, item.primary.orEmpty(), item.repoName)
     }
     Row(

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -77,6 +77,11 @@ import whl.trending.ai.core.DateTimeUtils
 fun ProfileScreen(onBack: () -> Unit) {
     val viewModel: ProfileViewModel = viewModel { ProfileViewModel() }
     val uiState by viewModel.uiState.collectAsState()
+    // nav3 默认无 per-entry VM 作用域，VM 是 Activity 级缓存；每次进入本页全量重载，
+    // 避免登出换账号串号 / feed 失败态永久残留
+    LaunchedEffect(Unit) {
+        viewModel.load()
+    }
     val uriHandler = LocalUriHandler.current
     val listState = rememberLazyListState()
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -34,22 +34,18 @@ class ProfileViewModel(
     private val repository: UserRepository = UserRepository(),
     private val githubApi: GithubApi = GithubApi(),
     private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
-    private val authManager: AuthManager = globalAuthManager,
+    private val authManager: () -> AuthManager = { globalAuthManager },
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(ProfileUiState())
     val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
 
     private var nextFeedPage = 1
 
-    init {
-        load()
-    }
-
     fun load() {
         viewModelScope.launch {
             _uiState.value = ProfileUiState(isLoading = true)
             nextFeedPage = 1
-            val token = authManager.getAccessToken()
+            val token = authManager().getAccessToken()
             if (token == null) {
                 _uiState.value = ProfileUiState(isLoading = false, isError = true)
                 return@launch
@@ -115,5 +111,5 @@ class ProfileViewModel(
         }
     }
 
-    fun signOut() = authManager.signOut()
+    fun signOut() = authManager().signOut()
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -3,8 +3,6 @@ package whl.trending.ai.ui.profile
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -13,6 +11,7 @@ import whl.trending.ai.auth.AuthManager
 import whl.trending.ai.auth.FollowingInfo
 import whl.trending.ai.auth.FollowingProvider
 import whl.trending.ai.auth.GithubTokenProvider
+import whl.trending.ai.auth.OwnRepoEventsProvider
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.local.globalSettingsManager
@@ -46,6 +45,7 @@ class ProfileViewModel(
     private val githubApi: GithubApi = GithubApi(),
     private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
     private val followingProvider: FollowingProvider = FollowingProvider.shared,
+    private val ownRepoEventsProvider: OwnRepoEventsProvider = OwnRepoEventsProvider.shared,
     private val authManager: () -> AuthManager = { globalAuthManager },
     private val settingsManager: SettingsManager = globalSettingsManager,
 ) : ViewModel() {
@@ -57,6 +57,8 @@ class ProfileViewModel(
     private var consumedRawCount = 0
     /** 进行中的 feed 拉取协程；切档/重载前先取消，避免旧档结果写回新档 state */
     private var feedLoadJob: Job? = null
+    /** 进行中的整页加载协程；重复进入页面时先取消，避免两个 load 并发交叉写 state 与分页游标 */
+    private var loadJob: Job? = null
 
     /** 缓存当次会话的关注列表（load() 时重置） */
     private var followingInfo: FollowingInfo? = null
@@ -64,8 +66,9 @@ class ProfileViewModel(
     private var ownRepoItems: List<GithubFeedItem> = emptyList()
 
     fun load() {
+        loadJob?.cancel()
         feedLoadJob?.cancel()
-        viewModelScope.launch {
+        loadJob = viewModelScope.launch {
             val highlightsOnly = settingsManager.getFeedHighlightsOnlySync()
             _uiState.value = ProfileUiState(isLoading = true, highlightsOnly = highlightsOnly)
             nextFeedPage = 1
@@ -107,37 +110,23 @@ class ProfileViewModel(
         // 拉取关注列表（失败降级为 null，保留旧行为）
         followingInfo = followingProvider.get()
 
-        // 规则3：并发拉取自有仓库上别人的 star/fork
+        // 规则3：自有仓库上别人的 star/fork（会话级缓存，限最近活跃的前 N 个仓库）
         val loginLower = login.lowercase()
-        runCatching {
-            val repoNames = githubApi.fetchOwnRepos(githubToken)
-            val allEvents = coroutineScope {
-                repoNames.map { fullName ->
-                    async {
-                        runCatching { githubApi.fetchRepoEvents(githubToken, fullName) }
-                            .getOrElse { emptyList() }
-                    }
-                }.map { it.await() }.flatten()
+        ownRepoItems = ownRepoEventsProvider.get().orEmpty()
+            .map { it.toFeedItem() }
+            .filter { item ->
+                (item.kind == GithubFeedKind.STARRED || item.kind == GithubFeedKind.FORKED) &&
+                    item.actorLogin.lowercase() != loginLower
             }
-            ownRepoItems = allEvents
-                .map { it.toFeedItem() }
-                .filter { item ->
-                    (item.kind == GithubFeedKind.STARRED || item.kind == GithubFeedKind.FORKED) &&
-                        item.actorLogin.lowercase() != loginLower
-                }
-                .map { item ->
-                    item.copy(
-                        kind = if (item.kind == GithubFeedKind.STARRED)
-                            GithubFeedKind.STARRED_YOUR_REPO
-                        else
-                            GithubFeedKind.FORKED_YOUR_REPO
-                    )
-                }
-                .distinctBy { it.id }
-        }.onFailure { e ->
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            ownRepoItems = emptyList()
-        }
+            .map { item ->
+                item.copy(
+                    kind = if (item.kind == GithubFeedKind.STARRED)
+                        GithubFeedKind.STARRED_YOUR_REPO
+                    else
+                        GithubFeedKind.FORKED_YOUR_REPO
+                )
+            }
+            .distinctBy { it.id }
 
         loadMoreFeed()
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -3,11 +3,15 @@ package whl.trending.ai.ui.profile
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import whl.trending.ai.auth.AuthManager
+import whl.trending.ai.auth.FollowingInfo
+import whl.trending.ai.auth.FollowingProvider
 import whl.trending.ai.auth.GithubTokenProvider
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.data.local.SettingsManager
@@ -41,6 +45,7 @@ class ProfileViewModel(
     private val repository: UserRepository = UserRepository(),
     private val githubApi: GithubApi = GithubApi(),
     private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
+    private val followingProvider: FollowingProvider = FollowingProvider.shared,
     private val authManager: () -> AuthManager = { globalAuthManager },
     private val settingsManager: SettingsManager = globalSettingsManager,
 ) : ViewModel() {
@@ -53,6 +58,11 @@ class ProfileViewModel(
     /** 进行中的 feed 拉取协程；切档/重载前先取消，避免旧档结果写回新档 state */
     private var feedLoadJob: Job? = null
 
+    /** 缓存当次会话的关注列表（load() 时重置） */
+    private var followingInfo: FollowingInfo? = null
+    /** 规则3：我的仓库上别人的 star/fork（精选档合流，load() 时重置） */
+    private var ownRepoItems: List<GithubFeedItem> = emptyList()
+
     fun load() {
         feedLoadJob?.cancel()
         viewModelScope.launch {
@@ -60,6 +70,8 @@ class ProfileViewModel(
             _uiState.value = ProfileUiState(isLoading = true, highlightsOnly = highlightsOnly)
             nextFeedPage = 1
             consumedRawCount = 0
+            followingInfo = null
+            ownRepoItems = emptyList()
             val token = authManager().getAccessToken()
             if (token == null) {
                 _uiState.value = ProfileUiState(isLoading = false, isError = true, highlightsOnly = highlightsOnly)
@@ -91,6 +103,42 @@ class ProfileViewModel(
             if (e is kotlinx.coroutines.CancellationException) throw e
             // 计数失败不致命，feed 继续尝试
         }
+
+        // 拉取关注列表（失败降级为 null，保留旧行为）
+        followingInfo = followingProvider.get()
+
+        // 规则3：并发拉取自有仓库上别人的 star/fork
+        val loginLower = login.lowercase()
+        runCatching {
+            val repoNames = githubApi.fetchOwnRepos(githubToken)
+            val allEvents = coroutineScope {
+                repoNames.map { fullName ->
+                    async {
+                        runCatching { githubApi.fetchRepoEvents(githubToken, fullName) }
+                            .getOrElse { emptyList() }
+                    }
+                }.map { it.await() }.flatten()
+            }
+            ownRepoItems = allEvents
+                .map { it.toFeedItem() }
+                .filter { item ->
+                    (item.kind == GithubFeedKind.STARRED || item.kind == GithubFeedKind.FORKED) &&
+                        item.actorLogin.lowercase() != loginLower
+                }
+                .map { item ->
+                    item.copy(
+                        kind = if (item.kind == GithubFeedKind.STARRED)
+                            GithubFeedKind.STARRED_YOUR_REPO
+                        else
+                            GithubFeedKind.FORKED_YOUR_REPO
+                    )
+                }
+                .distinctBy { it.id }
+        }.onFailure { e ->
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            ownRepoItems = emptyList()
+        }
+
         loadMoreFeed()
     }
 
@@ -121,7 +169,7 @@ class ProfileViewModel(
                     consumedRawCount += events.size
 
                     val filtered = events.map { it.toFeedItem() }.let { items ->
-                        if (highlightsOnly) items.filter { it.kind in HighlightFeedKinds && !it.isBot() }
+                        if (highlightsOnly) items.filter { it.isHighlight(followingInfo) }
                         else items
                     }
 
@@ -132,8 +180,17 @@ class ProfileViewModel(
                     endReached = events.size < FEED_PAGE_SIZE || consumedRawCount >= FEED_MAX_EVENTS
                     nextFeedPage++
 
+                    // 精选档合流 ownRepoItems（按时间倒序，去重）
+                    val display = if (highlightsOnly) {
+                        (currentItems + ownRepoItems)
+                            .sortedByDescending { it.createdAt }
+                            .distinctBy { it.id }
+                    } else {
+                        currentItems
+                    }
+
                     _uiState.value = _uiState.value.copy(
-                        feedItems = currentItems,
+                        feedItems = display,
                         feedEndReached = endReached,
                     )
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -2,6 +2,7 @@ package whl.trending.ai.ui.profile
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -49,8 +50,11 @@ class ProfileViewModel(
     private var nextFeedPage = 1
     /** 已消费的原始 events 总数（用于判断是否到达 GitHub 300 条硬上限） */
     private var consumedRawCount = 0
+    /** 进行中的 feed 拉取协程；切档/重载前先取消，避免旧档结果写回新档 state */
+    private var feedLoadJob: Job? = null
 
     fun load() {
+        feedLoadJob?.cancel()
         viewModelScope.launch {
             val highlightsOnly = settingsManager.getFeedHighlightsOnlySync()
             _uiState.value = ProfileUiState(isLoading = true, highlightsOnly = highlightsOnly)
@@ -94,7 +98,7 @@ class ProfileViewModel(
         val state = _uiState.value
         if (state.isFeedLoading || state.feedEndReached || state.feedUnavailable) return
         val login = state.user?.githubLogin ?: return
-        viewModelScope.launch {
+        feedLoadJob = viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isFeedLoading = true)
             val githubToken = tokenProvider.get()
             if (githubToken == null) {
@@ -106,6 +110,9 @@ class ProfileViewModel(
                 var pagesThisLoad = 0
                 var newItemsThisLoad = 0
                 var endReached = false
+                // 局部累积：进入循环时读一次 state，之后只在局部 merge，
+                // 每轮写回一次（渐进展示）；配合 Job 取消杜绝跨档交叉读写
+                var currentItems = _uiState.value.feedItems
 
                 // 循环拉页：精选档过滤后新增不足 10 条且未到底时继续拉
                 while (!endReached && pagesThisLoad < MAX_PAGES_PER_LOAD) {
@@ -118,15 +125,15 @@ class ProfileViewModel(
                         else items
                     }
 
-                    val existing = _uiState.value.feedItems
-                    val merged = (existing + filtered).distinctBy { it.id }
-                    newItemsThisLoad += merged.size - existing.size
+                    val merged = (currentItems + filtered).distinctBy { it.id }
+                    newItemsThisLoad += merged.size - currentItems.size
+                    currentItems = merged
 
                     endReached = events.size < FEED_PAGE_SIZE || consumedRawCount >= FEED_MAX_EVENTS
                     nextFeedPage++
 
                     _uiState.value = _uiState.value.copy(
-                        feedItems = merged,
+                        feedItems = currentItems,
                         feedEndReached = endReached,
                     )
 
@@ -136,6 +143,7 @@ class ProfileViewModel(
 
                 _uiState.value = _uiState.value.copy(isFeedLoading = false)
             } catch (e: Exception) {
+                // 取消时直接透传，不写 state——isFeedLoading 由取消方的状态重置兜底归 false
                 if (e is kotlinx.coroutines.CancellationException) throw e
                 _uiState.value = _uiState.value.copy(
                     isFeedLoading = false,
@@ -145,8 +153,9 @@ class ProfileViewModel(
         }
     }
 
-    /** 切换精选/全部档：持久化设置，重置 feed 状态并重新拉取第一页 */
+    /** 切换精选/全部档：取消进行中的拉取，持久化设置，重置 feed 状态并重新拉取第一页 */
     fun setFeedFilter(highlightsOnly: Boolean) {
+        feedLoadJob?.cancel()
         settingsManager.setFeedHighlightsOnly(highlightsOnly)
         nextFeedPage = 1
         consumedRawCount = 0

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -7,22 +7,39 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import whl.trending.ai.auth.AuthManager
+import whl.trending.ai.auth.GithubTokenProvider
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.data.model.MeUser
+import whl.trending.ai.data.remote.GithubApi
+import whl.trending.ai.data.remote.GithubUser
 import whl.trending.ai.data.repository.UserRepository
+
+private const val FEED_PAGE_SIZE = 30
+private const val FEED_MAX_EVENTS = 300 // GitHub received_events 硬上限
 
 data class ProfileUiState(
     val isLoading: Boolean = true,
     val user: MeUser? = null,
     val isError: Boolean = false,
+    /** GitHub 实时计数；token 不可用或请求失败时为 null（UI 隐藏计数行） */
+    val githubUser: GithubUser? = null,
+    val feedItems: List<GithubFeedItem> = emptyList(),
+    val isFeedLoading: Boolean = false,
+    val feedEndReached: Boolean = false,
+    /** feed 不可用（无 GitHub token / 请求失败），与整页 isError 区分 */
+    val feedUnavailable: Boolean = false,
 )
 
 class ProfileViewModel(
     private val repository: UserRepository = UserRepository(),
+    private val githubApi: GithubApi = GithubApi(),
+    private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
     private val authManager: AuthManager = globalAuthManager,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(ProfileUiState())
     val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
+
+    private var nextFeedPage = 1
 
     init {
         load()
@@ -31,17 +48,69 @@ class ProfileViewModel(
     fun load() {
         viewModelScope.launch {
             _uiState.value = ProfileUiState(isLoading = true)
+            nextFeedPage = 1
             val token = authManager.getAccessToken()
             if (token == null) {
                 _uiState.value = ProfileUiState(isLoading = false, isError = true)
                 return@launch
             }
-            try {
-                val user = repository.fetchMe(token)
-                _uiState.value = ProfileUiState(isLoading = false, user = user)
+            val user = try {
+                repository.fetchMe(token)
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
                 _uiState.value = ProfileUiState(isLoading = false, isError = true)
+                return@launch
+            }
+            _uiState.value = ProfileUiState(isLoading = false, user = user)
+            loadGithubData(user)
+        }
+    }
+
+    private suspend fun loadGithubData(user: MeUser) {
+        val githubToken = tokenProvider.get()
+        val login = user.githubLogin
+        if (githubToken == null || login == null) {
+            _uiState.value = _uiState.value.copy(feedUnavailable = true)
+            return
+        }
+        try {
+            val githubUser = githubApi.fetchUser(githubToken)
+            _uiState.value = _uiState.value.copy(githubUser = githubUser)
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            // 计数失败不致命，feed 继续尝试
+        }
+        loadMoreFeed()
+    }
+
+    fun loadMoreFeed() {
+        val state = _uiState.value
+        if (state.isFeedLoading || state.feedEndReached || state.feedUnavailable) return
+        val login = state.user?.githubLogin ?: return
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isFeedLoading = true)
+            val githubToken = tokenProvider.get()
+            if (githubToken == null) {
+                _uiState.value = _uiState.value.copy(isFeedLoading = false, feedUnavailable = true)
+                return@launch
+            }
+            try {
+                val events = githubApi.fetchReceivedEvents(githubToken, login, nextFeedPage, FEED_PAGE_SIZE)
+                val newItems = events.map { it.toFeedItem() }
+                val merged = (_uiState.value.feedItems + newItems).distinctBy { it.id }
+                val endReached = events.size < FEED_PAGE_SIZE || merged.size >= FEED_MAX_EVENTS
+                nextFeedPage++
+                _uiState.value = _uiState.value.copy(
+                    feedItems = merged,
+                    isFeedLoading = false,
+                    feedEndReached = endReached,
+                )
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                _uiState.value = _uiState.value.copy(
+                    isFeedLoading = false,
+                    feedUnavailable = _uiState.value.feedItems.isEmpty(),
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.launch
 import whl.trending.ai.auth.AuthManager
 import whl.trending.ai.auth.GithubTokenProvider
 import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.MeUser
 import whl.trending.ai.data.remote.GithubApi
 import whl.trending.ai.data.remote.GithubUser
@@ -16,6 +18,8 @@ import whl.trending.ai.data.repository.UserRepository
 
 private const val FEED_PAGE_SIZE = 30
 private const val FEED_MAX_EVENTS = 300 // GitHub received_events 硬上限
+private const val HIGHLIGHTS_MIN_PER_LOAD = 10   // 精选档单次调用至少累计新增条目
+private const val MAX_PAGES_PER_LOAD = 5          // 单次调用最多连续拉取页数（防止过久）
 
 data class ProfileUiState(
     val isLoading: Boolean = true,
@@ -28,6 +32,8 @@ data class ProfileUiState(
     val feedEndReached: Boolean = false,
     /** feed 不可用（无 GitHub token / 请求失败），与整页 isError 区分 */
     val feedUnavailable: Boolean = false,
+    /** true = 精选档（默认），false = 全部档 */
+    val highlightsOnly: Boolean = true,
 )
 
 class ProfileViewModel(
@@ -35,29 +41,34 @@ class ProfileViewModel(
     private val githubApi: GithubApi = GithubApi(),
     private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
     private val authManager: () -> AuthManager = { globalAuthManager },
+    private val settingsManager: SettingsManager = globalSettingsManager,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(ProfileUiState())
     val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
 
     private var nextFeedPage = 1
+    /** 已消费的原始 events 总数（用于判断是否到达 GitHub 300 条硬上限） */
+    private var consumedRawCount = 0
 
     fun load() {
         viewModelScope.launch {
-            _uiState.value = ProfileUiState(isLoading = true)
+            val highlightsOnly = settingsManager.getFeedHighlightsOnlySync()
+            _uiState.value = ProfileUiState(isLoading = true, highlightsOnly = highlightsOnly)
             nextFeedPage = 1
+            consumedRawCount = 0
             val token = authManager().getAccessToken()
             if (token == null) {
-                _uiState.value = ProfileUiState(isLoading = false, isError = true)
+                _uiState.value = ProfileUiState(isLoading = false, isError = true, highlightsOnly = highlightsOnly)
                 return@launch
             }
             val user = try {
                 repository.fetchMe(token)
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
-                _uiState.value = ProfileUiState(isLoading = false, isError = true)
+                _uiState.value = ProfileUiState(isLoading = false, isError = true, highlightsOnly = highlightsOnly)
                 return@launch
             }
-            _uiState.value = ProfileUiState(isLoading = false, user = user)
+            _uiState.value = ProfileUiState(isLoading = false, user = user, highlightsOnly = highlightsOnly)
             loadGithubData(user)
         }
     }
@@ -91,16 +102,39 @@ class ProfileViewModel(
                 return@launch
             }
             try {
-                val events = githubApi.fetchReceivedEvents(githubToken, login, nextFeedPage, FEED_PAGE_SIZE)
-                val newItems = events.map { it.toFeedItem() }
-                val merged = (_uiState.value.feedItems + newItems).distinctBy { it.id }
-                val endReached = events.size < FEED_PAGE_SIZE || merged.size >= FEED_MAX_EVENTS
-                nextFeedPage++
-                _uiState.value = _uiState.value.copy(
-                    feedItems = merged,
-                    isFeedLoading = false,
-                    feedEndReached = endReached,
-                )
+                val highlightsOnly = _uiState.value.highlightsOnly
+                var pagesThisLoad = 0
+                var newItemsThisLoad = 0
+                var endReached = false
+
+                // 循环拉页：精选档过滤后新增不足 10 条且未到底时继续拉
+                while (!endReached && pagesThisLoad < MAX_PAGES_PER_LOAD) {
+                    val events = githubApi.fetchReceivedEvents(githubToken, login, nextFeedPage, FEED_PAGE_SIZE)
+                    pagesThisLoad++
+                    consumedRawCount += events.size
+
+                    val filtered = events.map { it.toFeedItem() }.let { items ->
+                        if (highlightsOnly) items.filter { it.kind in HighlightFeedKinds && !it.isBot() }
+                        else items
+                    }
+
+                    val existing = _uiState.value.feedItems
+                    val merged = (existing + filtered).distinctBy { it.id }
+                    newItemsThisLoad += merged.size - existing.size
+
+                    endReached = events.size < FEED_PAGE_SIZE || consumedRawCount >= FEED_MAX_EVENTS
+                    nextFeedPage++
+
+                    _uiState.value = _uiState.value.copy(
+                        feedItems = merged,
+                        feedEndReached = endReached,
+                    )
+
+                    // 已累计到足够条目则停止本次循环
+                    if (newItemsThisLoad >= HIGHLIGHTS_MIN_PER_LOAD) break
+                }
+
+                _uiState.value = _uiState.value.copy(isFeedLoading = false)
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
                 _uiState.value = _uiState.value.copy(
@@ -109,6 +143,21 @@ class ProfileViewModel(
                 )
             }
         }
+    }
+
+    /** 切换精选/全部档：持久化设置，重置 feed 状态并重新拉取第一页 */
+    fun setFeedFilter(highlightsOnly: Boolean) {
+        settingsManager.setFeedHighlightsOnly(highlightsOnly)
+        nextFeedPage = 1
+        consumedRawCount = 0
+        _uiState.value = _uiState.value.copy(
+            feedItems = emptyList(),
+            isFeedLoading = false,
+            feedEndReached = false,
+            feedUnavailable = false,
+            highlightsOnly = highlightsOnly,
+        )
+        loadMoreFeed()
     }
 
     fun signOut() = authManager().signOut()

--- a/shared/src/commonTest/kotlin/whl/trending/ai/core/DateTimeUtilsTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/core/DateTimeUtilsTest.kt
@@ -1,0 +1,65 @@
+package whl.trending.ai.core
+
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format
+import kotlinx.datetime.format.char
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class DateTimeUtilsTest {
+
+    /** 与实现中 private dateTimeFormat 等价的格式：yyyy-MM-dd HH:mm:ss */
+    private val dateTimeFormat = LocalDateTime.Format {
+        year()
+        char('-')
+        monthNumber()
+        char('-')
+        day()
+        char(' ')
+        hour()
+        char(':')
+        minute()
+        char(':')
+        second()
+    }
+
+    @Test
+    fun iso8601_with_z_is_parsed_and_converted() {
+        // GitHub events 格式：含 T 分隔符 + Z 时区
+        val input = "2026-06-09T12:47:28Z"
+        val result = DateTimeUtils.formatToLocalTime(input)
+        assertTrue(result.isNotEmpty())
+        // 输出为 yyyy-MM-dd HH:mm:ss 本地时间，必然不含 T/Z，说明确实走了解析转换
+        assertNotEquals(input, result)
+        assertTrue(!result.contains('T') && !result.contains('Z'))
+    }
+
+    @Test
+    fun legacy_format_is_parsed_and_converted() {
+        // 内部 API 格式回归：yyyy-MM-dd HH:mm:ss（UTC）
+        // 时区无关：测试内按相同逻辑自行计算期望值（UTC 解析 → 本地时区 → 同格式输出）
+        val input = "2026-02-15 00:17:20"
+        val expected = LocalDateTime.parse(input, dateTimeFormat)
+            .toInstant(TimeZone.UTC)
+            .toLocalDateTime(TimeZone.currentSystemDefault())
+            .format(dateTimeFormat)
+        assertEquals(expected, DateTimeUtils.formatToLocalTime(input))
+    }
+
+    @Test
+    fun empty_string_returns_empty() {
+        assertEquals("", DateTimeUtils.formatToLocalTime(""))
+    }
+
+    @Test
+    fun malformed_input_returns_original_string() {
+        // 解析失败走 catch 分支，原样返回
+        val input = "not-a-date"
+        assertEquals(input, DateTimeUtils.formatToLocalTime(input))
+    }
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt
@@ -82,4 +82,20 @@ class SettingsManagerTest {
         manager.setUserAvatarUrl(null)
         assertEquals(null, settings.getStringOrNull("prefs_user_avatar_url"))
     }
+
+    @Test
+    fun feedHighlightsOnly_defaults_true_and_persists() = runTest {
+        // 默认值
+        assertEquals(true, manager.getFeedHighlightsOnlySync())
+        assertEquals(true, manager.feedHighlightsOnly.first())
+
+        // 改为 false
+        manager.setFeedHighlightsOnly(false)
+        assertEquals(false, manager.getFeedHighlightsOnlySync())
+        assertEquals(false, manager.feedHighlightsOnly.first())
+
+        // 改回 true
+        manager.setFeedHighlightsOnly(true)
+        assertEquals(true, manager.getFeedHighlightsOnlySync())
+    }
 }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/remote/GithubApiModelsTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/remote/GithubApiModelsTest.kt
@@ -1,0 +1,40 @@
+package whl.trending.ai.data.remote
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GithubApiModelsTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decode_github_user() {
+        val payload = """
+            {"login":"HarlonWang","followers":491,"following":81,"public_repos":24,"name":"Harlon"}
+        """.trimIndent()
+        val user = json.decodeFromString<GithubUser>(payload)
+        assertEquals("HarlonWang", user.login)
+        assertEquals(491, user.followers)
+        assertEquals(81, user.following)
+        assertEquals(24, user.publicRepos)
+    }
+
+    @Test
+    fun decode_event_with_payload_kept_raw() {
+        val payload = """
+            [{"id":"22249084947","type":"WatchEvent",
+              "actor":{"id":1,"login":"octocat","avatar_url":"https://a.png"},
+              "repo":{"id":2,"name":"octocat/Hello-World"},
+              "payload":{"action":"started"},
+              "public":true,"created_at":"2026-06-09T12:47:28Z"}]
+        """.trimIndent()
+        val events = json.decodeFromString<List<GithubEventDto>>(payload)
+        assertEquals(1, events.size)
+        assertEquals("WatchEvent", events[0].type)
+        assertEquals("octocat", events[0].actor.login)
+        assertEquals("octocat/Hello-World", events[0].repo.name)
+        assertEquals("started", events[0].payload?.jsonObject?.get("action")?.jsonPrimitive?.content)
+    }
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/remote/GithubApiModelsTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/remote/GithubApiModelsTest.kt
@@ -10,6 +10,48 @@ class GithubApiModelsTest {
     private val json = Json { ignoreUnknownKeys = true }
 
     @Test
+    fun decode_github_following_user() {
+        val payload = """[{"login":"octocat","type":"User","avatar_url":"https://a.png","id":1}]"""
+        val list = json.decodeFromString<List<GithubFollowing>>(payload)
+        assertEquals(1, list.size)
+        assertEquals("octocat", list[0].login)
+        assertEquals("User", list[0].type)
+    }
+
+    @Test
+    fun decode_github_following_organization() {
+        val payload = """[{"login":"myorg","type":"Organization","id":99}]"""
+        val list = json.decodeFromString<List<GithubFollowing>>(payload)
+        assertEquals(1, list.size)
+        assertEquals("myorg", list[0].login)
+        assertEquals("Organization", list[0].type)
+    }
+
+    @Test
+    fun decode_github_following_default_type_is_user() {
+        // type フィールドが欠落している場合は "User" になる
+        val payload = """[{"login":"someone"}]"""
+        val list = json.decodeFromString<List<GithubFollowing>>(payload)
+        assertEquals("User", list[0].type)
+    }
+
+    @Test
+    fun decode_own_repos_list() {
+        val payload = """
+            [
+              {"id":1,"full_name":"HarlonWang/repo-a","private":false,"pushed_at":"2026-06-01T00:00:00Z"},
+              {"id":2,"full_name":"HarlonWang/repo-b","private":true,"pushed_at":"2026-05-01T00:00:00Z","extra_field":"ignored"}
+            ]
+        """.trimIndent()
+        // 只要能解析出 full_name 列表（多余字段忽略）
+        val repos = json.decodeFromString<List<kotlinx.serialization.json.JsonObject>>(payload)
+        val names = repos.map {
+            it["full_name"]?.let { e -> runCatching { e.jsonPrimitive.content }.getOrNull() }
+        }
+        assertEquals(listOf("HarlonWang/repo-a", "HarlonWang/repo-b"), names)
+    }
+
+    @Test
     fun decode_github_user() {
         val payload = """
             {"login":"HarlonWang","followers":491,"following":81,"public_repos":24,"name":"Harlon"}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/remote/LogtoAccountApiTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/remote/LogtoAccountApiTest.kt
@@ -1,0 +1,23 @@
+package whl.trending.ai.data.remote
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LogtoAccountApiTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decode_github_token_response() {
+        val payload = """{"access_token":"gho_abc123","scope":"read:user","token_type":"bearer"}"""
+        val resp = json.decodeFromString<GithubTokenResponse>(payload)
+        assertEquals("gho_abc123", resp.accessToken)
+    }
+
+    @Test
+    fun decode_minimal_response() {
+        val payload = """{"access_token":"gho_x"}"""
+        val resp = json.decodeFromString<GithubTokenResponse>(payload)
+        assertEquals("gho_x", resp.accessToken)
+    }
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/GithubFeedMapperTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/GithubFeedMapperTest.kt
@@ -2,11 +2,14 @@ package whl.trending.ai.ui.profile
 
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import whl.trending.ai.auth.FollowingInfo
 import whl.trending.ai.data.remote.GithubEventActor
 import whl.trending.ai.data.remote.GithubEventDto
 import whl.trending.ai.data.remote.GithubEventRepo
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class GithubFeedMapperTest {
     private fun event(type: String, payloadJson: String?): GithubEventDto = GithubEventDto(
@@ -158,6 +161,92 @@ class GithubFeedMapperTest {
             ),
             HighlightFeedKinds
         )
+    }
+
+    // =========================================================
+    // isHighlight 判定测试
+    // =========================================================
+
+    private fun feedItem(
+        actorLogin: String,
+        repoOwner: String,
+        kind: GithubFeedKind,
+    ) = GithubFeedItem(
+        id = "1",
+        actorLogin = actorLogin,
+        actorAvatarUrl = null,
+        repoName = "$repoOwner/repo",
+        kind = kind,
+        primary = null,
+        createdAt = "2026-06-09T12:47:28Z",
+        targetUrl = "https://github.com/$repoOwner/repo",
+    )
+
+    @Test
+    fun isHighlight_rule1_followed_user_with_highlight_kind() {
+        val following = FollowingInfo(users = setOf("octocat"), orgs = emptySet())
+        val item = feedItem("octocat", "someone", GithubFeedKind.STARRED)
+        assertTrue(item.isHighlight(following))
+    }
+
+    @Test
+    fun isHighlight_rule1_unknown_actor_not_highlight() {
+        val following = FollowingInfo(users = setOf("octocat"), orgs = emptySet())
+        val item = feedItem("stranger", "someone", GithubFeedKind.STARRED)
+        assertFalse(item.isHighlight(following))
+    }
+
+    @Test
+    fun isHighlight_rule2_org_release_is_highlight() {
+        val following = FollowingInfo(users = emptySet(), orgs = setOf("myorg"))
+        // actor is a random person, but repo owner is the org
+        val item = feedItem("randomuser", "myorg", GithubFeedKind.RELEASED)
+        assertTrue(item.isHighlight(following))
+    }
+
+    @Test
+    fun isHighlight_rule2_org_star_by_stranger_not_highlight() {
+        val following = FollowingInfo(users = emptySet(), orgs = setOf("myorg"))
+        val item = feedItem("randomuser", "myorg", GithubFeedKind.STARRED)
+        assertFalse(item.isHighlight(following))
+    }
+
+    @Test
+    fun isHighlight_null_following_fallback_to_kind_plus_not_bot() {
+        val humanItem = feedItem("octocat", "someone", GithubFeedKind.STARRED)
+        assertTrue(humanItem.isHighlight(null))
+
+        val botItem = feedItem("cursor[bot]", "someone", GithubFeedKind.STARRED)
+        assertFalse(botItem.isHighlight(null))
+
+        val lowSignalItem = feedItem("octocat", "someone", GithubFeedKind.PUSHED)
+        assertFalse(lowSignalItem.isHighlight(null))
+    }
+
+    @Test
+    fun isHighlight_rule1_bot_filtered_even_if_followed() {
+        val following = FollowingInfo(users = setOf("cursor[bot]"), orgs = emptySet())
+        val item = feedItem("cursor[bot]", "someone", GithubFeedKind.STARRED)
+        assertFalse(item.isHighlight(following))
+    }
+
+    @Test
+    fun isHighlight_rule2_bot_actor_not_filtered_for_org() {
+        // CI bot releasing for org should be included
+        val following = FollowingInfo(users = emptySet(), orgs = setOf("myorg"))
+        val item = feedItem("ci-bot[bot]", "myorg", GithubFeedKind.RELEASED)
+        assertTrue(item.isHighlight(following))
+    }
+
+    @Test
+    fun isHighlight_case_insensitive_login_comparison() {
+        val following = FollowingInfo(users = setOf("octocat"), orgs = setOf("myorg"))
+        // actor login in mixed case
+        val userItem = feedItem("OctoCat", "someone", GithubFeedKind.STARRED)
+        assertTrue(userItem.isHighlight(following))
+
+        val orgItem = feedItem("randomer", "MyOrg", GithubFeedKind.RELEASED)
+        assertTrue(orgItem.isHighlight(following))
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/GithubFeedMapperTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/GithubFeedMapperTest.kt
@@ -1,0 +1,126 @@
+package whl.trending.ai.ui.profile
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import whl.trending.ai.data.remote.GithubEventActor
+import whl.trending.ai.data.remote.GithubEventDto
+import whl.trending.ai.data.remote.GithubEventRepo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GithubFeedMapperTest {
+    private fun event(type: String, payloadJson: String?): GithubEventDto = GithubEventDto(
+        id = "1",
+        type = type,
+        actor = GithubEventActor(login = "octocat", avatarUrl = "https://a.png"),
+        repo = GithubEventRepo(name = "owner/repo"),
+        payload = payloadJson?.let { Json.parseToJsonElement(it) },
+        createdAt = "2026-06-09T12:47:28Z",
+    )
+
+    @Test
+    fun watch_event_maps_to_starred() {
+        val item = event("WatchEvent", """{"action":"started"}""").toFeedItem()
+        assertEquals(GithubFeedKind.STARRED, item.kind)
+        assertEquals("https://github.com/owner/repo", item.targetUrl)
+    }
+
+    @Test
+    fun fork_event() {
+        assertEquals(GithubFeedKind.FORKED, event("ForkEvent", "{}").toFeedItem().kind)
+    }
+
+    @Test
+    fun create_event_branch_and_repo_and_tag() {
+        val branch = event("CreateEvent", """{"ref":"dev","ref_type":"branch"}""").toFeedItem()
+        assertEquals(GithubFeedKind.CREATED_BRANCH, branch.kind)
+        assertEquals("dev", branch.primary)
+
+        val repo = event("CreateEvent", """{"ref":null,"ref_type":"repository"}""").toFeedItem()
+        assertEquals(GithubFeedKind.CREATED_REPO, repo.kind)
+
+        val tag = event("CreateEvent", """{"ref":"v1.0","ref_type":"tag"}""").toFeedItem()
+        assertEquals(GithubFeedKind.CREATED_TAG, tag.kind)
+        assertEquals("v1.0", tag.primary)
+    }
+
+    @Test
+    fun release_event_uses_release_url_and_tag() {
+        val item = event(
+            "ReleaseEvent",
+            """{"action":"published","release":{"tag_name":"v2.1","html_url":"https://github.com/owner/repo/releases/tag/v2.1"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.RELEASED, item.kind)
+        assertEquals("v2.1", item.primary)
+        assertEquals("https://github.com/owner/repo/releases/tag/v2.1", item.targetUrl)
+    }
+
+    @Test
+    fun push_event_counts_commits() {
+        val item = event("PushEvent", """{"size":3,"ref":"refs/heads/main"}""").toFeedItem()
+        assertEquals(GithubFeedKind.PUSHED, item.kind)
+        assertEquals("3", item.primary)
+    }
+
+    @Test
+    fun pull_request_opened_merged_closed() {
+        val opened = event(
+            "PullRequestEvent",
+            """{"action":"opened","number":12,"pull_request":{"merged":false,"html_url":"https://github.com/owner/repo/pull/12"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.PR_OPENED, opened.kind)
+        assertEquals("12", opened.primary)
+        assertEquals("https://github.com/owner/repo/pull/12", opened.targetUrl)
+
+        val merged = event(
+            "PullRequestEvent",
+            """{"action":"closed","number":13,"pull_request":{"merged":true,"html_url":"https://github.com/owner/repo/pull/13"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.PR_MERGED, merged.kind)
+
+        val closed = event(
+            "PullRequestEvent",
+            """{"action":"closed","number":14,"pull_request":{"merged":false,"html_url":"https://github.com/owner/repo/pull/14"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.PR_CLOSED, closed.kind)
+    }
+
+    @Test
+    fun issues_and_comment_events() {
+        val opened = event(
+            "IssuesEvent",
+            """{"action":"opened","issue":{"number":7,"html_url":"https://github.com/owner/repo/issues/7"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.ISSUE_OPENED, opened.kind)
+        assertEquals("7", opened.primary)
+
+        val closed = event(
+            "IssuesEvent",
+            """{"action":"closed","issue":{"number":8,"html_url":"https://github.com/owner/repo/issues/8"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.ISSUE_CLOSED, closed.kind)
+
+        val comment = event(
+            "IssueCommentEvent",
+            """{"action":"created","issue":{"number":9,"html_url":"https://github.com/owner/repo/issues/9"},"comment":{"html_url":"https://github.com/owner/repo/issues/9#issuecomment-1"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.ISSUE_COMMENTED, comment.kind)
+        assertEquals("https://github.com/owner/repo/issues/9#issuecomment-1", comment.targetUrl)
+    }
+
+    @Test
+    fun public_event_and_unknown_fallback() {
+        assertEquals(GithubFeedKind.MADE_PUBLIC, event("PublicEvent", "{}").toFeedItem().kind)
+
+        val other = event("MemberEvent", """{"action":"added"}""").toFeedItem()
+        assertEquals(GithubFeedKind.OTHER, other.kind)
+        assertEquals("Member", other.primary) // type 去掉 Event 后缀作展示
+    }
+
+    @Test
+    fun malformed_payload_does_not_crash() {
+        val item = event("PullRequestEvent", null).toFeedItem()
+        assertEquals(GithubFeedKind.OTHER, item.kind)
+        assertEquals("https://github.com/owner/repo", item.targetUrl)
+    }
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/GithubFeedMapperTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/GithubFeedMapperTest.kt
@@ -123,4 +123,62 @@ class GithubFeedMapperTest {
         assertEquals(GithubFeedKind.OTHER, item.kind)
         assertEquals("https://github.com/owner/repo", item.targetUrl)
     }
+
+    @Test
+    fun pull_request_merged_action() {
+        val item = event(
+            "PullRequestEvent",
+            """{"action":"merged","number":15,"pull_request":{"html_url":"https://github.com/owner/repo/pull/15"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.PR_MERGED, item.kind)
+        assertEquals("15", item.primary)
+        assertEquals("https://github.com/owner/repo/pull/15", item.targetUrl)
+    }
+
+    @Test
+    fun pull_request_labeled_falls_to_other() {
+        val item = event(
+            "PullRequestEvent",
+            """{"action":"labeled","number":16,"pull_request":{"html_url":"https://github.com/owner/repo/pull/16"}}"""
+        ).toFeedItem()
+        assertEquals(GithubFeedKind.OTHER, item.kind)
+    }
+
+    @Test
+    fun highlight_kinds_membership() {
+        assertEquals(
+            setOf(
+                GithubFeedKind.STARRED,
+                GithubFeedKind.FORKED,
+                GithubFeedKind.RELEASED,
+                GithubFeedKind.CREATED_REPO,
+                GithubFeedKind.MADE_PUBLIC,
+                GithubFeedKind.PR_OPENED,
+                GithubFeedKind.PR_MERGED,
+            ),
+            HighlightFeedKinds
+        )
+    }
+
+    @Test
+    fun bot_actor_detected() {
+        val botEvent = GithubEventDto(
+            id = "2",
+            type = "WatchEvent",
+            actor = GithubEventActor(login = "cursor[bot]", avatarUrl = null),
+            repo = GithubEventRepo(name = "owner/repo"),
+            payload = null,
+            createdAt = "2026-06-09T12:47:28Z",
+        )
+        val humanEvent = GithubEventDto(
+            id = "3",
+            type = "WatchEvent",
+            actor = GithubEventActor(login = "octocat", avatarUrl = null),
+            repo = GithubEventRepo(name = "owner/repo"),
+            payload = null,
+            createdAt = "2026-06-09T12:47:28Z",
+        )
+        assertEquals(true, botEvent.toFeedItem().isBot())
+        assertEquals(false, humanEvent.toFeedItem().isBot())
+    }
 }


### PR DESCRIPTION
## Summary
- Profile 页一体化：头部新增 followers/following/repos 实时计数，下方接 GitHub Dashboard 风格动态流（received_events，分页加载，14 类事件归一化渲染 + OTHER 兜底，30 天/300 条到底提示）
- GitHub token 链路：经 Logto Account API 从 Secret Vault 取回 GitHub token，会话内存缓存，登出清理（Worker 零改动）
- Phase 1 遗留清理：收拢双 syncMe 为单触发点、UserRepository 提为 remember、Profile 错误态增加登出出口
- 终审修复：nav3 无 per-entry VM 作用域 → Profile 改为每次进入全量重载（避免换账号串号/错误态锁死）；DateTimeUtils 增 ISO 8601 路径并补时区无关回归测试

## Test Plan
- [x] shared 单测 46/46 全绿（Account API/GitHub 模型解析 + mapper 全事件类型 + DateTimeUtils 回归）
- [x] 模拟器端到端：计数与 github.com 一致（491/81/24）、动态流渲染/翻页/头像/本地时间、登出重登链路、返回重进全量重载

设计文档：docs/superpowers/specs/2026-06-09-trendingai-logto-auth-design.md §6/§8
实施计划：docs/superpowers/plans/2026-06-10-logto-auth-phase2.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

将 GitHub 个人资料统计数据和活动动态整合到 Profile 页面中，同时清理 Logto Phase 1 的认证和同步流程。

New Features:
- 在 Profile 头部显示实时 GitHub 粉丝数、关注数和公开仓库数量，数据通过 GitHub API 获取。
- 在 Profile 页面添加类似 GitHub Dashboard 风格的活动动态（activity feed），基于 `received_events` 实现分页加载、事件类型归一化，以及“历史记录结束”的提示信息。
- 引入 `GithubTokenProvider` 和 `LogtoAccountApi`，通过 Logto Account API 在用户会话期间获取并缓存 GitHub 访问令牌。

Bug Fixes:
- 允许在 Profile 错误状态下直接登出，以从无效或过期凭据中恢复。
- 修复 `DateTimeUtils`，在现有内部时间格式之外，正确处理来自 GitHub 事件的 ISO 8601 UTC 时间戳。

Enhancements:
- 将 `ProfileScreen` 精简为一个单一的 lazy list 布局，将 profile 头部和 feed 合并，并支持无限滚动加载以及空/不可用状态。
- 将 GitHub 事件负载规范化为 `GithubFeedItem` 模型，并为中英文提供本地化字符串资源。
- 调整 `ProfileViewModel`，以增量方式加载 GitHub 用户数据和 `received_events`，并在页面级错误与 feed 不可用状态之间做出清晰区分。
- 简化 `LogtoAuthManager`，移除多余的后台作用域，仅依赖来自 `HomeScreen` 的单一 `syncMe` 触发；`HomeScreen` 现在会记住共享的 `UserRepository` 实例。
- 记录 Logto Phase 2 在 GitHub feed 和 Profile 集成方面的设计与实现计划。

Documentation:
- 添加 Logto Phase 2 关于 GitHub feed 和 Profile 增强的详细实现计划，并更新设计规范以澄清 iOS 登录 scope。

Tests:
- 为 GitHub API 和 Logto Account API 的响应解码、跨多种事件类型的 GitHub feed 映射逻辑，以及 `DateTimeUtils` 对 ISO 8601 与旧格式的处理新增单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate GitHub profile stats and activity feed into the Profile page while cleaning up Logto Phase 1 auth and sync flows.

New Features:
- Display live GitHub followers, following, and public repository counts on the Profile header using data fetched via the GitHub API.
- Add a GitHub Dashboard-style activity feed on the Profile page based on received_events with pagination, type-normalized entries, and end-of-history messaging.
- Introduce a GithubTokenProvider and LogtoAccountApi to retrieve and cache GitHub access tokens via Logto Account API during a user session.

Bug Fixes:
- Allow signing out directly from the Profile error state to recover from invalid or expired credentials.
- Fix DateTimeUtils to correctly handle ISO 8601 UTC timestamps from GitHub events in addition to the existing internal format.

Enhancements:
- Refine ProfileScreen into a single lazy list layout combining profile header and feed, with infinite scroll loading and empty/unavailable states.
- Normalize GitHub event payloads into a GithubFeedItem model with localized string resources for both English and Chinese.
- Adjust ProfileViewModel to load GitHub user data and received events incrementally, with proper separation between page-level errors and feed unavailability.
- Simplify LogtoAuthManager by removing redundant background scope and relying on a single syncMe trigger from HomeScreen, which now remembers a shared UserRepository instance.
- Document the Logto Phase 2 design and implementation plan for GitHub feed and profile integration.

Documentation:
- Add a detailed implementation plan for Logto Phase 2 GitHub feed and profile enhancements, and update the design spec to clarify iOS login scope.

Tests:
- Add unit tests for GitHub API and Logto Account API response decoding, GitHub feed mapping logic across multiple event types, and DateTimeUtils handling of ISO 8601 and legacy formats.

</details>