### PR TITLE
feat: Logto SDK 升级至 3.0.0-beta（WebView → Chrome Custom Tabs）

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -79,8 +79,10 @@ android {
 
         // Logto v3 登录/登出走系统浏览器（Chrome Custom Tabs），回跳经 OS intent-filter，
         // SDK 用该 scheme + ${applicationId} 注册接收 Activity；缺失会导致 manifest 合并失败。
-        // 须与传给 signIn/signOut 的 redirect URI scheme 一致（见 LogtoAuthManager.REDIRECT_URI）。
-        manifestPlaceholders["logtoRedirectScheme"] = "cn.trendingai"
+        // 单一来源：同时喂给 manifest 占位符与 Kotlin（经 BuildConfig），避免两处 scheme 漂移致回跳失效。
+        val logtoRedirectScheme = "cn.trendingai"
+        manifestPlaceholders["logtoRedirectScheme"] = logtoRedirectScheme
+        buildConfigField("String", "LOGTO_REDIRECT_SCHEME", "\"$logtoRedirectScheme\"")
     }
 
     // 签名配置：从环境变量读取加密存储的密钥信息

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -76,6 +76,11 @@ android {
         versionName = appVersionName
 
         manifestPlaceholders["appName"] = "Trending AI"
+
+        // Logto v3 登录/登出走系统浏览器（Chrome Custom Tabs），回跳经 OS intent-filter，
+        // SDK 用该 scheme + ${applicationId} 注册接收 Activity；缺失会导致 manifest 合并失败。
+        // 须与传给 signIn/signOut 的 redirect URI scheme 一致（见 LogtoAuthManager.REDIRECT_URI）。
+        manifestPlaceholders["logtoRedirectScheme"] = "cn.trendingai"
     }
 
     // 签名配置：从环境变量读取加密存储的密钥信息

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -90,9 +90,9 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
 
         /**
          * release: cn.trendingai://whl.trending.ai/callback；debug 包名带 .debug，两条均已在 Logto 注册。
-         * 同时用作登录回跳与登出后回跳（post sign-out redirect URI）；scheme 须与 manifestPlaceholder
-         * `logtoRedirectScheme` 一致（见 androidApp/build.gradle.kts）。
+         * 同时用作登录回跳与登出后回跳（post sign-out redirect URI）。scheme 与 manifestPlaceholder
+         * `logtoRedirectScheme` 共用 BuildConfig.LOGTO_REDIRECT_SCHEME 单一来源（见 androidApp/build.gradle.kts）。
          */
-        private val REDIRECT_URI = "cn.trendingai://${BuildConfig.APPLICATION_ID}/callback"
+        private val REDIRECT_URI = "${BuildConfig.LOGTO_REDIRECT_SCHEME}://${BuildConfig.APPLICATION_ID}/callback"
     }
 }

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -1,8 +1,6 @@
 package whl.trending.ai.auth
 
 import android.app.Activity
-import android.content.Context
-import androidx.core.content.edit
 import io.logto.sdk.android.LogtoClient
 import io.logto.sdk.android.type.LogtoConfig
 import java.lang.ref.WeakReference
@@ -18,6 +16,12 @@ import whl.trending.ai.data.local.globalSettingsManager
 /**
  * Logto 实现：OIDC PKCE 登录，token 存储/刷新由 SDK 托管。
  * scope 额外加 identities——Worker 经 userinfo 取 GitHub 数字 ID 建档。
+ *
+ * v3 起登录/登出改走系统浏览器（Chrome Custom Tabs）。两点行为变化：
+ * - 「登出与在途刷新竞态」已由 SDK 内置 CredentialGuard（乐观锁版本号）原生兜底，
+ *   登出后回包的刷新不会再把凭证写回存储复活登录态，故不再需要自管登出标记。
+ * - Custom Tabs 与系统浏览器共享会话 cookie：仅清本地凭证会让下次登录静默登回原账号、
+ *   无法切换账号。故登出用浏览器版 [LogtoClient.signOut] 走 end session endpoint 结束服务端会话。
  */
 class LogtoAuthManager(activity: Activity) : AuthManager {
     private val activityRef = WeakReference(activity)
@@ -33,37 +37,17 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         activity.application,
     )
 
-    /**
-     * 登录态的权威真相源（优先于 SDK 存储）。
-     *
-     * Logto SDK 存在「登出与在途刷新竞态」：signOut 同步清空凭证后，一个早已发出、
-     * 此刻才回包的 token 刷新会在 verifyAndSaveTokenResponse 里无条件把凭证写回
-     * SharedPreferences，使 [LogtoClient.isAuthenticated] 复活为 true——仅凭它判断登录态，
-     * 会在下次 Activity 重建时出现「登出后又显示已登录」。该标记一旦置位即压过 SDK 存储。
-     */
-    private val prefs = activity.application
-        .getSharedPreferences(AUTH_PREFS_NAME, Context.MODE_PRIVATE)
-    private val signedOut: Boolean get() = prefs.getBoolean(KEY_SIGNED_OUT, false)
-
     private val _authState = MutableStateFlow<AuthState>(
-        if (logtoClient.isAuthenticated && !signedOut) AuthState.LoggedIn else AuthState.LoggedOut
+        if (logtoClient.isAuthenticated) AuthState.LoggedIn else AuthState.LoggedOut
     )
     override val authState: StateFlow<AuthState> = _authState.asStateFlow()
     override val isSupported: Boolean = true
-
-    init {
-        // 复活检测：标记已登出、但 SDK 存储里又冒出凭证（被在途刷新写回）→ 再清一次并远端撤销
-        if (signedOut && logtoClient.isAuthenticated) {
-            logtoClient.signOut { /* 远端撤销失败不阻塞，本地清除即可 */ }
-        }
-    }
 
     override fun signIn() {
         val activity = activityRef.get() ?: return
         _authState.value = AuthState.LoggingIn
         logtoClient.signIn(activity, REDIRECT_URI) { logtoException ->
             if (logtoException == null && logtoClient.isAuthenticated) {
-                prefs.edit { remove(KEY_SIGNED_OUT) }
                 _authState.value = AuthState.LoggedIn
                 trackEvent("sign_in_success")
             } else {
@@ -74,9 +58,15 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
     }
 
     override fun signOut() {
-        // 先持久化登出标记：即便随后被在途刷新复活，凭证也不再被采信（见构造的复活检测与 getAccessToken 守卫）
-        prefs.edit { putBoolean(KEY_SIGNED_OUT, true) }
-        logtoClient.signOut { /* 本地凭证已清除即视为登出，远端失败不阻塞 */ }
+        // 完整登出：SDK 先撤销 refresh token，再经系统浏览器结束 Logto 会话、回跳 app。
+        // 本地凭证在 signOut 启动时即同步清除，故可立即置登出态；远端/浏览器步骤为尽力而为、失败不阻塞。
+        // 无可用 Activity 时（如后台错误处理）退回本地登出。
+        val activity = activityRef.get()
+        if (activity != null) {
+            logtoClient.signOut(activity, REDIRECT_URI) { /* 浏览器/撤销失败不阻塞本地登出 */ }
+        } else {
+            logtoClient.clearCredentials { /* 本地凭证已清除即视为登出 */ }
+        }
         globalSettingsManager.setUserAvatarUrl(null)
         GithubTokenProvider.shared.clear()
         FollowingProvider.shared.clear()
@@ -86,10 +76,8 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
     }
 
     override suspend fun getAccessToken(): String? {
-        // 以持久化登出标记 + SDK 状态为准（与构造时登录态判定一致），不依赖可能过期的 _authState 快照：
-        // 多实例并存时旧实例的 _authState 可能仍为 LoggedIn，而 marker 已置位。
-        // 登出态既不触发刷新（缩小竞态源），也不交出可能被在途刷新复活的 token。
-        if (signedOut || !logtoClient.isAuthenticated) return null
+        // 竞态由 SDK 的 CredentialGuard 兜底：登出后的在途刷新会以 NOT_AUTHENTICATED 收尾、不写回。
+        if (!logtoClient.isAuthenticated) return null
         return suspendCancellableCoroutine { cont ->
             logtoClient.getAccessToken { _, accessToken ->
                 cont.resume(accessToken?.token)
@@ -99,10 +87,12 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
 
     companion object {
         private const val LOGTO_APP_ID = "lasqslwwdjbim73vgkapj"
-        private const val AUTH_PREFS_NAME = "logto_auth_manager"
-        private const val KEY_SIGNED_OUT = "user_signed_out"
 
-        /** release: cn.trendingai://whl.trending.ai/callback；debug 包名带 .debug，两条均已在 Logto 注册 */
+        /**
+         * release: cn.trendingai://whl.trending.ai/callback；debug 包名带 .debug，两条均已在 Logto 注册。
+         * 同时用作登录回跳与登出后回跳（post sign-out redirect URI）；scheme 须与 manifestPlaceholder
+         * `logtoRedirectScheme` 一致（见 androidApp/build.gradle.kts）。
+         */
         private val REDIRECT_URI = "cn.trendingai://${BuildConfig.APPLICATION_ID}/callback"
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ coil = "3.4.0"
 material-kolor = "4.1.1"
 commonmark = "0.28.0"
 kmp-webview = "0.1.1"
-logto = "2.0.2"
+logto = "3.0.0-beta"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## 背景

Logto Kotlin SDK v3 用系统浏览器（Chrome Custom Tabs）取代内嵌 WebView 登录，符合 [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252)，解锁 passkey/WebAuthn 与浏览器 SSO，并**彻底移除内置 alipay/wechat connector 类**——R8 full-mode 不再缺类（见 logto-io/kotlin#255）。同时 v3 内置 `CredentialGuard` 原生修复了登出/在途刷新竞态（见 logto-io/kotlin#253），本仓库此前自管的登出标记 workaround 可移除。

## 改动

- **`libs.versions.toml`**：`logto` 2.0.2 → 3.0.0-beta
- **`androidApp/build.gradle.kts`**：新增 `manifestPlaceholders["logtoRedirectScheme"] = "cn.trendingai"`。v3 登录/登出回跳经 OS intent-filter，SDK 用该 scheme + `${applicationId}` 注册接收 Activity；缺失会导致 manifest 合并失败。
- **`LogtoAuthManager`**：
  - 登出改用浏览器版 `signOut(activity, postLogoutRedirectUri)` 走 end session endpoint 完整结束服务端会话；无 Activity 时退回 `clearCredentials` 本地登出。Custom Tabs 与系统浏览器共享会话 cookie，仅清本地凭证会让下次登录静默登回原账号、无法切换账号——这是业界（OIDC RP-Initiated Logout / Auth0 / Okta / AppAuth）推荐做法。
  - 移除针对 #253 自管的 `signedOut` 标记 + 复活检测 workaround，竞态交由 SDK 内置 `CredentialGuard`（乐观锁版本号）兜底。

## 行为变化

- 登录/登出从内嵌 WebView 变为跳系统浏览器（Custom Tabs）。
- 登出为完整登出（结束服务端会话 + 撤销 refresh token + 浏览器回跳），保持 v2「登出后需重新登录/可切账号」的既有效果。

## 验证

- ✅ `assembleGithubDebug` 编译 + manifest 合并通过（注入 `LogtoRedirectReceiverActivity`，intent-filter `scheme=cn.trendingai` / `path=/callback` / host=applicationId）
- ✅ `assembleGithubRelease` R8 full-mode 通过，无 alipay/wechat 缺类报错
- ✅ Logto 控制台已注册 post sign-out redirect URI（release/debug 两条）
- 🔄 模拟器运行时登录/登出端到端冒烟测试（进行中）

## 说明

3.0.0-beta 为预发布版本，建议合并后在各渠道灰度验证登录/登出/锁屏恢复后再随正式版发布。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

将 Logto Android SDK 升级到 v3，并将认证流程从内嵌 WebView 迁移到基于系统浏览器的 Chrome Custom Tabs，同时更新登出行为以执行完整的服务端会话终止，并简化本地状态处理。

新特性：
- 通过使用操作系统的重定向 Intent，在 Chrome Custom Tabs 中支持基于浏览器的 Logto 登录和登出。

增强：
- 移除自定义的登出竞态条件解决方案，改用 SDK 内置的 CredentialGuard 处理。
- 配置应用的 manifest 占位符，为 v3 提供 Logto 重定向 URI 的 scheme。
- 更新 Logto 重定向 URI 的使用方式，以基于 applicationId 同时支持登录和登出后的重定向。

构建：
- 将 Logto Kotlin SDK 依赖从 2.0.2 提升到 3.0.0-beta。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the Logto Android SDK to v3 and migrate authentication flows from embedded WebView to system browser-based Chrome Custom Tabs, updating logout behavior to perform full server-side session termination and simplifying local state handling.

New Features:
- Support browser-based Logto sign-in and sign-out via Chrome Custom Tabs using OS redirect intents.

Enhancements:
- Remove custom logout race-condition workaround in favor of the SDK's built-in CredentialGuard handling.
- Configure application manifest placeholders to supply the Logto redirect URI scheme for v3.
- Update Logto redirect URI usage to support both login and post-logout redirects based on applicationId.

Build:
- Bump Logto Kotlin SDK dependency from 2.0.2 to 3.0.0-beta.

</details>