### PR TITLE
fix: 修复 Logto 登出/在途刷新竞态致登录态复活，并升级 SDK 至 2.0.2

### DIFF
--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -1,6 +1,7 @@
 package whl.trending.ai.auth
 
 import android.app.Activity
+import android.content.Context
 import io.logto.sdk.android.LogtoClient
 import io.logto.sdk.android.type.LogtoConfig
 import java.lang.ref.WeakReference
@@ -31,17 +32,37 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         activity.application,
     )
 
+    /**
+     * 登录态的权威真相源（优先于 SDK 存储）。
+     *
+     * Logto SDK 存在「登出与在途刷新竞态」：signOut 同步清空凭证后，一个早已发出、
+     * 此刻才回包的 token 刷新会在 verifyAndSaveTokenResponse 里无条件把凭证写回
+     * SharedPreferences，使 [LogtoClient.isAuthenticated] 复活为 true——仅凭它判断登录态，
+     * 会在下次 Activity 重建时出现「登出后又显示已登录」。该标记一旦置位即压过 SDK 存储。
+     */
+    private val prefs = activity.application
+        .getSharedPreferences(AUTH_PREFS_NAME, Context.MODE_PRIVATE)
+    private val signedOut: Boolean get() = prefs.getBoolean(KEY_SIGNED_OUT, false)
+
     private val _authState = MutableStateFlow<AuthState>(
-        if (logtoClient.isAuthenticated) AuthState.LoggedIn else AuthState.LoggedOut
+        if (logtoClient.isAuthenticated && !signedOut) AuthState.LoggedIn else AuthState.LoggedOut
     )
     override val authState: StateFlow<AuthState> = _authState.asStateFlow()
     override val isSupported: Boolean = true
+
+    init {
+        // 复活检测：标记已登出、但 SDK 存储里又冒出凭证（被在途刷新写回）→ 再清一次并远端撤销
+        if (signedOut && logtoClient.isAuthenticated) {
+            logtoClient.signOut { /* 远端撤销失败不阻塞，本地清除即可 */ }
+        }
+    }
 
     override fun signIn() {
         val activity = activityRef.get() ?: return
         _authState.value = AuthState.LoggingIn
         logtoClient.signIn(activity, REDIRECT_URI) { logtoException ->
             if (logtoException == null && logtoClient.isAuthenticated) {
+                prefs.edit().remove(KEY_SIGNED_OUT).apply()
                 _authState.value = AuthState.LoggedIn
                 trackEvent("sign_in_success")
             } else {
@@ -52,6 +73,8 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
     }
 
     override fun signOut() {
+        // 先持久化登出标记：即便随后被在途刷新复活，凭证也不再被采信（见构造的复活检测与 getAccessToken 守卫）
+        prefs.edit().putBoolean(KEY_SIGNED_OUT, true).apply()
         logtoClient.signOut { /* 本地凭证已清除即视为登出，远端失败不阻塞 */ }
         globalSettingsManager.setUserAvatarUrl(null)
         GithubTokenProvider.shared.clear()
@@ -61,15 +84,20 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         trackEvent("sign_out")
     }
 
-    override suspend fun getAccessToken(): String? =
-        suspendCancellableCoroutine { cont ->
+    override suspend fun getAccessToken(): String? {
+        // 登出态不触发刷新、也不交出可能被复活的 token：既缩小竞态源，又阻断复活凭证外泄
+        if (_authState.value !is AuthState.LoggedIn) return null
+        return suspendCancellableCoroutine { cont ->
             logtoClient.getAccessToken { _, accessToken ->
                 cont.resume(accessToken?.token)
             }
         }
+    }
 
     companion object {
         private const val LOGTO_APP_ID = "lasqslwwdjbim73vgkapj"
+        private const val AUTH_PREFS_NAME = "logto_auth_manager"
+        private const val KEY_SIGNED_OUT = "user_signed_out"
 
         /** release: cn.trendingai://whl.trending.ai/callback；debug 包名带 .debug，两条均已在 Logto 注册 */
         private val REDIRECT_URI = "cn.trendingai://${BuildConfig.APPLICATION_ID}/callback"

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -85,8 +85,10 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
     }
 
     override suspend fun getAccessToken(): String? {
-        // 登出态不触发刷新、也不交出可能被复活的 token：既缩小竞态源，又阻断复活凭证外泄
-        if (_authState.value !is AuthState.LoggedIn) return null
+        // 以持久化登出标记 + SDK 状态为准（与构造时登录态判定一致），不依赖可能过期的 _authState 快照：
+        // 多实例并存时旧实例的 _authState 可能仍为 LoggedIn，而 marker 已置位。
+        // 登出态既不触发刷新（缩小竞态源），也不交出可能被在途刷新复活的 token。
+        if (signedOut || !logtoClient.isAuthenticated) return null
         return suspendCancellableCoroutine { cont ->
             logtoClient.getAccessToken { _, accessToken ->
                 cont.resume(accessToken?.token)

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -2,6 +2,7 @@ package whl.trending.ai.auth
 
 import android.app.Activity
 import android.content.Context
+import androidx.core.content.edit
 import io.logto.sdk.android.LogtoClient
 import io.logto.sdk.android.type.LogtoConfig
 import java.lang.ref.WeakReference
@@ -62,7 +63,7 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         _authState.value = AuthState.LoggingIn
         logtoClient.signIn(activity, REDIRECT_URI) { logtoException ->
             if (logtoException == null && logtoClient.isAuthenticated) {
-                prefs.edit().remove(KEY_SIGNED_OUT).apply()
+                prefs.edit { remove(KEY_SIGNED_OUT) }
                 _authState.value = AuthState.LoggedIn
                 trackEvent("sign_in_success")
             } else {
@@ -74,7 +75,7 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
 
     override fun signOut() {
         // 先持久化登出标记：即便随后被在途刷新复活，凭证也不再被采信（见构造的复活检测与 getAccessToken 守卫）
-        prefs.edit().putBoolean(KEY_SIGNED_OUT, true).apply()
+        prefs.edit { putBoolean(KEY_SIGNED_OUT, true) }
         logtoClient.signOut { /* 本地凭证已清除即视为登出，远端失败不阻塞 */ }
         globalSettingsManager.setUserAvatarUrl(null)
         GithubTokenProvider.shared.clear()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ coil = "3.4.0"
 material-kolor = "4.1.1"
 commonmark = "0.28.0"
 kmp-webview = "0.1.1"
-logto = "1.1.3"
+logto = "2.0.2"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## 问题

Logto SDK 存在「登出 / 在途刷新」竞态：`signOut()` 同步清除本地凭证后，一个早已由 `getAccessToken` 发出、此刻才回包的 token 刷新，会在 SDK 的 `verifyAndSaveTokenResponse` 里**无条件**把轮换后的 `idToken` / `refreshToken` 写回 SharedPreferences。由于 `isAuthenticated` 由存储中的 `idToken` 推导，下次 `Activity` 重建 / 冷启动时登录态被复活——表现为「明明退出了登录，操作几次回到首页又显示已登录」。

启用 refresh token rotation 时（Logto 默认），复活的是最新轮换出的 refresh token，即当前唯一有效的那一个，是真实可用会话而非过期残留。

真机（Pixel_9_2）在 SDK 2.0.2 上确定性复现，时间线：

```
t=0.00s  getAccessToken() → 刷新请求在途
t=0.15s  signOut() 返回 → isAuthenticated=false，存储已清空
t=1.34s  在途刷新回包 → verifyAndSaveTokenResponse 写回 → isAuthenticated=true，存储被重新填满
t=...    new LogtoClient() → loadFromStorage() → isAuthenticated=true  ← 复活
```

## 为什么在 app 层修

写回点在 SDK 内部，外部无法拦截或取消那条在途请求。因此本修复不阻止「复活」本身，而是让复活的凭证**永不被信任、永不被使用**：不再把可被后台刷新改写的 SDK 存储当作登录态真相源，改由 app 自己持有权威标记。

## 改动（`LogtoAuthManager`）

- 引入持久化「已登出」标记（私有 SharedPreferences）作为登录态权威真相源，**优先于** SDK 存储
- `signOut`：先落标记，再清 SDK 凭证与各缓存
- `signIn` 成功：清除标记
- 构造时：登录态判定为 `isAuthenticated && !signedOut`；若标记已登出但 SDK 存储又出现凭证（被在途刷新复活），就地再清一次并远端撤销
- `getAccessToken`：登出态直接返回 `null`，既缩小竞态源（不再触发新刷新），又阻断复活凭证外泄

同步升级 `logto` 1.1.3 → **2.0.2**（最新发布版，我们用到的 API 完全兼容）。

## 验证

临时注入诊断入口，在 Pixel_9_2 上完整走「signOut → 模拟在途刷新复活 → Activity 重建」序列，六个检查点全部符合预期（验证后已删除）：

| 步骤 | 结果 |
|---|---|
| signOut 后 | authState=LoggedOut、SDK 存储已清、marker=true |
| 模拟刷新复活后 | `getAccessToken()` 返回 null（守卫拦住） |
| 模拟重建新实例 | authState=LoggedOut（标记压过复活的 SDK 存储） |
| 重建清理后 | SDK 存储里的复活凭证被擦除 |

对比修复前：同样序列下重建会变回 LoggedIn。「登出后又显示已登录」已修复。

## 上游

竞态已上报 Logto：logto-io/kotlin#253（含相同复现与建议的 SDK 侧修复方向）。SDK 修复合入前，本 app 层防御作为可靠兜底；上游修复后可保留亦无害。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

防止 Logto 认证状态在登出/刷新之间出现竞争条件，并与最新的 Logto SDK 保持一致。

Bug 修复：
- 通过持久化本地“已登出”标记，并在优先级上高于 SDK 存储，防止已登出会话被仍在进行中的 Logto token 刷新响应“复活”。
- 确保当应用认为用户已登出时，不会签发或刷新访问令牌，从而避免暴露被“复活”的凭证。

增强：
- 引入专用的 SharedPreferences 存储作为登出状态的权威来源，并在初始化时与 LogtoClient 状态进行对账，以清理任何被“复活”的凭证。

构建：
- 将 Logto Android SDK 依赖从 1.1.3 版本升级到 2.0.2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard Logto authentication state against logout/refresh race conditions and align with the latest Logto SDK.

Bug Fixes:
- Prevent logged-out sessions from being resurrected by in-flight Logto token refresh responses by persisting a local signed-out marker and honoring it over SDK storage.
- Ensure access tokens are not issued or refreshed when the app considers the user logged out, avoiding exposure of resurrected credentials.

Enhancements:
- Introduce a dedicated SharedPreferences store as the authoritative source of logout state and reconcile it with LogtoClient state on initialization to clean up any resurrected credentials.

Build:
- Upgrade Logto Android SDK dependency from version 1.1.3 to 2.0.2.

</details>