### PR TITLE
feat(star): GitHub 仓库列表页与详情页支持一键 star

### DIFF
--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -84,7 +84,7 @@
     <string name="subscribe_not_subscribed">该邮箱未订阅</string>
     <string name="subscribe_error">网络错误，请稍后重试</string>
     <string name="view_on_github">在 GitHub 中查看</string>
-    <string name="share_to_ai">分享到 AI</string>
+    <string name="share_to_ai">分享</string>
     <string name="share_ai_text_full">请帮我解读这条技术资讯并提炼核心要点：\n\n标题：%1$s\n\n摘要：%2$s\n\n原文：%3$s</string>
     <string name="share_ai_text_brief">请帮我解读这条技术资讯并提炼核心要点：\n\n标题：%1$s\n\n原文：%2$s</string>
     <string name="readme_no_content">该仓库暂无 README 文件。</string>
@@ -107,6 +107,12 @@
     <string name="favorites_removed">已取消收藏</string>
     <string name="action_favorite">收藏</string>
     <string name="action_unfavorite">取消收藏</string>
+    <string name="action_star">Star</string>
+    <string name="action_unstar">取消 Star</string>
+    <string name="star_success">已 Star</string>
+    <string name="unstar_success">已取消 Star</string>
+    <string name="star_failed">操作失败，请重试</string>
+    <string name="star_need_login">登录后即可 Star 该仓库</string>
     <string name="favorites_delete_confirm">确定从收藏中移除？</string>
     <string name="theme_color">主题色</string>
     <string name="theme_color_default">默认紫</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -84,7 +84,7 @@
     <string name="subscribe_not_subscribed">This email is not subscribed</string>
     <string name="subscribe_error">Network error, please try again</string>
     <string name="view_on_github">View on GitHub</string>
-    <string name="share_to_ai">Share to AI</string>
+    <string name="share_to_ai">Share</string>
     <string name="share_ai_text_full">Please help me read and summarize this tech update:\n\nTitle: %1$s\n\nSummary: %2$s\n\nSource: %3$s</string>
     <string name="share_ai_text_brief">Please help me read and summarize this tech update:\n\nTitle: %1$s\n\nSource: %2$s</string>
     <string name="readme_no_content">No README found for this repository.</string>
@@ -107,6 +107,12 @@
     <string name="favorites_removed">Removed from favorites</string>
     <string name="action_favorite">Favorite</string>
     <string name="action_unfavorite">Unfavorite</string>
+    <string name="action_star">Star</string>
+    <string name="action_unstar">Unstar</string>
+    <string name="star_success">Starred</string>
+    <string name="unstar_success">Unstarred</string>
+    <string name="star_failed">Operation failed, please try again</string>
+    <string name="star_need_login">Sign in to star this repository</string>
     <string name="favorites_delete_confirm">Remove this item from favorites?</string>
     <string name="theme_color">Accent Color</string>
     <string name="theme_color_default">Default</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/auth/RepoStarService.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/auth/RepoStarService.kt
@@ -1,0 +1,52 @@
+package whl.trending.ai.auth
+
+import whl.trending.ai.data.remote.GithubApi
+
+/**
+ * GitHub 仓库 star / unstar 的共享业务逻辑：Trending 列表页与 README 详情页复用。
+ * 统一处理「取 GitHub token → 鉴权 → 调 API」，把结果归一为 [Result] 交由 UI 映射文案。
+ * token 经 [GithubTokenProvider] 从 Logto Secret Vault 取回，需含 `public_repo` scope 才能写 star。
+ */
+class RepoStarService(
+    private val githubApi: GithubApi = GithubApi(),
+    private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
+    private val authManager: () -> AuthManager = { globalAuthManager },
+) {
+    enum class Result { STARRED, UNSTARRED, NEED_LOGIN, FAILED }
+
+    /** 查询是否已 star；无 token（未登录/取不到）或查询失败时返回 null，UI 据此显示未点亮且不报错。 */
+    suspend fun isStarred(owner: String, repo: String): Boolean? {
+        val token = tokenProvider.get() ?: return null
+        return try {
+            githubApi.isStarred(token, owner, repo)
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            null
+        }
+    }
+
+    suspend fun star(owner: String, repo: String): Result = run(owner, repo, star = true)
+
+    suspend fun unstar(owner: String, repo: String): Result = run(owner, repo, star = false)
+
+    private suspend fun run(owner: String, repo: String, star: Boolean): Result {
+        val token = tokenProvider.get()
+        if (token == null) {
+            // 未登录 → 引导登录；已登录却取不到 token（Vault/网络问题）→ 普通失败
+            return if (authManager().authState.value is AuthState.LoggedIn) Result.FAILED
+            else Result.NEED_LOGIN
+        }
+        return try {
+            if (star) githubApi.starRepo(token, owner, repo)
+            else githubApi.unstarRepo(token, owner, repo)
+            if (star) Result.STARRED else Result.UNSTARRED
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            Result.FAILED
+        }
+    }
+
+    companion object {
+        val shared = RepoStarService()
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
@@ -4,9 +4,11 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
+import io.ktor.client.request.put
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
@@ -212,6 +214,44 @@ open class GithubApi {
             throw ApiException(response.status.value, response.bodyAsText())
         }
         return response.body<List<GithubRepoDto>>().map { it.fullName }
+    }
+
+    /**
+     * 查询当前用户是否已 star 某仓库：GET /user/starred/{owner}/{repo}。
+     * 204=已 star，404=未 star。需 token 含 `public_repo` scope，否则 GitHub 同样以 404 兜底。
+     */
+    open suspend fun isStarred(githubToken: String, owner: String, repo: String): Boolean {
+        val response = client.get("$baseHost/user/starred/$owner/$repo") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+        }
+        return when (response.status.value) {
+            in 200..299 -> true
+            404 -> false
+            else -> throw ApiException(response.status.value, response.bodyAsText())
+        }
+    }
+
+    /** 给仓库 star：PUT /user/starred/{owner}/{repo}，204 成功。空 body 由 Ktor 自动带 Content-Length: 0。 */
+    open suspend fun starRepo(githubToken: String, owner: String, repo: String) {
+        val response = client.put("$baseHost/user/starred/$owner/$repo") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+    }
+
+    /** 取消 star：DELETE /user/starred/{owner}/{repo}，204 成功。 */
+    open suspend fun unstarRepo(githubToken: String, owner: String, repo: String) {
+        val response = client.delete("$baseHost/user/starred/$owner/$repo") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
     }
 
     open suspend fun fetchRepoEvents(

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/ItemActionMenu.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/ItemActionMenu.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -23,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.action_favorite
+import trendingai.shared.generated.resources.action_star
 import trendingai.shared.generated.resources.action_unfavorite
 import trendingai.shared.generated.resources.share_to_ai
 
@@ -31,7 +33,9 @@ fun ItemActionMenu(
     isFavorite: Boolean,
     onToggle: () -> Unit,
     onShare: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    /** 非空时在菜单中显示「Star 到 GitHub」项（仅 GitHub 仓库场景传入），null 则不显示 */
+    onStar: (() -> Unit)? = null,
 ) {
     var expanded by remember { mutableStateOf(false) }
     Box(modifier) {
@@ -79,6 +83,18 @@ fun ItemActionMenu(
                     onShare()
                 }
             )
+            if (onStar != null) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(Res.string.action_star)) },
+                    leadingIcon = {
+                        Icon(Icons.Outlined.StarBorder, contentDescription = null)
+                    },
+                    onClick = {
+                        expanded = false
+                        onStar()
+                    }
+                )
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -28,10 +30,14 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -44,11 +50,19 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.action_star
+import trendingai.shared.generated.resources.action_unstar
 import trendingai.shared.generated.resources.back
 import trendingai.shared.generated.resources.readme_no_content
 import trendingai.shared.generated.resources.retry
 import trendingai.shared.generated.resources.share_to_ai
+import trendingai.shared.generated.resources.sign_in
+import trendingai.shared.generated.resources.star_failed
+import trendingai.shared.generated.resources.star_need_login
+import trendingai.shared.generated.resources.star_success
+import trendingai.shared.generated.resources.unstar_success
 import trendingai.shared.generated.resources.view_on_github
+import whl.trending.ai.auth.RepoStarService
 import whl.trending.ai.ui.common.aiShareText
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -76,7 +90,31 @@ fun ReadmeScreen(
     // README 摘录涉及多次正则替换，缓存结果避免每次重组重算（分享栏与 FAB 共用）
     val summary = remember(uiState.html) { readmeExcerpt(uiState.html) }
 
+    val snackbarHostState = remember { SnackbarHostState() }
+    val msgStarred = stringResource(Res.string.star_success)
+    val msgUnstarred = stringResource(Res.string.unstar_success)
+    val msgFailed = stringResource(Res.string.star_failed)
+    val msgNeedLogin = stringResource(Res.string.star_need_login)
+    val actionLogin = stringResource(Res.string.sign_in)
+    LaunchedEffect(Unit) {
+        viewModel.starEvents.collect { result ->
+            when (result) {
+                RepoStarService.Result.STARRED -> snackbarHostState.showSnackbar(msgStarred)
+                RepoStarService.Result.UNSTARRED -> snackbarHostState.showSnackbar(msgUnstarred)
+                RepoStarService.Result.FAILED -> snackbarHostState.showSnackbar(msgFailed)
+                RepoStarService.Result.NEED_LOGIN -> {
+                    val action = snackbarHostState.showSnackbar(
+                        message = msgNeedLogin,
+                        actionLabel = actionLogin,
+                    )
+                    if (action == SnackbarResult.ActionPerformed) viewModel.signIn()
+                }
+            }
+        }
+    }
+
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = {
@@ -95,6 +133,24 @@ fun ReadmeScreen(
                     }
                 },
                 actions = {
+                    if (uiState.starSupported) {
+                        IconButton(
+                            onClick = { viewModel.toggleStar() },
+                            enabled = !uiState.isStarLoading,
+                        ) {
+                            when {
+                                uiState.isStarLoading -> LoadingIndicator(modifier = Modifier.size(24.dp))
+                                uiState.isStarred == true -> Icon(
+                                    imageVector = Icons.Filled.Star,
+                                    contentDescription = stringResource(Res.string.action_unstar),
+                                )
+                                else -> Icon(
+                                    imageVector = Icons.Outlined.StarBorder,
+                                    contentDescription = stringResource(Res.string.action_star),
+                                )
+                            }
+                        }
+                    }
                     val shareContent = aiShareText("$owner/$repo", summary, repoUrl)
                     IconButton(onClick = {
                         shareText(shareContent)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeViewModel.kt
@@ -1,11 +1,17 @@
 package whl.trending.ai.ui.detail
 
+import whl.trending.ai.auth.AuthManager
+import whl.trending.ai.auth.RepoStarService
+import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.data.repository.TrendingRepository
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -13,21 +19,69 @@ import kotlinx.coroutines.launch
 data class ReadmeUiState(
     val html: String = "",
     val isLoading: Boolean = true,
-    val error: String? = null
+    val error: String? = null,
+    /** 当前平台是否支持 GitHub 登录（不支持则隐藏 star 按钮） */
+    val starSupported: Boolean = false,
+    /** 是否已 star；null=未知/未登录（显示空心星，点击引导登录） */
+    val isStarred: Boolean? = null,
+    /** star/unstar 请求进行中（按钮位显示加载指示） */
+    val isStarLoading: Boolean = false,
 )
 
 class ReadmeViewModel(
     private val owner: String,
     private val repo: String,
-    private val repository: TrendingRepository = TrendingRepository()
+    private val repository: TrendingRepository = TrendingRepository(),
+    private val starService: RepoStarService = RepoStarService.shared,
+    private val authManager: () -> AuthManager = { globalAuthManager },
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ReadmeUiState())
     val uiState: StateFlow<ReadmeUiState> = _uiState.asStateFlow()
 
+    /** star 操作结果一次性事件：UI 收到后弹 Snackbar */
+    private val _starEvents = MutableSharedFlow<RepoStarService.Result>(extraBufferCapacity = 1)
+    val starEvents: SharedFlow<RepoStarService.Result> = _starEvents.asSharedFlow()
+
     init {
         fetchReadme()
+        refreshStarState()
     }
+
+    /** 进入页面时查询初始 star 状态（已登录才查；无 token 时保持 null=空心星） */
+    private fun refreshStarState() {
+        if (!authManager().isSupported) return
+        _uiState.update { it.copy(starSupported = true) }
+        viewModelScope.launch {
+            val starred = starService.isStarred(owner, repo)
+            _uiState.update { it.copy(isStarred = starred) }
+        }
+    }
+
+    /** 切换 star 状态：请求完成后再更新图标（期间显示 loading），失败/需登录通过 [starEvents] 提示 */
+    fun toggleStar() {
+        val state = _uiState.value
+        if (state.isStarLoading) return
+        val currentlyStarred = state.isStarred == true
+        viewModelScope.launch {
+            _uiState.update { it.copy(isStarLoading = true) }
+            val result =
+                if (currentlyStarred) starService.unstar(owner, repo)
+                else starService.star(owner, repo)
+            when (result) {
+                RepoStarService.Result.STARRED ->
+                    _uiState.update { it.copy(isStarred = true, isStarLoading = false) }
+                RepoStarService.Result.UNSTARRED ->
+                    _uiState.update { it.copy(isStarred = false, isStarLoading = false) }
+                RepoStarService.Result.NEED_LOGIN,
+                RepoStarService.Result.FAILED ->
+                    _uiState.update { it.copy(isStarLoading = false) }
+            }
+            _starEvents.tryEmit(result)
+        }
+    }
+
+    fun signIn() = authManager().signIn()
 
     fun fetchReadme() {
         viewModelScope.launch {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
@@ -38,6 +38,9 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -47,6 +50,7 @@ import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -90,10 +94,16 @@ import trendingai.shared.generated.resources.period_monthly
 import trendingai.shared.generated.resources.period_weekly
 import trendingai.shared.generated.resources.retry
 import trendingai.shared.generated.resources.select_date
+import trendingai.shared.generated.resources.sign_in
+import trendingai.shared.generated.resources.star_failed
+import trendingai.shared.generated.resources.star_need_login
+import trendingai.shared.generated.resources.star_success
 import trendingai.shared.generated.resources.stars_period
 import trendingai.shared.generated.resources.stars_total
 import trendingai.shared.generated.resources.update_info_content
 import trendingai.shared.generated.resources.update_info_title
+import whl.trending.ai.auth.RepoStarService
+import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.core.DateTimeUtils
 import whl.trending.ai.core.platform.shareText
 import whl.trending.ai.core.platform.trackEvent
@@ -119,13 +129,44 @@ fun TrendingScreen(
     viewModel: TrendingViewModel = viewModel { TrendingViewModel() }
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    // GitHub 登录不被支持的平台（如 iOS NoopAuthManager）隐藏 star 入口
+    val starEnabled = remember { globalAuthManager.isSupported }
 
-    RepoList(
-        uiState = uiState,
-        modifier = modifier,
-        onRefresh = { viewModel.fetchData(isRefresh = true) },
-        onNavigateToDetail = onNavigateToDetail
-    )
+    val msgStarred = stringResource(Res.string.star_success)
+    val msgFailed = stringResource(Res.string.star_failed)
+    val msgNeedLogin = stringResource(Res.string.star_need_login)
+    val actionLogin = stringResource(Res.string.sign_in)
+    LaunchedEffect(Unit) {
+        viewModel.starEvents.collect { result ->
+            when (result) {
+                RepoStarService.Result.STARRED -> snackbarHostState.showSnackbar(msgStarred)
+                RepoStarService.Result.FAILED -> snackbarHostState.showSnackbar(msgFailed)
+                RepoStarService.Result.NEED_LOGIN -> {
+                    val action = snackbarHostState.showSnackbar(
+                        message = msgNeedLogin,
+                        actionLabel = actionLogin,
+                    )
+                    if (action == SnackbarResult.ActionPerformed) globalAuthManager.signIn()
+                }
+                RepoStarService.Result.UNSTARRED -> Unit // 列表页只 star，不触发取消
+            }
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        RepoList(
+            uiState = uiState,
+            modifier = Modifier.fillMaxSize(),
+            onRefresh = { viewModel.fetchData(isRefresh = true) },
+            onNavigateToDetail = onNavigateToDetail,
+            onStarRepo = if (starEnabled) viewModel::starRepo else null,
+        )
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
 
     if (showFilterSheet) {
         FilterBottomSheet(
@@ -172,7 +213,9 @@ private fun RepoList(
     uiState: TrendingUiState,
     modifier: Modifier = Modifier,
     onRefresh: () -> Unit,
-    onNavigateToDetail: (owner: String, repo: String) -> Unit
+    onNavigateToDetail: (owner: String, repo: String) -> Unit,
+    /** 非空时列表项菜单显示「Star 到 GitHub」，null（不支持登录的平台）则隐藏 */
+    onStarRepo: ((TrendingRepo) -> Unit)? = null,
 ) {
     val state = rememberPullToRefreshState()
 
@@ -235,6 +278,7 @@ private fun RepoList(
                         repo = repo,
                         since = uiState.since,
                         isFavorite = repo.url in favoriteUrls,
+                        onStar = onStarRepo?.let { star -> { star(repo) } },
                         onToggleFavorite = {
                             if (repo.url in favoriteUrls) {
                                 globalSettingsManager.removeFavorite(repo.url)
@@ -283,7 +327,7 @@ private fun RepoList(
 }
 
 @Composable
-private fun RepoItem(index: Int, repo: TrendingRepo, since: String, isFavorite: Boolean, onToggleFavorite: () -> Unit, onClick: () -> Unit) {
+private fun RepoItem(index: Int, repo: TrendingRepo, since: String, isFavorite: Boolean, onToggleFavorite: () -> Unit, onClick: () -> Unit, onStar: (() -> Unit)? = null) {
     Row(
         modifier = Modifier
             .clickable { onClick() }
@@ -354,7 +398,8 @@ private fun RepoItem(index: Int, repo: TrendingRepo, since: String, isFavorite: 
                                 "from" to "list"
                             )
                         )
-                    }
+                    },
+                    onStar = onStar,
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingViewModel.kt
@@ -1,8 +1,10 @@
 package whl.trending.ai.ui.trending
 
+import whl.trending.ai.auth.RepoStarService
 import whl.trending.ai.data.model.TrendingRepo
 import whl.trending.ai.data.repository.TrendingRepository
 import whl.trending.ai.core.DateTimeUtils
+import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.core.platform.getSystemLanguage
@@ -11,8 +13,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
@@ -34,10 +39,15 @@ data class TrendingUiState(
 
 class TrendingViewModel(
     private val repository: TrendingRepository = TrendingRepository(),
-    private val settingsManager: SettingsManager = globalSettingsManager
+    private val settingsManager: SettingsManager = globalSettingsManager,
+    private val starService: RepoStarService = RepoStarService.shared,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(TrendingUiState())
     val uiState: StateFlow<TrendingUiState> = _uiState.asStateFlow()
+
+    /** star 操作结果一次性事件：UI 收到后弹 Snackbar（成功/失败/需登录） */
+    private val _starEvents = MutableSharedFlow<RepoStarService.Result>(extraBufferCapacity = 1)
+    val starEvents: SharedFlow<RepoStarService.Result> = _starEvents.asSharedFlow()
 
     private var fetchJob: Job? = null
 
@@ -92,6 +102,23 @@ class TrendingViewModel(
                         error = e.message ?: "Unknown Error"
                     )
                 }
+            }
+        }
+    }
+
+    /**
+     * 列表页 star：仅做「点 star」（不展示已 star 状态，避免逐项查询）。GitHub PUT 幂等，
+     * 已 star 再点也安全。结果通过 [starEvents] 通知 UI。
+     */
+    fun starRepo(repo: TrendingRepo) {
+        viewModelScope.launch {
+            val result = starService.star(repo.author, repo.repoName)
+            _starEvents.tryEmit(result)
+            if (result == RepoStarService.Result.STARRED) {
+                trackEvent(
+                    "repo_star",
+                    mapOf("source" to "github", "from" to "list")
+                )
             }
         }
     }


### PR DESCRIPTION
## 背景
为 GitHub Trending 列表页和仓库详情页增加 star 能力，登录用户可直接给仓库点 star。

## 改动
**网络层**
- `GithubApi` 新增 `starRepo` / `unstarRepo` / `isStarred`（`PUT`/`DELETE`/`GET /user/starred/{owner}/{repo}`，`404` 视为未 star、非错误）
- 新增 `RepoStarService`：封装「取 GitHub token → 鉴权 → 调用」，列表页与详情页复用；结果归一为 `STARRED / UNSTARRED / NEED_LOGIN / FAILED`，由 UI 映射文案

**详情页（有状态）**
- TopBar 加 star 按钮：进页查询 `isStarred`，实心/空心切换，请求中显示 `LoadingIndicator`，成功/失败/需登录用 Snackbar 反馈（需登录带「登录」操作）

**列表页（无状态，即发即忘）**
- 项菜单加「Star」项：幂等 star（GitHub PUT 幂等），**不逐项查询状态**以避免 N 次请求；Snackbar 反馈，未登录引导登录
- 设计权衡见讨论：列表与「今日热门」的已 star 交集通常很小，逐项查状态成本中等收益低，故列表只 star、不展示状态；有状态需求由详情页承接

**文案**
- 菜单三项统一为裸动词：**收藏 / 分享 / Star**（去掉「到 AI」「到 GitHub」冗余后缀，图标承载语义）

**平台**
- 不支持 GitHub 登录的平台（iOS `NoopAuthManager`）自动隐藏 star 入口

## ⚠️ 上线前置（后端配置，不在本仓库）
star 写操作需要 GitHub token 带 `public_repo` scope。**已在 Logto 后台给 GitHub 社交连接器的 Scope 加上 `public_repo`**（原本为空，只读）。新登录用户授权后即带该 scope；本功能尚未上线，无需考虑老用户重授权。

## 验证
- 模拟器手动验证：详情页 star 可点亮 + 「已 Star」、可取消；列表页菜单「Star」生效（需以带 `public_repo` 的新 token 登录）。
- 读 token 路径不变（Profile 计数正常），star 仅依赖新增的写 scope。

## 备注（已记录、本 PR 不处理）
排查中发现 Logto 3.0.0-beta 登录在 Custom Tab 被系统回收时，取消路径无法自愈、`authState` 可能卡在 `LoggingIn`（头像一直 loading）。属 SDK 缺口、小概率，按决定暂不在客户端加兜底，后续可上报上游。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在趋势列表和仓库详情页中添加 GitHub 仓库加星功能，包括共享的加星业务逻辑和用户反馈。

新功能：
- 当支持 GitHub 登录时，允许用户通过条目操作菜单中的一项条目，直接从趋势列表中为 GitHub 仓库加星。
- 在仓库详情（README）顶部栏中提供一个加星/取消加星控件，用于反映当前加星状态并允许切换。

改进：
- 引入共享的 `RepoStarService`，封装 GitHub 的加星/取消加星/是否已加星 API 调用、令牌获取和鉴权检查，并提供统一的结果类型以供 UI 使用。
- 将条目操作菜单标签更新为更简洁的动词，并在适用位置加入 GitHub 加星选项。
- 在列表和详情视图中为加星操作显示上下文提示条（snackbar），包括带有内联登录操作的登录提示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add GitHub repository starring support to the trending list and repository detail pages, including shared star business logic and user feedback.

New Features:
- Allow users to star GitHub repositories directly from the trending list via an item action menu entry when GitHub login is supported.
- Expose a star/unstar control in the repository detail (README) top bar that reflects current star status and allows toggling it.

Enhancements:
- Introduce a shared RepoStarService that encapsulates GitHub star/unstar/is-starred API calls, token retrieval, and auth checks with unified result types for UI consumption.
- Update item action menu labels to concise verbs and add a GitHub star option where applicable.
- Show contextual snackbars for star operations across list and detail views, including login prompts with inline sign-in actions.

</details>