### PR TITLE
feat: 订阅时上报当前语言

### DIFF
--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -8,10 +8,12 @@ import com.russhwolf.settings.coroutines.getIntFlow
 import com.russhwolf.settings.coroutines.getLongFlow
 import com.russhwolf.settings.coroutines.getStringOrNullFlow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.Json
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
+import whl.trending.ai.core.platform.getSystemLanguage
 import whl.trending.ai.data.model.FavoriteItem
 
 enum class ThemeMode(val title: String) {
@@ -80,6 +82,13 @@ class SettingsManager(private val settings: ObservableSettings) {
 
     val appLanguage: Flow<AppLanguage> = settings.getIntFlow(LANGUAGE_KEY, AppLanguage.FOLLOW_SYSTEM.ordinal)
         .map { AppLanguage.entries.getOrElse(it) { AppLanguage.FOLLOW_SYSTEM } }
+
+    /**
+     * 当前内容语言：跟随 App 语言设置，FOLLOW_SYSTEM 时回退系统语言。
+     * 供摘要请求与邮件订阅复用，避免各处各自推导导致口径分叉。
+     */
+    suspend fun currentContentLang(): String =
+        appLanguage.first().isoCode ?: getSystemLanguage()
 
     fun setLanguage(language: AppLanguage) {
         settings.putInt(LANGUAGE_KEY, language.ordinal)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -114,13 +114,14 @@ open class TrendingApi {
         }
     }
 
-    open suspend fun submitSubscribe(email: String, source: String): Result<SubscribeResponse> {
+    open suspend fun submitSubscribe(email: String, source: String, lang: String): Result<SubscribeResponse> {
         return try {
             val response = client.post("$baseHost/api/subscribe") {
                 contentType(ContentType.Application.Json)
                 setBody(buildJsonObject {
                     put("email", email)
                     put("source", source)
+                    put("lang", lang)
                 })
             }
             if (response.status.value in 200..299) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/TrendingRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/TrendingRepository.kt
@@ -34,8 +34,8 @@ class TrendingRepository(private val api: TrendingApi = TrendingApi()) {
         return api.submitFeedback(content, email)
     }
 
-    suspend fun subscribe(email: String, source: String): Result<SubscribeResponse> {
-        return api.submitSubscribe(email, source)
+    suspend fun subscribe(email: String, source: String, lang: String): Result<SubscribeResponse> {
+        return api.submitSubscribe(email, source, lang)
     }
 
     suspend fun cancelSubscribe(email: String): Result<SubscribeResponse> {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedViewModel.kt
@@ -4,7 +4,6 @@ import whl.trending.ai.data.model.FeedItem
 import whl.trending.ai.data.repository.TrendingRepository
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.local.globalSettingsManager
-import whl.trending.ai.core.platform.getSystemLanguage
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -14,7 +13,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -56,8 +54,7 @@ class FeedViewModel(
                 _uiState.update { it.copy(isLoading = true, error = null) }
             }
             try {
-                val currentAppLanguage = settingsManager.appLanguage.first()
-                val summaryLang = currentAppLanguage.isoCode ?: getSystemLanguage()
+                val summaryLang = settingsManager.currentContentLang()
                 val response = repository.getFeed(source, summaryLang)
                 _uiState.update {
                     it.copy(

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksViewModel.kt
@@ -4,7 +4,6 @@ import whl.trending.ai.data.model.PicksResponse
 import whl.trending.ai.data.repository.TrendingRepository
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.local.globalSettingsManager
-import whl.trending.ai.core.platform.getSystemLanguage
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -14,7 +13,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -55,8 +53,7 @@ class PicksViewModel(
                 _uiState.update { it.copy(isLoading = true, error = null) }
             }
             try {
-                val currentAppLanguage = settingsManager.appLanguage.first()
-                val summaryLang = currentAppLanguage.isoCode ?: getSystemLanguage()
+                val summaryLang = settingsManager.currentContentLang()
                 val response = repository.getPicks(summaryLang)
                 _uiState.update {
                     it.copy(

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/subscribe/SubscribeViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/subscribe/SubscribeViewModel.kt
@@ -1,5 +1,6 @@
 package whl.trending.ai.ui.subscribe
 
+import whl.trending.ai.core.platform.getSystemLanguage
 import whl.trending.ai.core.platform.isIosPlatform
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.local.globalSettingsManager
@@ -13,6 +14,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -60,7 +62,9 @@ class SubscribeViewModel(
 
         viewModelScope.launch {
             _uiState.update { it.copy(isSubmitting = true) }
-            val result = repository.subscribe(email, currentSource())
+            // 订阅语言跟随 App 当前语言设置（与摘要请求口径一致），后端按 zh/en 决定邮件语言，非法值兜底英文
+            val lang = settings.appLanguage.first().isoCode ?: getSystemLanguage()
+            val result = repository.subscribe(email, currentSource(), lang)
             result.fold(
                 onSuccess = { resp ->
                     val status = SubscribeStatus.from(resp.status)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/subscribe/SubscribeViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/subscribe/SubscribeViewModel.kt
@@ -4,7 +4,6 @@ import whl.trending.ai.core.platform.isIosPlatform
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.SubscribeStatus
-import whl.trending.ai.data.remote.ApiException
 import whl.trending.ai.data.repository.TrendingRepository
 
 import androidx.lifecycle.ViewModel

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/subscribe/SubscribeViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/subscribe/SubscribeViewModel.kt
@@ -1,6 +1,5 @@
 package whl.trending.ai.ui.subscribe
 
-import whl.trending.ai.core.platform.getSystemLanguage
 import whl.trending.ai.core.platform.isIosPlatform
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.local.globalSettingsManager
@@ -14,7 +13,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -62,8 +60,8 @@ class SubscribeViewModel(
 
         viewModelScope.launch {
             _uiState.update { it.copy(isSubmitting = true) }
-            // 订阅语言跟随 App 当前语言设置（与摘要请求口径一致），后端按 zh/en 决定邮件语言，非法值兜底英文
-            val lang = settings.appLanguage.first().isoCode ?: getSystemLanguage()
+            // 订阅语言跟随 App 当前语言设置（与摘要请求同口径），后端按 zh/en 决定邮件语言，非法值兜底英文
+            val lang = settings.currentContentLang()
             val result = repository.subscribe(email, currentSource(), lang)
             result.fold(
                 onSuccess = { resp ->

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingViewModel.kt
@@ -7,7 +7,6 @@ import whl.trending.ai.core.DateTimeUtils
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.local.globalSettingsManager
-import whl.trending.ai.core.platform.getSystemLanguage
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -20,7 +19,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -75,8 +73,7 @@ class TrendingViewModel(
             }
 
             try {
-                val currentAppLanguage = settingsManager.appLanguage.first()
-                val summaryLang = currentAppLanguage.isoCode ?: getSystemLanguage()
+                val summaryLang = settingsManager.currentContentLang()
 
                 val response = repository.getTrending(
                     _uiState.value.selectedPeriod,


### PR DESCRIPTION
## 背景
订阅邮件按语言推送：订阅时携带当前语言，后端据此决定发中文还是英文 Daily Picks。

## 改动
- `SubscribeViewModel.submit()`：计算订阅语言，口径与摘要请求一致——`settings.appLanguage.first().isoCode ?: getSystemLanguage()`。
- `TrendingRepository.subscribe()` / `TrendingApi.submitSubscribe()`：透传 `lang`，POST body 增加 `lang` 字段。

非 `zh/en`（如系统语言为其他）由后端兜底英文，与 App「摘要仅中英」的现状一致。

## 配套
- 后端 PR：github-ai-trending-api#11（接收 `lang` + 英文邮件模板）。
- 官网：已带 `lang: "zh"`。

## 验证
`:shared:compileCommonMainKotlinMetadata` 编译通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在提交电子邮件订阅时上报应用当前语言，以便后端可以发送本地化的 Daily Picks 邮件。

新功能：
- 在订阅请求中包含应用的当前语言，该语言基于用户设置或系统语言。

改进：
- 扩展订阅 API 和仓储方法，使其能够在订阅的 POST 请求体中接收并转发语言参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Report the app's current language when submitting email subscriptions so the backend can send localized Daily Picks emails.

New Features:
- Include the app's current language in subscription requests based on user settings or system language.

Enhancements:
- Extend subscription API and repository methods to accept and forward a language parameter in the subscription POST body.

</details>