### PR TITLE
feat(profile): Followers/Following/Repos 可点击下钻列表页

### DIFF
--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -130,6 +130,11 @@
     <string name="profile_followers">粉丝</string>
     <string name="profile_following">关注</string>
     <string name="profile_repos">仓库</string>
+    <string name="list_load_failed">加载失败</string>
+    <string name="list_empty_followers">还没有粉丝</string>
+    <string name="list_empty_following">还没有关注任何人</string>
+    <string name="list_empty_repos">还没有仓库</string>
+    <string name="repo_fork_label">Fork</string>
     <string name="feed_starred">Star 了 %1$s</string>
     <string name="feed_forked">Fork 了 %1$s</string>
     <string name="feed_created_repo">创建了仓库 %1$s</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -130,6 +130,11 @@
     <string name="profile_followers">Followers</string>
     <string name="profile_following">Following</string>
     <string name="profile_repos">Repos</string>
+    <string name="list_load_failed">Failed to load</string>
+    <string name="list_empty_followers">No followers yet</string>
+    <string name="list_empty_following">Not following anyone yet</string>
+    <string name="list_empty_repos">No repositories yet</string>
+    <string name="repo_fork_label">Fork</string>
     <string name="feed_starred">Starred %1$s</string>
     <string name="feed_forked">Forked %1$s</string>
     <string name="feed_created_repo">Created repository %1$s</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
@@ -4,7 +4,10 @@ import whl.trending.ai.ui.detail.ReadmeScreen
 import whl.trending.ai.ui.favorites.FavoriteListScreen
 import whl.trending.ai.ui.feedback.FeedbackScreen
 import whl.trending.ai.ui.home.HomeScreen
+import whl.trending.ai.ui.profile.GithubUserListMode
+import whl.trending.ai.ui.profile.GithubUserListScreen
 import whl.trending.ai.ui.profile.ProfileScreen
+import whl.trending.ai.ui.profile.RepoListScreen
 import whl.trending.ai.ui.settings.SettingsScreen
 import whl.trending.ai.ui.subscribe.SubscribeScreen
 import whl.trending.ai.ui.theme.TrendingTheme
@@ -29,6 +32,9 @@ data class RepoDetail(val owner: String, val repo: String)
 data class WebPage(val url: String, val title: String)
 data object Favorites
 data object Profile
+data object ProfileFollowers
+data object ProfileFollowing
+data object ProfileRepos
 data class Chat(val context: ChatContext?)
 
 /**
@@ -130,7 +136,35 @@ fun App() {
                     }
 
                     is Profile -> NavEntry(key) {
-                        ProfileScreen(onBack = { backStack.safePop() })
+                        ProfileScreen(
+                            onBack = { backStack.safePop() },
+                            onOpenFollowers = { backStack.add(ProfileFollowers) },
+                            onOpenFollowing = { backStack.add(ProfileFollowing) },
+                            onOpenRepos = { backStack.add(ProfileRepos) },
+                        )
+                    }
+
+                    is ProfileFollowers -> NavEntry(key) {
+                        GithubUserListScreen(
+                            mode = GithubUserListMode.FOLLOWERS,
+                            onBack = { backStack.safePop() },
+                        )
+                    }
+
+                    is ProfileFollowing -> NavEntry(key) {
+                        GithubUserListScreen(
+                            mode = GithubUserListMode.FOLLOWING,
+                            onBack = { backStack.safePop() },
+                        )
+                    }
+
+                    is ProfileRepos -> NavEntry(key) {
+                        RepoListScreen(
+                            onBack = { backStack.safePop() },
+                            onOpenRepo = { owner, repo ->
+                                backStack.add(RepoDetail(owner, repo))
+                            },
+                        )
                     }
 
                     is RepoDetail -> NavEntry(key) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
@@ -175,7 +175,11 @@ open class GithubApi {
         return response.body<List<GithubUserSummary>>()
     }
 
-    /** 我的自有仓库分页列表（含 fork），按最近 push 倒序——与顶部 publicRepos 计数口径一致。 */
+    /**
+     * 我的自有公开仓库分页列表（含 fork），按最近 push 倒序。
+     * 显式 visibility=public：与顶部 publicRepos 计数口径一致——否则默认会带回私有仓库，
+     * 导致列表条数大于头部计数。
+     */
     open suspend fun fetchReposPage(
         githubToken: String,
         page: Int,
@@ -187,6 +191,7 @@ open class GithubApi {
             parameter("per_page", perPage)
             parameter("page", page)
             parameter("affiliation", "owner")
+            parameter("visibility", "public")
             parameter("sort", "pushed")
         }
         if (response.status.value !in 200..299) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
@@ -34,6 +34,28 @@ data class GithubUser(
     @SerialName("public_repos") val publicRepos: Int = 0,
 )
 
+/** followers / following 列表项：含头像与主页，供 Profile 下钻列表展示。 */
+@Serializable
+data class GithubUserSummary(
+    val login: String,
+    @SerialName("avatar_url") val avatarUrl: String? = null,
+    @SerialName("html_url") val htmlUrl: String? = null,
+    val type: String = "User",
+)
+
+/** repos 列表项：供 Profile 仓库下钻列表展示。 */
+@Serializable
+data class GithubRepoSummary(
+    @SerialName("full_name") val fullName: String,
+    val name: String,
+    val description: String? = null,
+    @SerialName("stargazers_count") val stars: Int = 0,
+    val language: String? = null,
+    @SerialName("html_url") val htmlUrl: String? = null,
+    val fork: Boolean = false,
+    @SerialName("pushed_at") val pushedAt: String? = null,
+)
+
 @Serializable
 data class GithubEventActor(
     val login: String,
@@ -115,6 +137,62 @@ open class GithubApi {
             throw ApiException(response.status.value, response.bodyAsText())
         }
         return response.body<List<GithubFollowing>>()
+    }
+
+    /** 我的 followers 分页列表（含头像）。 */
+    open suspend fun fetchFollowers(
+        githubToken: String,
+        page: Int,
+        perPage: Int = 30,
+    ): List<GithubUserSummary> {
+        val response = client.get("$baseHost/user/followers") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+            parameter("per_page", perPage)
+            parameter("page", page)
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<List<GithubUserSummary>>()
+    }
+
+    /** 我关注的 following 分页列表（含头像）。与 [fetchFollowing] 区分：后者仅供 feed 过滤取 login。 */
+    open suspend fun fetchFollowingUsers(
+        githubToken: String,
+        page: Int,
+        perPage: Int = 30,
+    ): List<GithubUserSummary> {
+        val response = client.get("$baseHost/user/following") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+            parameter("per_page", perPage)
+            parameter("page", page)
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<List<GithubUserSummary>>()
+    }
+
+    /** 我的自有仓库分页列表（含 fork），按最近 push 倒序——与顶部 publicRepos 计数口径一致。 */
+    open suspend fun fetchReposPage(
+        githubToken: String,
+        page: Int,
+        perPage: Int = 30,
+    ): List<GithubRepoSummary> {
+        val response = client.get("$baseHost/user/repos") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+            parameter("per_page", perPage)
+            parameter("page", page)
+            parameter("affiliation", "owner")
+            parameter("sort", "pushed")
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<List<GithubRepoSummary>>()
     }
 
     open suspend fun fetchOwnRepos(githubToken: String, perPage: Int = 100): List<String> {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubUserListScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubUserListScreen.kt
@@ -1,0 +1,166 @@
+package whl.trending.ai.ui.profile
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil3.compose.AsyncImage
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.list_empty_followers
+import trendingai.shared.generated.resources.list_empty_following
+import trendingai.shared.generated.resources.list_load_failed
+import trendingai.shared.generated.resources.profile_followers
+import trendingai.shared.generated.resources.profile_following
+import trendingai.shared.generated.resources.profile_retry
+import whl.trending.ai.data.remote.GithubUserSummary
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun GithubUserListScreen(
+    mode: GithubUserListMode,
+    onBack: () -> Unit,
+) {
+    val viewModel: GithubUserListViewModel = viewModel(key = "user_list_$mode") {
+        GithubUserListViewModel(mode)
+    }
+    val uiState by viewModel.uiState.collectAsState()
+    LaunchedEffect(Unit) { viewModel.load() }
+    // VM 为 Activity 级缓存，离开即清空，避免再次进入闪出旧数据（与 ProfileScreen 一致）
+    DisposableEffect(Unit) { onDispose { viewModel.onLeave() } }
+    val uriHandler = LocalUriHandler.current
+    val listState = rememberLazyListState()
+
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            last >= listState.layoutInfo.totalItemsCount - 3
+        }
+    }
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore) viewModel.loadMore()
+    }
+
+    val title = when (mode) {
+        GithubUserListMode.FOLLOWERS -> stringResource(Res.string.profile_followers)
+        GithubUserListMode.FOLLOWING -> stringResource(Res.string.profile_following)
+    }
+    val emptyText = when (mode) {
+        GithubUserListMode.FOLLOWERS -> stringResource(Res.string.list_empty_followers)
+        GithubUserListMode.FOLLOWING -> stringResource(Res.string.list_empty_following)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        }
+    ) { padding ->
+        when {
+            uiState.isLoading -> Box(
+                Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center,
+            ) { LoadingIndicator(modifier = Modifier.size(48.dp)) }
+
+            uiState.isError && uiState.items.isEmpty() -> Column(
+                modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(stringResource(Res.string.list_load_failed), Modifier.padding(top = 48.dp))
+                Button(onClick = { viewModel.load() }) { Text(stringResource(Res.string.profile_retry)) }
+            }
+
+            uiState.items.isEmpty() -> Box(
+                Modifier.fillMaxSize().padding(padding).padding(24.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    emptyText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            else -> LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize().padding(padding),
+            ) {
+                items(uiState.items, key = { it.login }) { user ->
+                    GithubUserRow(
+                        user = user,
+                        onClick = { user.htmlUrl?.let { uriHandler.openUri(it) } },
+                    )
+                    HorizontalDivider(thickness = 0.5.dp)
+                }
+                if (uiState.isLoadingMore) {
+                    item(key = "loading_more") {
+                        Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                            LoadingIndicator(modifier = Modifier.size(32.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GithubUserRow(user: GithubUserSummary, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        AsyncImage(
+            model = user.avatarUrl,
+            contentDescription = null,
+            modifier = Modifier.size(40.dp).clip(CircleShape),
+        )
+        Text(user.login, style = MaterialTheme.typography.bodyLarge)
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubUserListScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubUserListScreen.kt
@@ -2,37 +2,18 @@ package whl.trending.ai.ui.profile
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Button
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -44,13 +25,10 @@ import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.list_empty_followers
 import trendingai.shared.generated.resources.list_empty_following
-import trendingai.shared.generated.resources.list_load_failed
 import trendingai.shared.generated.resources.profile_followers
 import trendingai.shared.generated.resources.profile_following
-import trendingai.shared.generated.resources.profile_retry
 import whl.trending.ai.data.remote.GithubUserSummary
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun GithubUserListScreen(
     mode: GithubUserListMode,
@@ -64,17 +42,6 @@ fun GithubUserListScreen(
     // VM 为 Activity 级缓存，离开即清空，避免再次进入闪出旧数据（与 ProfileScreen 一致）
     DisposableEffect(Unit) { onDispose { viewModel.onLeave() } }
     val uriHandler = LocalUriHandler.current
-    val listState = rememberLazyListState()
-
-    val shouldLoadMore by remember {
-        derivedStateOf {
-            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-            last >= listState.layoutInfo.totalItemsCount - 3
-        }
-    }
-    LaunchedEffect(shouldLoadMore) {
-        if (shouldLoadMore) viewModel.loadMore()
-    }
 
     val title = when (mode) {
         GithubUserListMode.FOLLOWERS -> stringResource(Res.string.profile_followers)
@@ -85,64 +52,19 @@ fun GithubUserListScreen(
         GithubUserListMode.FOLLOWING -> stringResource(Res.string.list_empty_following)
     }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(title) },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
-                    }
-                },
-            )
-        }
-    ) { padding ->
-        when {
-            uiState.isLoading -> Box(
-                Modifier.fillMaxSize().padding(padding),
-                contentAlignment = Alignment.Center,
-            ) { LoadingIndicator(modifier = Modifier.size(48.dp)) }
-
-            uiState.isError && uiState.items.isEmpty() -> Column(
-                modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                Text(stringResource(Res.string.list_load_failed), Modifier.padding(top = 48.dp))
-                Button(onClick = { viewModel.load() }) { Text(stringResource(Res.string.profile_retry)) }
-            }
-
-            uiState.items.isEmpty() -> Box(
-                Modifier.fillMaxSize().padding(padding).padding(24.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    emptyText,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            else -> LazyColumn(
-                state = listState,
-                modifier = Modifier.fillMaxSize().padding(padding),
-            ) {
-                items(uiState.items, key = { it.login }) { user ->
-                    GithubUserRow(
-                        user = user,
-                        onClick = { user.htmlUrl?.let { uriHandler.openUri(it) } },
-                    )
-                    HorizontalDivider(thickness = 0.5.dp)
-                }
-                if (uiState.isLoadingMore) {
-                    item(key = "loading_more") {
-                        Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
-                            LoadingIndicator(modifier = Modifier.size(32.dp))
-                        }
-                    }
-                }
-            }
-        }
+    PaginatedListScaffold(
+        title = title,
+        emptyText = emptyText,
+        uiState = uiState,
+        onBack = onBack,
+        onRetry = { viewModel.load() },
+        onLoadMore = { viewModel.loadMore() },
+        itemKey = { it.login },
+    ) { user ->
+        GithubUserRow(
+            user = user,
+            onClick = { user.htmlUrl?.let { uriHandler.openUri(it) } },
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubUserListViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubUserListViewModel.kt
@@ -1,101 +1,24 @@
 package whl.trending.ai.ui.profile
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import whl.trending.ai.auth.GithubTokenProvider
 import whl.trending.ai.data.remote.GithubApi
 import whl.trending.ai.data.remote.GithubUserSummary
 
 enum class GithubUserListMode { FOLLOWERS, FOLLOWING }
 
-private const val PAGE_SIZE = 30
-
-data class GithubUserListUiState(
-    val isLoading: Boolean = true,
-    val isLoadingMore: Boolean = false,
-    val items: List<GithubUserSummary> = emptyList(),
-    val isError: Boolean = false,
-    val endReached: Boolean = false,
-)
-
-/** Followers / Following 下钻列表：分页拉取（触底加载下一页）。 */
+/** Followers / Following 下钻列表：靠 [mode] 切换数据源，分页逻辑见 [PagedListViewModel]。 */
 class GithubUserListViewModel(
     private val mode: GithubUserListMode,
     private val githubApi: GithubApi = GithubApi(),
-    private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
-) : ViewModel() {
-    private val _uiState = MutableStateFlow(GithubUserListUiState())
-    val uiState: StateFlow<GithubUserListUiState> = _uiState.asStateFlow()
+    tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
+) : PagedListViewModel<GithubUserSummary>(tokenProvider) {
+    override val pageSize = 30
 
-    private var nextPage = 1
-    private var loadJob: Job? = null
-
-    private suspend fun fetchPage(token: String, page: Int): List<GithubUserSummary> =
+    override suspend fun fetchPage(token: String, page: Int): List<GithubUserSummary> =
         when (mode) {
-            GithubUserListMode.FOLLOWERS -> githubApi.fetchFollowers(token, page, PAGE_SIZE)
-            GithubUserListMode.FOLLOWING -> githubApi.fetchFollowingUsers(token, page, PAGE_SIZE)
+            GithubUserListMode.FOLLOWERS -> githubApi.fetchFollowers(token, page, pageSize)
+            GithubUserListMode.FOLLOWING -> githubApi.fetchFollowingUsers(token, page, pageSize)
         }
 
-    fun load() {
-        loadJob?.cancel()
-        loadJob = viewModelScope.launch {
-            _uiState.value = GithubUserListUiState(isLoading = true)
-            nextPage = 1
-            val token = tokenProvider.get()
-            if (token == null) {
-                _uiState.value = GithubUserListUiState(isLoading = false, isError = true)
-                return@launch
-            }
-            try {
-                val page = fetchPage(token, nextPage)
-                nextPage++
-                _uiState.value = GithubUserListUiState(
-                    isLoading = false,
-                    items = page,
-                    endReached = page.size < PAGE_SIZE,
-                )
-            } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
-                _uiState.value = GithubUserListUiState(isLoading = false, isError = true)
-            }
-        }
-    }
-
-    fun loadMore() {
-        val state = _uiState.value
-        if (state.isLoading || state.isLoadingMore || state.endReached) return
-        loadJob = viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoadingMore = true)
-            val token = tokenProvider.get()
-            if (token == null) {
-                _uiState.value = _uiState.value.copy(isLoadingMore = false, endReached = true)
-                return@launch
-            }
-            try {
-                val page = fetchPage(token, nextPage)
-                nextPage++
-                val merged = (_uiState.value.items + page).distinctBy { it.login }
-                _uiState.value = _uiState.value.copy(
-                    isLoadingMore = false,
-                    items = merged,
-                    endReached = page.size < PAGE_SIZE,
-                )
-            } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
-                // 翻页失败不致命：保留已加载内容，停止继续拉取
-                _uiState.value = _uiState.value.copy(isLoadingMore = false, endReached = true)
-            }
-        }
-    }
-
-    /** 离开页面：取消在途加载并重置为初始 loading 态（VM 为 Activity 级缓存）。 */
-    fun onLeave() {
-        loadJob?.cancel()
-        _uiState.value = GithubUserListUiState()
-    }
+    override fun keyOf(item: GithubUserSummary): Any = item.login
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubUserListViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubUserListViewModel.kt
@@ -1,0 +1,101 @@
+package whl.trending.ai.ui.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import whl.trending.ai.auth.GithubTokenProvider
+import whl.trending.ai.data.remote.GithubApi
+import whl.trending.ai.data.remote.GithubUserSummary
+
+enum class GithubUserListMode { FOLLOWERS, FOLLOWING }
+
+private const val PAGE_SIZE = 30
+
+data class GithubUserListUiState(
+    val isLoading: Boolean = true,
+    val isLoadingMore: Boolean = false,
+    val items: List<GithubUserSummary> = emptyList(),
+    val isError: Boolean = false,
+    val endReached: Boolean = false,
+)
+
+/** Followers / Following 下钻列表：分页拉取（触底加载下一页）。 */
+class GithubUserListViewModel(
+    private val mode: GithubUserListMode,
+    private val githubApi: GithubApi = GithubApi(),
+    private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(GithubUserListUiState())
+    val uiState: StateFlow<GithubUserListUiState> = _uiState.asStateFlow()
+
+    private var nextPage = 1
+    private var loadJob: Job? = null
+
+    private suspend fun fetchPage(token: String, page: Int): List<GithubUserSummary> =
+        when (mode) {
+            GithubUserListMode.FOLLOWERS -> githubApi.fetchFollowers(token, page, PAGE_SIZE)
+            GithubUserListMode.FOLLOWING -> githubApi.fetchFollowingUsers(token, page, PAGE_SIZE)
+        }
+
+    fun load() {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            _uiState.value = GithubUserListUiState(isLoading = true)
+            nextPage = 1
+            val token = tokenProvider.get()
+            if (token == null) {
+                _uiState.value = GithubUserListUiState(isLoading = false, isError = true)
+                return@launch
+            }
+            try {
+                val page = fetchPage(token, nextPage)
+                nextPage++
+                _uiState.value = GithubUserListUiState(
+                    isLoading = false,
+                    items = page,
+                    endReached = page.size < PAGE_SIZE,
+                )
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                _uiState.value = GithubUserListUiState(isLoading = false, isError = true)
+            }
+        }
+    }
+
+    fun loadMore() {
+        val state = _uiState.value
+        if (state.isLoading || state.isLoadingMore || state.endReached) return
+        loadJob = viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoadingMore = true)
+            val token = tokenProvider.get()
+            if (token == null) {
+                _uiState.value = _uiState.value.copy(isLoadingMore = false, endReached = true)
+                return@launch
+            }
+            try {
+                val page = fetchPage(token, nextPage)
+                nextPage++
+                val merged = (_uiState.value.items + page).distinctBy { it.login }
+                _uiState.value = _uiState.value.copy(
+                    isLoadingMore = false,
+                    items = merged,
+                    endReached = page.size < PAGE_SIZE,
+                )
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                // 翻页失败不致命：保留已加载内容，停止继续拉取
+                _uiState.value = _uiState.value.copy(isLoadingMore = false, endReached = true)
+            }
+        }
+    }
+
+    /** 离开页面：取消在途加载并重置为初始 loading 态（VM 为 Activity 级缓存）。 */
+    fun onLeave() {
+        loadJob?.cancel()
+        _uiState.value = GithubUserListUiState()
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/PagedListViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/PagedListViewModel.kt
@@ -1,0 +1,94 @@
+package whl.trending.ai.ui.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import whl.trending.ai.auth.GithubTokenProvider
+
+data class PagedListUiState<T>(
+    val isLoading: Boolean = true,
+    val isLoadingMore: Boolean = false,
+    val items: List<T> = emptyList(),
+    val isError: Boolean = false,
+    val endReached: Boolean = false,
+)
+
+/**
+ * GitHub 下钻列表的通用分页 VM：首屏 load + 触底 loadMore + 离开重置。
+ * 子类只需提供 [pageSize]、[fetchPage]（取第 N 页）与 [keyOf]（去重键）。
+ * 错误处理：首屏失败置 isError；翻页失败保留已加载内容并置 endReached（不致命）。
+ */
+abstract class PagedListViewModel<T>(
+    protected val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(PagedListUiState<T>())
+    val uiState: StateFlow<PagedListUiState<T>> = _uiState.asStateFlow()
+
+    private var nextPage = 1
+    private var loadJob: Job? = null
+
+    protected abstract val pageSize: Int
+    protected abstract suspend fun fetchPage(token: String, page: Int): List<T>
+    protected abstract fun keyOf(item: T): Any
+
+    fun load() {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            _uiState.value = PagedListUiState(isLoading = true)
+            nextPage = 1
+            val token = tokenProvider.get()
+            if (token == null) {
+                _uiState.value = PagedListUiState(isLoading = false, isError = true)
+                return@launch
+            }
+            try {
+                val page = fetchPage(token, nextPage)
+                nextPage++
+                _uiState.value = PagedListUiState(
+                    isLoading = false,
+                    items = page,
+                    endReached = page.size < pageSize,
+                )
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                _uiState.value = PagedListUiState(isLoading = false, isError = true)
+            }
+        }
+    }
+
+    fun loadMore() {
+        val state = _uiState.value
+        if (state.isLoading || state.isLoadingMore || state.endReached) return
+        loadJob = viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoadingMore = true)
+            val token = tokenProvider.get()
+            if (token == null) {
+                _uiState.value = _uiState.value.copy(isLoadingMore = false, endReached = true)
+                return@launch
+            }
+            try {
+                val page = fetchPage(token, nextPage)
+                nextPage++
+                val merged = (_uiState.value.items + page).distinctBy { keyOf(it) }
+                _uiState.value = _uiState.value.copy(
+                    isLoadingMore = false,
+                    items = merged,
+                    endReached = page.size < pageSize,
+                )
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                _uiState.value = _uiState.value.copy(isLoadingMore = false, endReached = true)
+            }
+        }
+    }
+
+    /** 离开页面：取消在途加载并重置为初始 loading 态（VM 为 Activity 级缓存）。 */
+    fun onLeave() {
+        loadJob?.cancel()
+        _uiState.value = PagedListUiState()
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/PaginatedListScaffold.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/PaginatedListScaffold.kt
@@ -1,0 +1,127 @@
+package whl.trending.ai.ui.profile
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.back
+import trendingai.shared.generated.resources.list_load_failed
+import trendingai.shared.generated.resources.profile_retry
+
+/**
+ * GitHub 下钻列表的通用骨架：TopAppBar + loading/error/empty/列表 四态 + 触底翻页。
+ * 各列表只需提供 [title]、[emptyText]、行渲染 [itemContent] 与去重键 [itemKey]。
+ * loading 统一用 M3 Expressive LoadingIndicator（首屏 48dp / 翻页 32dp）。
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun <T> PaginatedListScaffold(
+    title: String,
+    emptyText: String,
+    uiState: PagedListUiState<T>,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onLoadMore: () -> Unit,
+    itemKey: (T) -> Any,
+    itemContent: @Composable (T) -> Unit,
+) {
+    val listState = rememberLazyListState()
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            last >= listState.layoutInfo.totalItemsCount - 3
+        }
+    }
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore) onLoadMore()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(Res.string.back),
+                        )
+                    }
+                },
+            )
+        }
+    ) { padding ->
+        when {
+            uiState.isLoading -> Box(
+                Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center,
+            ) { LoadingIndicator(modifier = Modifier.size(48.dp)) }
+
+            uiState.isError && uiState.items.isEmpty() -> Column(
+                modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(stringResource(Res.string.list_load_failed), Modifier.padding(top = 48.dp))
+                Button(onClick = onRetry) { Text(stringResource(Res.string.profile_retry)) }
+            }
+
+            uiState.items.isEmpty() -> Box(
+                Modifier.fillMaxSize().padding(padding).padding(24.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    emptyText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            else -> LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize().padding(padding),
+            ) {
+                items(uiState.items, key = { itemKey(it) }) { item ->
+                    itemContent(item)
+                    HorizontalDivider(thickness = 0.5.dp)
+                }
+                if (uiState.isLoadingMore) {
+                    item(key = "loading_more") {
+                        Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                            LoadingIndicator(modifier = Modifier.size(32.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -107,7 +107,12 @@ import whl.trending.ai.core.DateTimeUtils
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun ProfileScreen(onBack: () -> Unit) {
+fun ProfileScreen(
+    onBack: () -> Unit,
+    onOpenFollowers: () -> Unit,
+    onOpenFollowing: () -> Unit,
+    onOpenRepos: () -> Unit,
+) {
     val viewModel: ProfileViewModel = viewModel { ProfileViewModel() }
     val uiState by viewModel.uiState.collectAsState()
     // nav3 默认无 per-entry VM 作用域，VM 是 Activity 级缓存；每次进入本页全量重载，
@@ -201,7 +206,12 @@ fun ProfileScreen(onBack: () -> Unit) {
                 modifier = Modifier.fillMaxSize(),
             ) {
                 item(key = "header") {
-                    ProfileHeader(uiState = uiState)
+                    ProfileHeader(
+                        uiState = uiState,
+                        onOpenFollowers = onOpenFollowers,
+                        onOpenFollowing = onOpenFollowing,
+                        onOpenRepos = onOpenRepos,
+                    )
                 }
                 item(key = "feed_filter") {
                     Row(
@@ -314,6 +324,9 @@ private fun FeedRulesSection(title: String, body: String) {
 @Composable
 private fun ProfileHeader(
     uiState: ProfileUiState,
+    onOpenFollowers: () -> Unit,
+    onOpenFollowing: () -> Unit,
+    onOpenRepos: () -> Unit,
 ) {
     val user = uiState.user ?: return
     Column(
@@ -339,17 +352,23 @@ private fun ProfileHeader(
         }
         uiState.githubUser?.let { gh ->
             Row(horizontalArrangement = Arrangement.spacedBy(24.dp)) {
-                CountCell(gh.followers, stringResource(Res.string.profile_followers))
-                CountCell(gh.following, stringResource(Res.string.profile_following))
-                CountCell(gh.publicRepos, stringResource(Res.string.profile_repos))
+                CountCell(gh.followers, stringResource(Res.string.profile_followers), onClick = onOpenFollowers)
+                CountCell(gh.following, stringResource(Res.string.profile_following), onClick = onOpenFollowing)
+                CountCell(gh.publicRepos, stringResource(Res.string.profile_repos), onClick = onOpenRepos)
             }
         }
     }
 }
 
 @Composable
-private fun CountCell(count: Int, label: String) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+private fun CountCell(count: Int, label: String, onClick: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .clip(MaterialTheme.shapes.small)
+            .clickable { onClick() }
+            .padding(horizontal = 12.dp, vertical = 4.dp),
+    ) {
         Text(DateTimeUtils.formatNumber(count), style = MaterialTheme.typography.titleMedium)
         Text(
             label,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/RepoListScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/RepoListScreen.kt
@@ -1,0 +1,212 @@
+package whl.trending.ai.ui.profile
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.list_empty_repos
+import trendingai.shared.generated.resources.list_load_failed
+import trendingai.shared.generated.resources.profile_repos
+import trendingai.shared.generated.resources.profile_retry
+import trendingai.shared.generated.resources.repo_fork_label
+import whl.trending.ai.core.DateTimeUtils
+import whl.trending.ai.data.remote.GithubRepoSummary
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun RepoListScreen(
+    onBack: () -> Unit,
+    onOpenRepo: (owner: String, repo: String) -> Unit,
+) {
+    val viewModel: RepoListViewModel = viewModel { RepoListViewModel() }
+    val uiState by viewModel.uiState.collectAsState()
+    LaunchedEffect(Unit) { viewModel.load() }
+    DisposableEffect(Unit) { onDispose { viewModel.onLeave() } }
+    val listState = rememberLazyListState()
+
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            last >= listState.layoutInfo.totalItemsCount - 3
+        }
+    }
+    LaunchedEffect(shouldLoadMore) {
+        if (shouldLoadMore) viewModel.loadMore()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(Res.string.profile_repos)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        }
+    ) { padding ->
+        when {
+            uiState.isLoading -> Box(
+                Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center,
+            ) { LoadingIndicator(modifier = Modifier.size(48.dp)) }
+
+            uiState.isError && uiState.items.isEmpty() -> Column(
+                modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(stringResource(Res.string.list_load_failed), Modifier.padding(top = 48.dp))
+                Button(onClick = { viewModel.load() }) { Text(stringResource(Res.string.profile_retry)) }
+            }
+
+            uiState.items.isEmpty() -> Box(
+                Modifier.fillMaxSize().padding(padding).padding(24.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    stringResource(Res.string.list_empty_repos),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            else -> LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize().padding(padding),
+            ) {
+                items(uiState.items, key = { it.fullName }) { repo ->
+                    RepoRow(
+                        repo = repo,
+                        onClick = {
+                            val parts = repo.fullName.split("/", limit = 2)
+                            if (parts.size == 2) onOpenRepo(parts[0], parts[1])
+                        },
+                    )
+                    HorizontalDivider(thickness = 0.5.dp)
+                }
+                if (uiState.isLoadingMore) {
+                    item(key = "loading_more") {
+                        Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                            LoadingIndicator(modifier = Modifier.size(32.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RepoRow(repo: GithubRepoSummary, onClick: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                repo.name,
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.weight(1f, fill = false),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (repo.fork) {
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    shape = MaterialTheme.shapes.small,
+                ) {
+                    Text(
+                        stringResource(Res.string.repo_fork_label),
+                        style = MaterialTheme.typography.labelSmall,
+                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                    )
+                }
+            }
+        }
+        repo.description?.takeIf { it.isNotBlank() }?.let {
+            Text(
+                it,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            repo.language?.takeIf { it.isNotBlank() }?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (repo.stars > 0) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    Icon(
+                        Icons.Filled.Star,
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        DateTimeUtils.formatNumber(repo.stars),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/RepoListScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/RepoListScreen.kt
@@ -2,38 +2,22 @@ package whl.trending.ai.ui.profile
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Button
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
@@ -42,14 +26,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.list_empty_repos
-import trendingai.shared.generated.resources.list_load_failed
 import trendingai.shared.generated.resources.profile_repos
-import trendingai.shared.generated.resources.profile_retry
 import trendingai.shared.generated.resources.repo_fork_label
 import whl.trending.ai.core.DateTimeUtils
 import whl.trending.ai.data.remote.GithubRepoSummary
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun RepoListScreen(
     onBack: () -> Unit,
@@ -59,79 +40,23 @@ fun RepoListScreen(
     val uiState by viewModel.uiState.collectAsState()
     LaunchedEffect(Unit) { viewModel.load() }
     DisposableEffect(Unit) { onDispose { viewModel.onLeave() } }
-    val listState = rememberLazyListState()
 
-    val shouldLoadMore by remember {
-        derivedStateOf {
-            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-            last >= listState.layoutInfo.totalItemsCount - 3
-        }
-    }
-    LaunchedEffect(shouldLoadMore) {
-        if (shouldLoadMore) viewModel.loadMore()
-    }
-
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(stringResource(Res.string.profile_repos)) },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
-                    }
-                },
-            )
-        }
-    ) { padding ->
-        when {
-            uiState.isLoading -> Box(
-                Modifier.fillMaxSize().padding(padding),
-                contentAlignment = Alignment.Center,
-            ) { LoadingIndicator(modifier = Modifier.size(48.dp)) }
-
-            uiState.isError && uiState.items.isEmpty() -> Column(
-                modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                Text(stringResource(Res.string.list_load_failed), Modifier.padding(top = 48.dp))
-                Button(onClick = { viewModel.load() }) { Text(stringResource(Res.string.profile_retry)) }
-            }
-
-            uiState.items.isEmpty() -> Box(
-                Modifier.fillMaxSize().padding(padding).padding(24.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    stringResource(Res.string.list_empty_repos),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            else -> LazyColumn(
-                state = listState,
-                modifier = Modifier.fillMaxSize().padding(padding),
-            ) {
-                items(uiState.items, key = { it.fullName }) { repo ->
-                    RepoRow(
-                        repo = repo,
-                        onClick = {
-                            val parts = repo.fullName.split("/", limit = 2)
-                            if (parts.size == 2) onOpenRepo(parts[0], parts[1])
-                        },
-                    )
-                    HorizontalDivider(thickness = 0.5.dp)
-                }
-                if (uiState.isLoadingMore) {
-                    item(key = "loading_more") {
-                        Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
-                            LoadingIndicator(modifier = Modifier.size(32.dp))
-                        }
-                    }
-                }
-            }
-        }
+    PaginatedListScaffold(
+        title = stringResource(Res.string.profile_repos),
+        emptyText = stringResource(Res.string.list_empty_repos),
+        uiState = uiState,
+        onBack = onBack,
+        onRetry = { viewModel.load() },
+        onLoadMore = { viewModel.loadMore() },
+        itemKey = { it.fullName },
+    ) { repo ->
+        RepoRow(
+            repo = repo,
+            onClick = {
+                val parts = repo.fullName.split("/", limit = 2)
+                if (parts.size == 2) onOpenRepo(parts[0], parts[1])
+            },
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/RepoListViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/RepoListViewModel.kt
@@ -1,0 +1,91 @@
+package whl.trending.ai.ui.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import whl.trending.ai.auth.GithubTokenProvider
+import whl.trending.ai.data.remote.GithubApi
+import whl.trending.ai.data.remote.GithubRepoSummary
+
+private const val PAGE_SIZE = 30
+
+data class RepoListUiState(
+    val isLoading: Boolean = true,
+    val isLoadingMore: Boolean = false,
+    val items: List<GithubRepoSummary> = emptyList(),
+    val isError: Boolean = false,
+    val endReached: Boolean = false,
+)
+
+/** 自有仓库下钻列表：分页拉取（按最近 push 倒序，触底加载下一页）。 */
+class RepoListViewModel(
+    private val githubApi: GithubApi = GithubApi(),
+    private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(RepoListUiState())
+    val uiState: StateFlow<RepoListUiState> = _uiState.asStateFlow()
+
+    private var nextPage = 1
+    private var loadJob: Job? = null
+
+    fun load() {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            _uiState.value = RepoListUiState(isLoading = true)
+            nextPage = 1
+            val token = tokenProvider.get()
+            if (token == null) {
+                _uiState.value = RepoListUiState(isLoading = false, isError = true)
+                return@launch
+            }
+            try {
+                val page = githubApi.fetchReposPage(token, nextPage, PAGE_SIZE)
+                nextPage++
+                _uiState.value = RepoListUiState(
+                    isLoading = false,
+                    items = page,
+                    endReached = page.size < PAGE_SIZE,
+                )
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                _uiState.value = RepoListUiState(isLoading = false, isError = true)
+            }
+        }
+    }
+
+    fun loadMore() {
+        val state = _uiState.value
+        if (state.isLoading || state.isLoadingMore || state.endReached) return
+        loadJob = viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoadingMore = true)
+            val token = tokenProvider.get()
+            if (token == null) {
+                _uiState.value = _uiState.value.copy(isLoadingMore = false, endReached = true)
+                return@launch
+            }
+            try {
+                val page = githubApi.fetchReposPage(token, nextPage, PAGE_SIZE)
+                nextPage++
+                val merged = (_uiState.value.items + page).distinctBy { it.fullName }
+                _uiState.value = _uiState.value.copy(
+                    isLoadingMore = false,
+                    items = merged,
+                    endReached = page.size < PAGE_SIZE,
+                )
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                _uiState.value = _uiState.value.copy(isLoadingMore = false, endReached = true)
+            }
+        }
+    }
+
+    /** 离开页面：取消在途加载并重置为初始 loading 态（VM 为 Activity 级缓存）。 */
+    fun onLeave() {
+        loadJob?.cancel()
+        _uiState.value = RepoListUiState()
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/RepoListViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/RepoListViewModel.kt
@@ -1,91 +1,18 @@
 package whl.trending.ai.ui.profile
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import whl.trending.ai.auth.GithubTokenProvider
 import whl.trending.ai.data.remote.GithubApi
 import whl.trending.ai.data.remote.GithubRepoSummary
 
-private const val PAGE_SIZE = 30
-
-data class RepoListUiState(
-    val isLoading: Boolean = true,
-    val isLoadingMore: Boolean = false,
-    val items: List<GithubRepoSummary> = emptyList(),
-    val isError: Boolean = false,
-    val endReached: Boolean = false,
-)
-
-/** 自有仓库下钻列表：分页拉取（按最近 push 倒序，触底加载下一页）。 */
+/** 自有公开仓库下钻列表：按最近 push 倒序，分页逻辑见 [PagedListViewModel]。 */
 class RepoListViewModel(
     private val githubApi: GithubApi = GithubApi(),
-    private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
-) : ViewModel() {
-    private val _uiState = MutableStateFlow(RepoListUiState())
-    val uiState: StateFlow<RepoListUiState> = _uiState.asStateFlow()
+    tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
+) : PagedListViewModel<GithubRepoSummary>(tokenProvider) {
+    override val pageSize = 30
 
-    private var nextPage = 1
-    private var loadJob: Job? = null
+    override suspend fun fetchPage(token: String, page: Int): List<GithubRepoSummary> =
+        githubApi.fetchReposPage(token, page, pageSize)
 
-    fun load() {
-        loadJob?.cancel()
-        loadJob = viewModelScope.launch {
-            _uiState.value = RepoListUiState(isLoading = true)
-            nextPage = 1
-            val token = tokenProvider.get()
-            if (token == null) {
-                _uiState.value = RepoListUiState(isLoading = false, isError = true)
-                return@launch
-            }
-            try {
-                val page = githubApi.fetchReposPage(token, nextPage, PAGE_SIZE)
-                nextPage++
-                _uiState.value = RepoListUiState(
-                    isLoading = false,
-                    items = page,
-                    endReached = page.size < PAGE_SIZE,
-                )
-            } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
-                _uiState.value = RepoListUiState(isLoading = false, isError = true)
-            }
-        }
-    }
-
-    fun loadMore() {
-        val state = _uiState.value
-        if (state.isLoading || state.isLoadingMore || state.endReached) return
-        loadJob = viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoadingMore = true)
-            val token = tokenProvider.get()
-            if (token == null) {
-                _uiState.value = _uiState.value.copy(isLoadingMore = false, endReached = true)
-                return@launch
-            }
-            try {
-                val page = githubApi.fetchReposPage(token, nextPage, PAGE_SIZE)
-                nextPage++
-                val merged = (_uiState.value.items + page).distinctBy { it.fullName }
-                _uiState.value = _uiState.value.copy(
-                    isLoadingMore = false,
-                    items = merged,
-                    endReached = page.size < PAGE_SIZE,
-                )
-            } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
-                _uiState.value = _uiState.value.copy(isLoadingMore = false, endReached = true)
-            }
-        }
-    }
-
-    /** 离开页面：取消在途加载并重置为初始 loading 态（VM 为 Activity 级缓存）。 */
-    fun onLeave() {
-        loadJob?.cancel()
-        _uiState.value = RepoListUiState()
-    }
+    override fun keyOf(item: GithubRepoSummary): Any = item.fullName
 }


### PR DESCRIPTION
## 背景

Profile 顶部三个计数 Followers / Following / Repos 原本仅为只读数字，点不动、无详情。这是「Profile 功能升级」第一层：可点击下钻 + 三个列表页。

## 改动

**数据层 — `GithubApi.kt`**
- 新增 `GithubUserSummary`（login + 头像 + 主页）、`GithubRepoSummary`（名称/描述/star/语言/fork/pushed_at）
- 新增分页接口：
  - `fetchFollowers` → `GET /user/followers`
  - `fetchFollowingUsers` → `GET /user/following`（与既有仅取 login 的 `fetchFollowing` 区分）
  - `fetchReposPage` → `GET /user/repos?affiliation=owner&sort=pushed`（含 fork，与顶部 publicRepos 计数口径一致）

**列表页（新增 4 文件）**
- `GithubUserListViewModel` + `GithubUserListScreen`：Followers / Following 共用一屏，靠 `GithubUserListMode` 区分；点击用户行用 `uriHandler` 外部打开其 GitHub 主页（与 feed 行为一致）
- `RepoListViewModel` + `RepoListScreen`：展示仓库名 / 描述 / 语言 / star / fork 标记；点击进**应用内 README 详情页**（拆 `full_name` 复用既有 `RepoDetail` 路由）

**接线**
- `ProfileScreen`：`CountCell` 加 `clickable`，三格分别回调 `onOpenFollowers/Following/Repos`
- `App.kt`：新增 `ProfileFollowers` / `ProfileFollowing` / `ProfileRepos` 路由并接线
- `strings.xml`（中/英）：列表空态、加载失败、Fork 标签

## 一致性
- 所有 loading 统一 M3 Expressive `LoadingIndicator`（首屏 48dp / 翻页 32dp）
- VM 为 Activity 级缓存，`onLeave()` 清空状态避免再次进入闪旧数据（沿用 ProfileScreen 模式）
- 分页触底加载复用 ProfileScreen 的 `derivedStateOf` 滚动判定

## 验证
- `./gradlew :androidApp:compileGithubDebugKotlin` 编译通过（仅有的 warning 来自无关的 `FavoriteListScreen`）
- 尚未在模拟器做视觉验证（需 GitHub 登录态）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在个人资料页面新增可导航的关注者、正在关注以及仓库列表视图，并使用支持分页的 GitHub 数据。

新功能：
- 在个人资料页头部新增可点击计数器，用于打开关注者、正在关注以及仓库列表页面。
- 新增专门的关注者/正在关注用户列表页面和仓库列表页面，这些页面由新的支持分页的 GitHub API 端点和对应的视图模型提供数据支持。
- 在个人资料中的仓库列表里点击仓库，可打开现有的应用内仓库详情视图；在关注者/正在关注列表中点击用户，可在浏览器中打开该用户的 GitHub 个人主页。

增强：
- 扩展共享的 GitHub API 层，为关注者、正在关注用户和拥有的仓库添加概要 DTO 和分页方法。
- 为新的个人资料列表添加用户可见的空状态、错误以及 fork 标签字符串，并提供英文和中文版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add navigable followers, following, and repository list views from the profile screen with paginated GitHub-backed data.

New Features:
- Introduce clickable counters on the profile header that open followers, following, and repository list pages.
- Add dedicated followers/following user list and repository list screens backed by new paginated GitHub API endpoints and view models.
- Allow tapping a repository in the profile repos list to open the existing in-app repo detail view, and tapping a user in followers/following to open their GitHub profile in a browser.

Enhancements:
- Extend the shared GitHub API layer with summary DTOs and pagination methods for followers, following users, and owned repositories.
- Add user-facing empty-state, error, and fork-label strings for the new profile lists in both English and Chinese.

</details>