### PR TITLE
feat(profile): 个人主页新增 GitHub 贡献热力图

### DIFF
--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -139,6 +139,10 @@
     <string name="profile_followers">粉丝</string>
     <string name="profile_following">关注</string>
     <string name="profile_repos">仓库</string>
+    <string name="contrib_total">最近一年 %1$s 次贡献</string>
+    <string name="contrib_less">少</string>
+    <string name="contrib_more">多</string>
+    <string name="contrib_months">1月,2月,3月,4月,5月,6月,7月,8月,9月,10月,11月,12月</string>
     <string name="list_load_failed">加载失败</string>
     <string name="list_empty_followers">还没有粉丝</string>
     <string name="list_empty_following">还没有关注任何人</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -143,6 +143,9 @@
     <string name="contrib_less">少</string>
     <string name="contrib_more">多</string>
     <string name="contrib_months">1月,2月,3月,4月,5月,6月,7月,8月,9月,10月,11月,12月</string>
+    <string name="contrib_weekday_mon">周一</string>
+    <string name="contrib_weekday_wed">周三</string>
+    <string name="contrib_weekday_fri">周五</string>
     <string name="list_load_failed">加载失败</string>
     <string name="list_empty_followers">还没有粉丝</string>
     <string name="list_empty_following">还没有关注任何人</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -143,6 +143,9 @@
     <string name="contrib_less">Less</string>
     <string name="contrib_more">More</string>
     <string name="contrib_months">Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec</string>
+    <string name="contrib_weekday_mon">Mon</string>
+    <string name="contrib_weekday_wed">Wed</string>
+    <string name="contrib_weekday_fri">Fri</string>
     <string name="list_load_failed">Failed to load</string>
     <string name="list_empty_followers">No followers yet</string>
     <string name="list_empty_following">Not following anyone yet</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -139,6 +139,10 @@
     <string name="profile_followers">Followers</string>
     <string name="profile_following">Following</string>
     <string name="profile_repos">Repos</string>
+    <string name="contrib_total">%1$s contributions in the last year</string>
+    <string name="contrib_less">Less</string>
+    <string name="contrib_more">More</string>
+    <string name="contrib_months">Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec</string>
     <string name="list_load_failed">Failed to load</string>
     <string name="list_empty_followers">No followers yet</string>
     <string name="list_empty_following">Not following anyone yet</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/Contribution.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/Contribution.kt
@@ -1,0 +1,46 @@
+package whl.trending.ai.data.model
+
+/**
+ * GitHub 贡献日历（绿色热力图）的干净领域模型。
+ * 数据仅来自 GitHub GraphQL API（REST 不暴露 contribution calendar），
+ * UI 只依赖本模型，与 GraphQL 响应的深层嵌套结构解耦。
+ */
+data class ContributionCalendar(
+    /** 最近一年的总贡献数 */
+    val total: Int,
+    /** 按周分组，每周含 7 天（首尾周可能不足 7 天） */
+    val weeks: List<ContributionWeek>,
+)
+
+data class ContributionWeek(
+    val days: List<ContributionDay>,
+)
+
+data class ContributionDay(
+    /** ISO 日期，如 "2026-06-23" */
+    val date: String,
+    /** 0=周日 … 6=周六，对齐 GitHub */
+    val weekday: Int,
+    val count: Int,
+    val level: ContributionLevel,
+)
+
+/** GitHub 直接返回的五档强度，省得自算分位；UI 据此映射颜色深浅。 */
+enum class ContributionLevel {
+    NONE,
+    FIRST,
+    SECOND,
+    THIRD,
+    FOURTH;
+
+    companion object {
+        /** 映射 GraphQL 的 contributionLevel 枚举字符串；未知值兜底为 NONE。 */
+        fun fromRaw(raw: String): ContributionLevel = when (raw) {
+            "FIRST_QUARTILE" -> FIRST
+            "SECOND_QUARTILE" -> SECOND
+            "THIRD_QUARTILE" -> THIRD
+            "FOURTH_QUARTILE" -> FOURTH
+            else -> NONE
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
@@ -18,6 +18,7 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
@@ -145,6 +146,9 @@ open class GithubApi {
     }
 
     private val baseHost = "https://api.github.com"
+
+    /** GraphQL 错误路径需手动解码（只读一次 body），与 client 的 ContentNegotiation 共用同一解析策略 */
+    private val graphQlJson = Json { ignoreUnknownKeys = true }
 
     open suspend fun fetchUser(githubToken: String): GithubUser {
         val response = client.get("$baseHost/user") {
@@ -319,12 +323,14 @@ open class GithubApi {
                 put("variables", buildJsonObject { put("login", login) })
             })
         }
+        // Ktor 响应 body 一次性，只读一次 raw：非 2xx 与「2xx 但 calendar 缺失」两条错误路径复用同一份
+        val raw = response.bodyAsText()
         if (response.status.value !in 200..299) {
-            throw ApiException(response.status.value, response.bodyAsText())
+            throw ApiException(response.status.value, raw)
         }
-        val calendar = response.body<ContributionEnvelope>()
+        val calendar = graphQlJson.decodeFromString<ContributionEnvelope>(raw)
             .data?.user?.collection?.calendar
-            ?: throw ApiException(response.status.value, response.bodyAsText())
+            ?: throw ApiException(response.status.value, "GraphQL 响应缺少 contributionCalendar: ${raw.take(300)}")
         return ContributionCalendar(
             total = calendar.total,
             weeks = calendar.weeks.map { week ->

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
@@ -8,14 +8,24 @@ import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
+import io.ktor.client.request.post
 import io.ktor.client.request.put
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import whl.trending.ai.data.model.ContributionCalendar
+import whl.trending.ai.data.model.ContributionDay
+import whl.trending.ai.data.model.ContributionLevel
+import whl.trending.ai.data.model.ContributionWeek
 
 @Serializable
 data class GithubFollowing(
@@ -79,6 +89,47 @@ data class GithubEventDto(
     val payload: JsonElement? = null,
     @SerialName("created_at") val createdAt: String,
 )
+
+// --- GraphQL: contribution calendar（REST 不暴露，仅 GraphQL 可取）---
+
+@Serializable
+private data class ContributionEnvelope(val data: ContributionData? = null)
+
+@Serializable
+private data class ContributionData(val user: ContributionUserDto? = null)
+
+@Serializable
+private data class ContributionUserDto(
+    @SerialName("contributionsCollection") val collection: ContributionCollectionDto? = null,
+)
+
+@Serializable
+private data class ContributionCollectionDto(
+    @SerialName("contributionCalendar") val calendar: ContributionCalendarDto? = null,
+)
+
+@Serializable
+private data class ContributionCalendarDto(
+    @SerialName("totalContributions") val total: Int = 0,
+    val weeks: List<ContributionWeekDto> = emptyList(),
+)
+
+@Serializable
+private data class ContributionWeekDto(
+    @SerialName("contributionDays") val days: List<ContributionDayDto> = emptyList(),
+)
+
+@Serializable
+private data class ContributionDayDto(
+    val date: String,
+    val weekday: Int = 0,
+    @SerialName("contributionCount") val count: Int = 0,
+    @SerialName("contributionLevel") val level: String = "NONE",
+)
+
+private const val CONTRIBUTION_QUERY =
+    "query(\$login:String!){user(login:\$login){contributionsCollection{contributionCalendar{" +
+        "totalContributions weeks{contributionDays{date weekday contributionCount contributionLevel}}}}}}"
 
 /** GitHub REST 直连：feed 与计数。token 来自 GithubTokenProvider（Secret Vault 取回）。 */
 open class GithubApi {
@@ -252,6 +303,43 @@ open class GithubApi {
         if (response.status.value !in 200..299) {
             throw ApiException(response.status.value, response.bodyAsText())
         }
+    }
+
+    /**
+     * 最近一年的贡献日历（绿色热力图）。GitHub REST 不暴露此数据，走 GraphQL。
+     * 不传时间范围即默认最近 365 天，对齐 GitHub 个人主页默认视图。
+     */
+    open suspend fun fetchContributionCalendar(githubToken: String, login: String): ContributionCalendar {
+        val response = client.post("$baseHost/graphql") {
+            header(HttpHeaders.Authorization, "Bearer $githubToken")
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+            contentType(ContentType.Application.Json)
+            setBody(buildJsonObject {
+                put("query", CONTRIBUTION_QUERY)
+                put("variables", buildJsonObject { put("login", login) })
+            })
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        val calendar = response.body<ContributionEnvelope>()
+            .data?.user?.collection?.calendar
+            ?: throw ApiException(response.status.value, response.bodyAsText())
+        return ContributionCalendar(
+            total = calendar.total,
+            weeks = calendar.weeks.map { week ->
+                ContributionWeek(
+                    days = week.days.map { day ->
+                        ContributionDay(
+                            date = day.date,
+                            weekday = day.weekday,
+                            count = day.count,
+                            level = ContributionLevel.fromRaw(day.level),
+                        )
+                    },
+                )
+            },
+        )
     }
 
     open suspend fun fetchRepoEvents(

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ContributionGraph.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ContributionGraph.kt
@@ -39,6 +39,9 @@ import trendingai.shared.generated.resources.contrib_less
 import trendingai.shared.generated.resources.contrib_months
 import trendingai.shared.generated.resources.contrib_more
 import trendingai.shared.generated.resources.contrib_total
+import trendingai.shared.generated.resources.contrib_weekday_fri
+import trendingai.shared.generated.resources.contrib_weekday_mon
+import trendingai.shared.generated.resources.contrib_weekday_wed
 import whl.trending.ai.core.DateTimeUtils
 import whl.trending.ai.data.model.ContributionCalendar
 import whl.trending.ai.data.model.ContributionLevel
@@ -134,7 +137,15 @@ fun ContributionGraph(
 @Composable
 private fun WeekdayLabels() {
     // 行序对齐 GitHub：0=Sun(空) 1=Mon 2=Tue(空) 3=Wed 4=Thu(空) 5=Fri 6=Sat(空)
-    val labels = listOf("", "Mon", "", "Wed", "", "Fri", "")
+    val labels = listOf(
+        "",
+        stringResource(Res.string.contrib_weekday_mon),
+        "",
+        stringResource(Res.string.contrib_weekday_wed),
+        "",
+        stringResource(Res.string.contrib_weekday_fri),
+        "",
+    )
     Column(
         modifier = Modifier.width(WeekdayLabelWidth).padding(top = MonthLabelHeight, end = 4.dp),
         verticalArrangement = Arrangement.spacedBy(CellGap),

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ContributionGraph.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ContributionGraph.kt
@@ -1,0 +1,256 @@
+package whl.trending.ai.ui.profile
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.contrib_less
+import trendingai.shared.generated.resources.contrib_months
+import trendingai.shared.generated.resources.contrib_more
+import trendingai.shared.generated.resources.contrib_total
+import whl.trending.ai.core.DateTimeUtils
+import whl.trending.ai.data.model.ContributionCalendar
+import whl.trending.ai.data.model.ContributionLevel
+import whl.trending.ai.data.model.ContributionWeek
+
+private val CellSize = 11.dp
+private val CellGap = 3.dp
+private val WeekdayLabelWidth = 28.dp
+private val MonthLabelHeight = 16.dp
+
+// 配色方案 A：保留 GitHub 风格绿色梯度，辨识度最高（"一眼就是贡献图"）。
+// NONE 档用主题色融入背景，L1~L4 用 GitHub 明/暗两套绿阶。
+private val GreensLight = listOf(
+    Color(0xFF9BE9A8),
+    Color(0xFF40C463),
+    Color(0xFF30A14E),
+    Color(0xFF216E39),
+)
+private val GreensDark = listOf(
+    Color(0xFF0E4429),
+    Color(0xFF006D32),
+    Color(0xFF26A641),
+    Color(0xFF39D353),
+)
+
+/**
+ * GitHub 风格贡献热力图（52~53 周 × 7 天）。横向可滚动看满一年，左侧 Mon/Wed/Fri 标签固定。
+ * 仅在数据可用时渲染（[calendar] 由调用方判空后传入）。
+ */
+@Composable
+fun ContributionGraph(
+    calendar: ContributionCalendar,
+    // 滚动状态由调用方（ProfileScreen）持有：放在被 LazyColumn 回收的 item 内部会随上下滚动
+    // 销毁重建、位置被重置到最左，故上提到不随 item 回收的作用域
+    scrollState: ScrollState,
+    modifier: Modifier = Modifier,
+) {
+    val dark = isSystemInDarkTheme()
+    val greens = if (dark) GreensDark else GreensLight
+    val noneColor = MaterialTheme.colorScheme.surfaceContainerHighest
+
+    fun levelColor(level: ContributionLevel): Color = when (level) {
+        ContributionLevel.NONE -> noneColor
+        ContributionLevel.FIRST -> greens[0]
+        ContributionLevel.SECOND -> greens[1]
+        ContributionLevel.THIRD -> greens[2]
+        ContributionLevel.FOURTH -> greens[3]
+    }
+
+    val monthNames = stringResource(Res.string.contrib_months).split(",")
+    // 每周首格对应的月份索引（1~12）；用于在月份切换处打标签
+    val monthLabels = remember(calendar) { computeMonthLabels(calendar.weeks) }
+
+    // 默认滚动到最右（最新一周），且仅在首次布局后执行一次：用持久化 flag 锁定，
+    // 否则热力图每次重新进入可视区都会被强拉到末尾、覆盖用户手动滚动的位置
+    var didAutoScroll by rememberSaveable { mutableStateOf(false) }
+    LaunchedEffect(scrollState.maxValue) {
+        if (!didAutoScroll && scrollState.maxValue > 0) {
+            scrollState.scrollTo(scrollState.maxValue)
+            didAutoScroll = true
+        }
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            stringResource(Res.string.contrib_total, DateTimeUtils.formatNumber(calendar.total)),
+            style = MaterialTheme.typography.titleSmall,
+        )
+
+        Row {
+            // 固定的左侧 Mon/Wed/Fri 标签（与网格 7 行对齐）
+            WeekdayLabels()
+            // 网格本体：横向滚动
+            Column(
+                modifier = Modifier.horizontalScroll(scrollState),
+            ) {
+                MonthLabelsRow(monthLabels, monthNames)
+                Row(horizontalArrangement = Arrangement.spacedBy(CellGap)) {
+                    calendar.weeks.forEach { week ->
+                        WeekColumn(week) { levelColor(it) }
+                    }
+                }
+            }
+        }
+
+        Legend(noneColor = noneColor, greens = greens)
+    }
+}
+
+@Composable
+private fun WeekdayLabels() {
+    // 行序对齐 GitHub：0=Sun(空) 1=Mon 2=Tue(空) 3=Wed 4=Thu(空) 5=Fri 6=Sat(空)
+    val labels = listOf("", "Mon", "", "Wed", "", "Fri", "")
+    Column(
+        modifier = Modifier.width(WeekdayLabelWidth).padding(top = MonthLabelHeight, end = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(CellGap),
+    ) {
+        labels.forEach { label ->
+            Box(Modifier.height(CellSize), contentAlignment = Alignment.CenterEnd) {
+                if (label.isNotEmpty()) {
+                    Text(
+                        label,
+                        fontSize = 9.sp,
+                        lineHeight = 9.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        softWrap = false,
+                        overflow = TextOverflow.Visible,
+                        // 文字行高大于格高，允许溢出 Box 并居中，避免被裁掉上下沿
+                        modifier = Modifier.wrapContentSize(unbounded = true),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MonthLabelsRow(monthLabels: List<Int?>, monthNames: List<String>) {
+    Row(
+        modifier = Modifier.height(MonthLabelHeight),
+        horizontalArrangement = Arrangement.spacedBy(CellGap),
+    ) {
+        monthLabels.forEach { month ->
+            Box(Modifier.width(CellSize)) {
+                if (month != null) {
+                    val name = monthNames.getOrNull(month - 1) ?: ""
+                    Text(
+                        name,
+                        fontSize = 9.sp,
+                        lineHeight = 12.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        softWrap = false,
+                        overflow = TextOverflow.Visible,
+                        // 让月份名从本列起向右溢出到相邻空列上方，不被本列 11dp 宽度裁掉
+                        modifier = Modifier.wrapContentWidth(align = Alignment.Start, unbounded = true),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WeekColumn(week: ContributionWeek, colorOf: (ContributionLevel) -> Color) {
+    Column(verticalArrangement = Arrangement.spacedBy(CellGap)) {
+        // 按 weekday 0~6 补齐 7 行；首尾周缺失的日期渲染为透明占位，保持网格对齐
+        for (weekday in 0..6) {
+            val day = week.days.firstOrNull { it.weekday == weekday }
+            Box(
+                Modifier
+                    .size(CellSize)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(if (day == null) Color.Transparent else colorOf(day.level)),
+            )
+        }
+    }
+}
+
+@Composable
+private fun Legend(noneColor: Color, greens: List<Color>) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            stringResource(Res.string.contrib_less),
+            fontSize = 9.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.width(4.dp))
+        (listOf(noneColor) + greens).forEach { color ->
+            Box(
+                Modifier
+                    .padding(horizontal = 1.dp)
+                    .size(CellSize)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(color),
+            )
+        }
+        Spacer(Modifier.width(4.dp))
+        Text(
+            stringResource(Res.string.contrib_more),
+            fontSize = 9.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/**
+ * 计算每周列上方应显示的月份标签。规则对齐 GitHub：当某周首日的月份与上一周不同，
+ * 在该列打出新月份；否则留空（null）。
+ */
+private fun computeMonthLabels(weeks: List<ContributionWeek>): List<Int?> {
+    var prevMonth = -1
+    return weeks.map { week ->
+        val firstDate = week.days.firstOrNull()?.date
+        val month = firstDate?.let { monthOf(it) }
+        if (month != null && month != prevMonth) {
+            prevMonth = month
+            month
+        } else {
+            null
+        }
+    }
+}
+
+/** 从 "YYYY-MM-DD" 取月份（1~12）；解析失败返回 null。 */
+private fun monthOf(date: String): Int? =
+    date.substringAfter('-', "").substringBefore('-', "").toIntOrNull()

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -117,17 +116,17 @@ fun ProfileScreen(
 ) {
     val viewModel: ProfileViewModel = viewModel { ProfileViewModel() }
     val uiState by viewModel.uiState.collectAsState()
-    // nav3 默认无 per-entry VM 作用域，VM 是 Activity 级缓存；每次进入本页全量重载，
-    // 避免登出换账号串号 / feed 失败态永久残留
+    // nav3 默认无 per-entry VM 作用域，VM 是 Activity 级缓存。load() 自身幂等：
+    // 首次进入加载，从 followers/following/repos 子页返回时跳过重拉（数据仍在 VM state 里）；
+    // 换账号串号由 VM 内 authState 监听兜底（登出即清空并复位）。
     LaunchedEffect(Unit) {
         viewModel.load()
     }
-    // 离开页面即清空缓存 VM 的状态，避免再次进入时首帧先闪出上次的旧数据
-    DisposableEffect(Unit) {
-        onDispose { viewModel.onLeave() }
-    }
     val uriHandler = LocalUriHandler.current
     val listState = rememberLazyListState()
+    // 贡献热力图横向滚动状态：持有在此（不随 LazyColumn item 回收销毁），
+    // 否则上下滚动时热力图位置会被重置到最左
+    val contributionScrollState = rememberScrollState()
     val pullToRefreshState = rememberPullToRefreshState()
     val onSignOut = { viewModel.signOut(); onBack() }
     var showRulesSheet by remember { mutableStateOf(false) }
@@ -206,6 +205,12 @@ fun ProfileScreen(
                         onOpenFollowing = onOpenFollowing,
                         onOpenRepos = onOpenRepos,
                     )
+                }
+                uiState.contributions?.let { calendar ->
+                    item(key = "contributions") {
+                        ContributionGraph(calendar, scrollState = contributionScrollState)
+                        HorizontalDivider(thickness = 0.5.dp)
+                    }
                 }
                 item(key = "feed_filter") {
                     Row(

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -6,8 +6,10 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import whl.trending.ai.auth.AuthManager
+import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.FollowingInfo
 import whl.trending.ai.auth.FollowingProvider
 import whl.trending.ai.auth.GithubTokenProvider
@@ -15,6 +17,7 @@ import whl.trending.ai.auth.OwnRepoEventsProvider
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.model.ContributionCalendar
 import whl.trending.ai.data.model.MeUser
 import whl.trending.ai.data.remote.GithubApi
 import whl.trending.ai.data.remote.GithubUser
@@ -33,6 +36,8 @@ data class ProfileUiState(
     val isError: Boolean = false,
     /** GitHub 实时计数；token 不可用或请求失败时为 null（UI 隐藏计数行） */
     val githubUser: GithubUser? = null,
+    /** 最近一年贡献日历；加载中或不可用时为 null（UI 隐藏热力图） */
+    val contributions: ContributionCalendar? = null,
     val feedItems: List<GithubFeedItem> = emptyList(),
     val isFeedLoading: Boolean = false,
     val feedEndReached: Boolean = false,
@@ -76,7 +81,31 @@ class ProfileViewModel(
     /** 规则3：我的仓库上别人的 star/fork（精选档合流，load() 时重置） */
     private var ownRepoItems: List<GithubFeedItem> = emptyList()
 
+    /**
+     * 是否已成功加载过当前账号的数据。VM 是 Activity 级缓存，下钻 followers/following/repos
+     * 子页再返回时 [load] 据此跳过重拉（数据仍在 state 里），避免无谓的整页重载。
+     * 登出（authState→LoggedOut）时复位，确保换账号后重新加载。
+     */
+    private var hasLoaded = false
+
+    init {
+        // 监听登出：清空缓存数据并复位 hasLoaded，兜底换账号串号
+        viewModelScope.launch {
+            authManager().authState.collect { state ->
+                if (state is AuthState.LoggedOut) {
+                    hasLoaded = false
+                    loadJob?.cancel()
+                    feedLoadJob?.cancel()
+                    _uiState.value = ProfileUiState()
+                }
+            }
+        }
+    }
+
     fun load() {
+        // 已加载过且数据健在（非错误态）则跳过：用于从子页返回时不重拉
+        val current = _uiState.value
+        if (hasLoaded && current.user != null && !current.isError) return
         loadJob?.cancel()
         feedLoadJob?.cancel()
         loadJob = viewModelScope.launch {
@@ -99,6 +128,7 @@ class ProfileViewModel(
                 return@launch
             }
             _uiState.value = ProfileUiState(isLoading = false, user = user, highlightsOnly = highlightsOnly)
+            hasLoaded = true
             loadGithubData(user)
         }
     }
@@ -116,6 +146,16 @@ class ProfileViewModel(
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             // 计数失败不致命，feed 继续尝试
+        }
+
+        // 贡献热力图：与 feed 并行拉取，失败仅隐藏，不影响 feed
+        viewModelScope.launch {
+            try {
+                val calendar = githubApi.fetchContributionCalendar(githubToken, login)
+                _uiState.value = _uiState.value.copy(contributions = calendar)
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+            }
         }
 
         // 拉取关注列表（失败降级为 null，保留旧行为）
@@ -242,6 +282,7 @@ class ProfileViewModel(
                 feedItems = emptyList(),
                 feedEndReached = false,
                 feedUnavailable = false,
+                contributions = null,
             )
             loadGithubData(user)
         }
@@ -261,17 +302,6 @@ class ProfileViewModel(
             highlightsOnly = highlightsOnly,
         )
         loadMoreFeed()
-    }
-
-    /**
-     * 离开页面时调用：取消在途加载并把状态重置为初始加载态。
-     * VM 是 Activity 级缓存（复用同一实例），不清理会在重新进入页面时先闪出上次的旧数据，
-     * 之后才被 [load] 异步重置。离开时同步清掉，使下次进入的首帧即为初始 loading 态。
-     */
-    fun onLeave() {
-        loadJob?.cancel()
-        feedLoadJob?.cancel()
-        _uiState.value = ProfileUiState()
     }
 
     fun signOut() = authManager().signOut()


### PR DESCRIPTION
## 概述

在个人主页 Header 下方新增最近一年的 GitHub 贡献热力图（GitHub 风格绿色日历），并顺带修复 Profile 子页返回时整页重载的问题。

## 改动

### 贡献热力图（新功能）
- **数据通道**：新增 `GithubApi.fetchContributionCalendar()` 走 GitHub **GraphQL**（REST 不暴露贡献日历），复用现有 GitHub OAuth token，**无需新增 scope**；私有 DTO 接收深层嵌套响应后映射为干净领域模型。
- **领域模型**（新文件 `data/model/Contribution.kt`）：`ContributionCalendar / Week / Day` + `ContributionLevel` 五档枚举（直接用 GitHub 返回的 `contributionLevel`，不自算分位）。
- **ViewModel**：`ProfileUiState` 增加 `contributions`，在 `loadGithubData()` 中与 feed **并行**拉取，失败仅隐藏不影响 feed；下拉刷新一并重置重拉。
- **UI**（新文件 `ui/profile/ContributionGraph.kt`）：自绘 52~53 周 × 7 天网格，配色保留 GitHub 绿色五档梯度（明/暗各一套，NONE 用主题色融入背景），横向可滚动、左侧 Mon/Wed/Fri 与顶部月份标签、底部「少 ▢▢▢▢▢ 多」图例；**默认滚到最新一周**，横向位置在上下滚动 / 子页返回时保持不丢。
- **文案**：en/zh 各新增 `contrib_total / contrib_less / contrib_more / contrib_months`。

### 顺带修复
- `ProfileViewModel.load()` 改为**幂等**：从 followers/following/repos 子页返回时跳过整页重载（数据仍在 Activity 级缓存的 VM 里）；换账号串号由新增的 `authState` 监听兜底（登出 `LoggedOut` 即清空 state 并复位 `hasLoaded`）。移除了下钻时清空 state 的 `onLeave()`。

## 验证

实机 Pixel 9 (2) 模拟器：
- ✅ 进页面自动滚到最新；月份/周文字完整显示（不再裁切）
- ✅ 横向滚到中间 → 上下滚动列表使热力图移出再回来 → 位置保留
- ✅ 点「关注」进子页再返回 → 无 loading 转圈、无重拉，数据即时呈现
- ✅ `:androidApp:compileGithubDebugKotlin` 编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在个人资料页面添加类似 GitHub 的贡献热力图，并使个人资料加载过程具备幂等性，以避免从子页面返回时出现不必要的重新加载。

新功能：
- 暴露一个新的 `GithubApi` 端点和领域模型，用于通过 GitHub GraphQL 获取用户年度贡献日历。
- 在个人资料页面渲染 GitHub 风格的贡献热力图，包括总数、星期/月份标签，以及使用本地化字符串的图例文本。

错误修复：
- 使 `ProfileViewModel` 的加载具备幂等性，并在登出时重置状态，防止从粉丝/关注/仓库等子页面返回时出现整页重新加载和陈旧数据。

改进：
- 更新 `ProfileViewModel` 和 `ProfileScreen`，使其在加载动态(feed)数据的同时加载 GitHub 贡献数据，并在垂直滚动时保持热力图的滚动位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a GitHub-style contribution heatmap to the profile screen and make profile loading idempotent to avoid unnecessary reloads when returning from subpages.

New Features:
- Expose a new GithubApi endpoint and domain models for fetching a user’s yearly contribution calendar via GitHub GraphQL.
- Render a GitHub-style contribution heatmap on the profile screen, including totals, weekday/month labels, and legend text with localized strings.

Bug Fixes:
- Make ProfileViewModel loading idempotent and reset state on logout to prevent full-page reloads and stale data when navigating back from followers/following/repos subpages.

Enhancements:
- Update ProfileViewModel and ProfileScreen to load GitHub contributions alongside feed data and to persist the heatmap scroll position across vertical scrolling.

</details>