### PR TITLE
fix(profile): 进入页面后 feed 区先空白再显示 loading

### DIFF
--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -212,7 +212,7 @@ fun ProfileScreen(onBack: () -> Unit) {
                     GithubFeedRow(item = item, onClick = { uriHandler.openUri(item.targetUrl) })
                     HorizontalDivider(thickness = 0.5.dp)
                 }
-                if (uiState.isFeedLoading) {
+                if (uiState.isFeedLoadingVisible) {
                     item(key = "feed_loading") {
                         Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
                             LoadingIndicator(modifier = Modifier.size(32.dp))

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -98,6 +99,10 @@ fun ProfileScreen(onBack: () -> Unit) {
     // 避免登出换账号串号 / feed 失败态永久残留
     LaunchedEffect(Unit) {
         viewModel.load()
+    }
+    // 离开页面即清空缓存 VM 的状态，避免再次进入时首帧先闪出上次的旧数据
+    DisposableEffect(Unit) {
+        onDispose { viewModel.onLeave() }
     }
     val uriHandler = LocalUriHandler.current
     val listState = rememberLazyListState()

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -42,13 +42,13 @@ data class ProfileUiState(
     val highlightsOnly: Boolean = true,
 ) {
     /**
-     * feed 是否应显示加载态。除「正在拉取」(isFeedLoading) 外，还覆盖
-     * load → loadGithubData（取计数/关注/自有仓库事件）→ loadMoreFeed 之间
-     * isFeedLoading 尚未置位的空窗：此时 feed 首个结果未产出（空且未到底、未不可用），
-     * 同样应显示 loading，避免进入页面后 feed 区先空白一会再冒出 loading。
+     * feed 是否应显示加载态。语义：feed 首个结果尚未产出（空、且未到底、未不可用）即视为加载中，
+     * 而不仅是「正在发起网络请求」(isFeedLoading)——这样从页面内容出现到首批 feed 到达期间始终有
+     * loading，不会先空白。整页加载中 (isLoading) 时不计入，避免与整页 loading 叠加。
      */
     val isFeedLoadingVisible: Boolean
-        get() = isFeedLoading || (feedItems.isEmpty() && !feedEndReached && !feedUnavailable)
+        get() = !isLoading &&
+            (isFeedLoading || (feedItems.isEmpty() && !feedEndReached && !feedUnavailable))
 }
 
 class ProfileViewModel(

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -263,5 +263,16 @@ class ProfileViewModel(
         loadMoreFeed()
     }
 
+    /**
+     * 离开页面时调用：取消在途加载并把状态重置为初始加载态。
+     * VM 是 Activity 级缓存（复用同一实例），不清理会在重新进入页面时先闪出上次的旧数据，
+     * 之后才被 [load] 异步重置。离开时同步清掉，使下次进入的首帧即为初始 loading 态。
+     */
+    fun onLeave() {
+        loadJob?.cancel()
+        feedLoadJob?.cancel()
+        _uiState.value = ProfileUiState()
+    }
+
     fun signOut() = authManager().signOut()
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -40,7 +40,16 @@ data class ProfileUiState(
     val feedUnavailable: Boolean = false,
     /** true = 精选档（默认），false = 全部档 */
     val highlightsOnly: Boolean = true,
-)
+) {
+    /**
+     * feed 是否应显示加载态。除「正在拉取」(isFeedLoading) 外，还覆盖
+     * load → loadGithubData（取计数/关注/自有仓库事件）→ loadMoreFeed 之间
+     * isFeedLoading 尚未置位的空窗：此时 feed 首个结果未产出（空且未到底、未不可用），
+     * 同样应显示 loading，避免进入页面后 feed 区先空白一会再冒出 loading。
+     */
+    val isFeedLoadingVisible: Boolean
+        get() = isFeedLoading || (feedItems.isEmpty() && !feedEndReached && !feedUnavailable)
+}
 
 class ProfileViewModel(
     private val repository: UserRepository = UserRepository(),

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileUiStateTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileUiStateTest.kt
@@ -1,0 +1,58 @@
+package whl.trending.ai.ui.profile
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProfileUiStateTest {
+
+    private val oneItem = listOf(
+        GithubFeedItem(
+            id = "1",
+            kind = GithubFeedKind.OTHER,
+            actorLogin = "a",
+            actorAvatarUrl = null,
+            repoName = "a/b",
+            primary = null,
+            targetUrl = "https://x",
+            createdAt = "2026-06-13T00:00:00Z",
+        )
+    )
+
+    @Test
+    fun pending_first_load_shows_loading() {
+        // load 已出 header、loadGithubData 前置请求进行中：feed 空且未到底/未不可用 → 应显示 loading
+        val state = ProfileUiState(isLoading = false, isFeedLoading = false)
+        assertTrue(state.isFeedLoadingVisible)
+    }
+
+    @Test
+    fun actively_fetching_shows_loading() {
+        val state = ProfileUiState(isLoading = false, isFeedLoading = true)
+        assertTrue(state.isFeedLoadingVisible)
+    }
+
+    @Test
+    fun unavailable_does_not_show_loading() {
+        val state = ProfileUiState(isLoading = false, isFeedLoading = false, feedUnavailable = true)
+        assertFalse(state.isFeedLoadingVisible)
+    }
+
+    @Test
+    fun empty_but_end_reached_does_not_show_loading() {
+        val state = ProfileUiState(isLoading = false, isFeedLoading = false, feedEndReached = true)
+        assertFalse(state.isFeedLoadingVisible)
+    }
+
+    @Test
+    fun has_items_and_not_fetching_does_not_show_loading() {
+        val state = ProfileUiState(isLoading = false, isFeedLoading = false, feedItems = oneItem)
+        assertFalse(state.isFeedLoadingVisible)
+    }
+
+    @Test
+    fun has_items_and_fetching_more_shows_loading() {
+        val state = ProfileUiState(isLoading = false, isFeedLoading = true, feedItems = oneItem)
+        assertTrue(state.isFeedLoadingVisible)
+    }
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileUiStateTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileUiStateTest.kt
@@ -27,6 +27,13 @@ class ProfileUiStateTest {
     }
 
     @Test
+    fun full_page_loading_does_not_show_feed_loading() {
+        // 整页 loading 阶段不渲染 feed spinner，避免与整页 loading 叠加
+        val state = ProfileUiState(isLoading = true)
+        assertFalse(state.isFeedLoadingVisible)
+    }
+
+    @Test
     fun actively_fetching_shows_loading() {
         val state = ProfileUiState(isLoading = false, isFeedLoading = true)
         assertTrue(state.isFeedLoadingVisible)


### PR DESCRIPTION
## 问题
进入 Profile 后，feed 区不会立即显示 loading，而是先空白一会，再出现 loading，然后才出数据。

## 根因
feed 加载指示只绑定 `isFeedLoading`，而它**仅在 `loadMoreFeed()` 内置位**；`loadMoreFeed()` 又排在 `loadGithubData` 的多个前置请求之后（github token → 计数 `fetchUser` → 关注列表 `following` → 自有仓库事件 `ownRepoEvents`）。

状态时序：
1. `isLoading=true` → 整页 loading（立即）
2. `getAccessToken`+`fetchMe` 后 → `isLoading=false, user=set`，但 `feedItems=[]`/`isFeedLoading=false`/`feedEndReached=false`/`feedUnavailable=false` → **feed 区无 item、无 spinner、无 notice = 空白**
3. `loadGithubData` 跑前置请求（即「等待的一会」）
4. `loadMoreFeed()` 才 `isFeedLoading=true` → spinner 出现 → 出数据

缺少一个表达「页面已出、feed 首个结果尚未产出」的加载态。

## 修复
`ProfileUiState` 新增派生态：
```kotlin
val isFeedLoadingVisible: Boolean
    get() = isFeedLoading || (feedItems.isEmpty() && !feedEndReached && !feedUnavailable)
```
feed spinner 由 `isFeedLoading` 改用 `isFeedLoadingVisible`，进入页面后立即显示 loading 直到首批数据/空态/不可用态产出。也顺带覆盖切换精选/全部档的空窗。

## 验证
- ✅ `:shared:testAndroidHostTest`（新增 `ProfileUiStateTest`，覆盖 pending/fetching/unavailable/endReached/有数据 各态）通过
- ✅ `:androidApp:assembleGithubDebug` 通过
- 🔄 登录态下的实机观感需人工确认（自动化未代登录）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

确保在进入页面时，个人资料动态(feed) 能立即显示合适的加载状态，而不是短暂地显示为空白。

Bug Fixes:
- 修复一个时序问题：在初始数据获取过程中，个人资料动态区域会在加载指示器显示之前短暂出现空白。

Enhancements:
- 引入一个派生的 UI 状态标志，用于根据加载状态和当前动态内容共同控制动态加载可见性。

Tests:
- 新增单元测试，覆盖新的个人资料动态加载可见性逻辑，包括空数据、加载中、不可用、已到末尾以及已填充等状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the profile feed shows an appropriate loading state immediately when entering the page instead of briefly appearing blank.

Bug Fixes:
- Fix a timing issue where the profile feed area appeared blank before the loading indicator was shown while initial data was being fetched.

Enhancements:
- Introduce a derived UI state flag to control feed loading visibility based on both loading status and current feed content.

Tests:
- Add unit tests covering the new profile feed loading visibility logic across empty, loading, unavailable, end-reached, and populated states.

</details>