### PR TITLE
feat(cache): 统一「上次数据缓存」— 首页四 tab + Profile 进入秒出 + 自动刷新（SWR）

### DIFF
--- a/docs/superpowers/specs/2026-07-03-last-data-cache-design.md
+++ b/docs/superpowers/specs/2026-07-03-last-data-cache-design.md
@@ -90,7 +90,7 @@ init:
 - 自动刷新复用 `isRefreshing`：`PullToRefreshBox` 顶部 `LoadingIndicator` 自然转起来，UI 零新增。
 - `delay(500)` 只保留给手动下拉（防指示器闪烁），SWR 自动刷新不加。
 - Trending 仅默认视图读写缓存：init 读缓存只在初始参数为默认时；fetch 成功只在当前参数为默认时 put。
-- 错误展示条件收紧：各 Screen 整页错误改为「`error != null` 且无内容」才显示；有内容时刷新失败静默保留。
+- 错误展示条件收紧：规则收敛在 VM 层——失败且已有内容时不置 `error`（静默保留），仅无内容时才置 `error` 触发整页错误。Screen 零改动，且规则可单测。
 - 语言切换监听不动：切换后 fetch 成功写入新语言 key，冷启动按当前语言读 key，天然隔离。
 
 ## 4. Profile（GitHub 个人主页）

--- a/docs/superpowers/specs/2026-07-03-last-data-cache-design.md
+++ b/docs/superpowers/specs/2026-07-03-last-data-cache-design.md
@@ -1,0 +1,141 @@
+# 统一「上次数据缓存」（SWR）设计
+
+日期：2026-07-03
+状态：已确认
+
+## 背景与目标
+
+首次进入各页面时接口加载较慢，用户只能看骨架屏。目标：为首页四个 tab（Picks / Hacker News / Product Hunt / Trending）与 GitHub 个人主页（Profile）引入统一的「上次数据缓存」——进入页面优先展示上次成功获取的数据，同时自动触发一次刷新（顶部显示下拉刷新指示器），拿到新数据后无感替换（stale-while-revalidate）。
+
+已确认的取舍：
+
+- **覆盖范围**：首页四 tab + Profile 首屏（用户信息 / GitHub 计数 / 贡献热力图 / feed 首屏）。下钻页（README、repos/followers 分页列表）不缓存。
+- **刷新策略**：有缓存必刷新（SWR），不做 TTL。
+- **Trending 参数**：只缓存默认视图（`period=daily`、`language=all`、无日期无批次），切换筛选条件仍走网络。
+- **存储**：文件缓存（每个 key 一个 JSON 文件，存平台 cache 目录），不用 multiplatform-settings 塞大 JSON，不用 Ktor HttpCache（给不了先展示旧数据的 UI 语义）。
+
+## 1. 缓存基础设施
+
+### CacheFileStore（`data/local/CacheFileStore.kt`）
+
+```kotlin
+interface CacheFileStore {
+    fun read(name: String): String?
+    fun write(name: String, content: String)
+    fun delete(name: String)
+}
+expect fun platformCacheFileStore(): CacheFileStore
+```
+
+- Android actual：`AndroidContextHolder.get()?.cacheDir` 下的 `lastdata/` 子目录，普通 File 读写；拿不到 context 时降级为 no-op。
+- iOS actual：`NSCachesDirectory` 下同名子目录。
+- 抽 interface 而非裸 expect fun，为了 commonTest 注入内存 fake。
+
+### LastDataCache（`data/local/LastDataCache.kt`）
+
+```kotlin
+class LastDataCache(private val store: CacheFileStore = platformCacheFileStore()) {
+    inline fun <reified T> get(key: String): T?    // 缺失/解码失败 → 删文件并返回 null
+    inline fun <reified T> put(key: String, value: T)
+    fun remove(key: String)
+}
+val globalLastDataCache by lazy { LastDataCache() }
+```
+
+- 文件名含全局 schema 版本：`v1_<key>.json`。数据模型不兼容改动时 bump 版本整体失效，无迁移。
+- `Json { ignoreUnknownKeys = true }`；解码失败静默当无缓存并删除文件，绝不 crash。
+
+### 缓存 key（lang = summaryLang，内容随语言变化必须进 key）
+
+| key | 内容 |
+|---|---|
+| `picks_{lang}` | `PicksResponse` |
+| `feed_hackernews_{lang}` / `feed_producthunt_{lang}` | `FeedResponse` |
+| `trending_default_{lang}` | `TrendingResponse`（仅默认视图） |
+| `profile` | `ProfileCache` |
+
+## 2. 缓存写入规则（覆盖语义）
+
+**基本规则：只有网络成功才写缓存；写入是对该 key 的全量覆盖，不做增量合并。**
+
+- Picks / Feed / Trending：fetch 成功即 `put(key, response)` 覆盖。列表是服务端一次性返回的完整快照，无合并意义；返回空列表也照常覆盖（空是合法的最新状态）。
+- 失败不碰缓存：网络失败、解码失败走不到 `put()`，旧缓存原样保留——这是「刷新失败仍能展示上次数据」的保障。
+- 文件级原子性：先写临时文件再 rename，避免写一半被杀进程留下损坏文件；即使损坏，读取侧解码失败兜底删除，双保险。
+
+**Profile 例外：覆盖 + 只增不减。** Profile 渐进加载（user 先到 → contributions / feed 后到），现有 `refresh()` 在 fetchMe 成功后会先清空 contributions 和 feed 再重拉。若 `persistSnapshot()` 在中间时刻纯覆盖，会把完整旧缓存冲成 header-only 的残缺快照。因此：
+
+- `persistSnapshot()` 组装快照时，若当前 state 的 `contributions == null` 或 `feedItems` 为空，而旧缓存有值且 `highlightsOnly` 档位一致，则沿用旧缓存对应字段补齐后再覆盖写入；
+- 新数据到达后快照即为新值，最终一致；
+- 登出直接 `remove("profile")`，不受此规则影响。
+
+一句话：列表页 = 成功即覆盖；Profile = 成功即覆盖，但残缺字段用旧值补齐后再覆盖。
+
+## 3. 列表页统一接入模式（Picks / Feed / Trending）
+
+三个 VM 按同一模式各自改造（不引入额外抽象层，保持手动 DI 风格），每个 VM 约 +15 行：
+
+```
+init:
+  cached = cache.get(key)
+  if (cached != null) → state = { isLoading=false, data=cached, isRefreshing=true }
+                        → 走网络（复用现有 fetch，跳过 delay(500)）
+  else                → 现状不变（isLoading 骨架屏 → 网络）
+
+网络成功 → 更新 state + cache.put(key, response)
+网络失败 → 有内容时保留、仅收起指示器；无内容才整页错误
+```
+
+要点：
+
+- 自动刷新复用 `isRefreshing`：`PullToRefreshBox` 顶部 `LoadingIndicator` 自然转起来，UI 零新增。
+- `delay(500)` 只保留给手动下拉（防指示器闪烁），SWR 自动刷新不加。
+- Trending 仅默认视图读写缓存：init 读缓存只在初始参数为默认时；fetch 成功只在当前参数为默认时 put。
+- 错误展示条件收紧：各 Screen 整页错误改为「`error != null` 且无内容」才显示；有内容时刷新失败静默保留。
+- 语言切换监听不动：切换后 fetch 成功写入新语言 key，冷启动按当前语言读 key，天然隔离。
+
+## 4. Profile（GitHub 个人主页）
+
+### 缓存载体
+
+```kotlin
+@Serializable
+data class ProfileCache(
+    val login: String,                        // 冗余校验字段
+    val user: MeUser,                         // 已 @Serializable
+    val githubUser: GithubUser?,              // 已 @Serializable
+    val contributions: ContributionCalendar?, // 需补 @Serializable
+    val feedItems: List<GithubFeedItem>,      // 需补 @Serializable
+    val highlightsOnly: Boolean,              // 缓存的 feed 属于哪个档
+)
+```
+
+feedItems 只缓存前 50 条（首屏够用，控制体积）。
+
+### 读取（`load()` 开头）
+
+- 命中缓存 → 一次性填充完整 state（头像/计数/热力图/feed 秒出）+ `isRefreshing=true`，走现有 `refresh()` 网络路径（已实现保留旧内容、渐进替换）。
+- 缓存的 `highlightsOnly` 与当前设置不一致 → 只用 header 部分（user/计数/热力图），feed 走骨架。
+- 无缓存 → 现状不变。
+
+### 写入
+
+`persistSnapshot()`（含只增不减规则）在三个时机调用：`fetchMe` 成功、contributions 到达、`loadMoreFeed` 每轮成功写回 state 后。每次全量 snapshot 序列化落盘。
+
+### 清理
+
+已有 `authState → LoggedOut` 监听里追加 `cache.remove("profile")`，杜绝换账号串号（换账号必经登出，key 不必带 login，`login` 字段仅冗余校验）。`hasLoaded` 子页返回不重拉语义不变。
+
+## 5. 边界与错误处理
+
+- 冷启动无网络：有缓存 → 展示缓存，刷新失败静默收起指示器；无缓存 → 现有错误页。
+- 缓存损坏/模型变更：解码失败删文件回退骨架屏；不兼容改动 bump `v1` → `v2`。
+- 系统清缓存：文件在 cacheDir，被清后自动回退首装行为，无需处理。
+
+## 6. 测试（commonTest）
+
+- `LastDataCache`：注入内存 fake `CacheFileStore`——put/get 往返、解码失败返 null 并删文件、remove。
+- 各 VM：命中缓存先出数据且 `isRefreshing=true`；网络成功覆盖并写缓存；网络失败保留缓存内容；Trending 非默认参数不写缓存；Profile 登出清缓存、persistSnapshot 只增不减。
+
+## 7. 提交方式
+
+预计 ~12 文件、300+ 行，属大改动：从 main 切 `feat/last-data-cache` 分支走 PR。

--- a/shared/src/androidMain/kotlin/whl/trending/ai/data/local/CacheFileStore.android.kt
+++ b/shared/src/androidMain/kotlin/whl/trending/ai/data/local/CacheFileStore.android.kt
@@ -1,0 +1,35 @@
+package whl.trending.ai.data.local
+
+import java.io.File
+import whl.trending.ai.core.platform.AndroidContextHolder
+
+actual fun platformCacheFileStore(): CacheFileStore = AndroidCacheFileStore()
+
+private class AndroidCacheFileStore : CacheFileStore {
+    /** 拿不到 context（理论上不会发生）时返回 null，整体降级为无缓存 */
+    private fun dir(): File? = AndroidContextHolder.get()?.let {
+        File(it.cacheDir, "lastdata").apply { mkdirs() }
+    }
+
+    override fun read(name: String): String? {
+        val file = dir()?.let { File(it, name) } ?: return null
+        return runCatching { if (file.exists()) file.readText() else null }.getOrNull()
+    }
+
+    override fun write(name: String, content: String) {
+        val d = dir() ?: return
+        runCatching {
+            // 先写临时文件再 rename：避免写一半被杀进程留下损坏文件
+            val tmp = File(d, "$name.tmp")
+            tmp.writeText(content)
+            if (!tmp.renameTo(File(d, name))) {
+                File(d, name).writeText(content)
+                tmp.delete()
+            }
+        }
+    }
+
+    override fun delete(name: String) {
+        dir()?.let { runCatching { File(it, name).delete() } }
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/CacheFileStore.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/CacheFileStore.kt
@@ -1,0 +1,15 @@
+package whl.trending.ai.data.local
+
+/**
+ * 「上次数据缓存」的底层文件存取抽象：每个 name 对应平台 cache 目录下的一个文件。
+ * 抽成接口是为了 commonTest 能注入内存替身；所有实现都必须静默吞掉 IO 异常——
+ * 缓存读写失败只能降级为无缓存，绝不能影响正常流程。
+ */
+interface CacheFileStore {
+    fun read(name: String): String?
+    fun write(name: String, content: String)
+    fun delete(name: String)
+}
+
+/** 平台默认实现：Android 用 context.cacheDir，iOS 用 NSCachesDirectory */
+expect fun platformCacheFileStore(): CacheFileStore

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/LastDataCache.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/LastDataCache.kt
@@ -41,7 +41,9 @@ class LastDataCache(
 
     suspend inline fun <reified T> put(key: String, value: T) {
         withContext(dispatcher) {
+            // 序列化/IO 失败只降级为「本次不缓存」，不影响调用方；打日志保留可观测性
             runCatching { store.write(fileName(key), json.encodeToString(value)) }
+                .onFailure { println("LastDataCache: put($key) failed: $it") }
         }
     }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/LastDataCache.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/LastDataCache.kt
@@ -1,0 +1,53 @@
+package whl.trending.ai.data.local
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+
+/**
+ * 缓存 schema 版本：数据模型发生不兼容改动时 bump，老文件读取解码失败会被自动删除，
+ * 无需迁移逻辑。
+ */
+private const val CACHE_SCHEMA_VERSION = 1
+
+/**
+ * 「上次数据缓存」统一入口（SWR）：进入页面先展示上次成功获取的数据，再后台刷新。
+ *
+ * 语义约定（详见 docs/superpowers/specs/2026-07-03-last-data-cache-design.md）：
+ * - 只有网络成功才 [put]，写入是对该 key 的全量覆盖，不做增量合并；
+ * - [get] 在文件缺失或解码失败时返回 null（损坏文件顺手删除），调用方回退骨架屏；
+ * - 读写都切到后台调度器，调用方可安全地在主线程协程里使用。
+ */
+class LastDataCache(
+    @PublishedApi internal val store: CacheFileStore = platformCacheFileStore(),
+    /** 文件 IO 调度器；测试注入 TestDispatcher 以获得确定性 */
+    @PublishedApi internal val dispatcher: CoroutineDispatcher = Dispatchers.Default,
+) {
+    @PublishedApi
+    internal val json = Json { ignoreUnknownKeys = true }
+
+    @PublishedApi
+    internal fun fileName(key: String): String = "v${CACHE_SCHEMA_VERSION}_$key.json"
+
+    suspend inline fun <reified T> get(key: String): T? = withContext(dispatcher) {
+        val name = fileName(key)
+        val content = store.read(name) ?: return@withContext null
+        runCatching { json.decodeFromString<T>(content) }.getOrElse {
+            store.delete(name)
+            null
+        }
+    }
+
+    suspend inline fun <reified T> put(key: String, value: T) {
+        withContext(dispatcher) {
+            runCatching { store.write(fileName(key), json.encodeToString(value)) }
+        }
+    }
+
+    suspend fun remove(key: String) = withContext(dispatcher) {
+        store.delete(fileName(key))
+    }
+}
+
+val globalLastDataCache by lazy { LastDataCache() }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/Contribution.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/Contribution.kt
@@ -1,10 +1,14 @@
 package whl.trending.ai.data.model
 
+import kotlinx.serialization.Serializable
+
 /**
  * GitHub 贡献日历（绿色热力图）的干净领域模型。
  * 数据仅来自 GitHub GraphQL API（REST 不暴露 contribution calendar），
  * UI 只依赖本模型，与 GraphQL 响应的深层嵌套结构解耦。
+ * @Serializable 供 Profile 上次数据缓存（ProfileCache）序列化落盘。
  */
+@Serializable
 data class ContributionCalendar(
     /** 最近一年的总贡献数 */
     val total: Int,
@@ -12,10 +16,12 @@ data class ContributionCalendar(
     val weeks: List<ContributionWeek>,
 )
 
+@Serializable
 data class ContributionWeek(
     val days: List<ContributionDay>,
 )
 
+@Serializable
 data class ContributionDay(
     /** ISO 日期，如 "2026-06-23" */
     val date: String,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/TrendingRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/TrendingRepository.kt
@@ -7,12 +7,13 @@ import whl.trending.ai.data.model.SubscribeResponse
 import whl.trending.ai.data.model.TrendingResponse
 import whl.trending.ai.data.remote.TrendingApi
 
-class TrendingRepository(private val api: TrendingApi = TrendingApi()) {
-    suspend fun getFeed(source: String, summaryLang: String = "zh"): FeedResponse {
+// open：便于测试以子类替身注入（保持手动 DI，不引入 mock 框架）
+open class TrendingRepository(private val api: TrendingApi = TrendingApi()) {
+    open suspend fun getFeed(source: String, summaryLang: String = "zh"): FeedResponse {
         return api.fetchFeed(source, summaryLang)
     }
 
-    suspend fun getPicks(summaryLang: String = "zh"): PicksResponse {
+    open suspend fun getPicks(summaryLang: String = "zh"): PicksResponse {
         return api.fetchPicks(summaryLang)
     }
 
@@ -20,7 +21,7 @@ class TrendingRepository(private val api: TrendingApi = TrendingApi()) {
         return api.fetchReadme(owner, repo)
     }
 
-    suspend fun getTrending(
+    open suspend fun getTrending(
         period: String,
         language: String,
         summaryLang: String,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
@@ -4,9 +4,10 @@ import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.MeUser
 import whl.trending.ai.data.remote.TrendingApi
 
-class UserRepository(private val api: TrendingApi = TrendingApi()) {
+// open：便于测试以子类替身注入（保持手动 DI，不引入 mock 框架）
+open class UserRepository(private val api: TrendingApi = TrendingApi()) {
 
-    suspend fun fetchMe(accessToken: String): MeUser = api.fetchMe(accessToken).user
+    open suspend fun fetchMe(accessToken: String): MeUser = api.fetchMe(accessToken).user
 
     /**
      * 登录成功/应用启动（已登录）时调用：服务端建档 + 刷新 last_login_at，并缓存头像。

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedViewModel.kt
@@ -1,8 +1,11 @@
 package whl.trending.ai.ui.feed
 
 import whl.trending.ai.data.model.FeedItem
+import whl.trending.ai.data.model.FeedResponse
 import whl.trending.ai.data.repository.TrendingRepository
+import whl.trending.ai.data.local.LastDataCache
 import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.local.globalLastDataCache
 import whl.trending.ai.data.local.globalSettingsManager
 
 import androidx.lifecycle.ViewModel
@@ -26,7 +29,8 @@ data class FeedUiState(
 class FeedViewModel(
     private val source: String,
     private val repository: TrendingRepository = TrendingRepository(),
-    private val settingsManager: SettingsManager = globalSettingsManager
+    private val settingsManager: SettingsManager = globalSettingsManager,
+    private val cache: LastDataCache = globalLastDataCache
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(FeedUiState())
     val uiState: StateFlow<FeedUiState> = _uiState.asStateFlow()
@@ -34,7 +38,7 @@ class FeedViewModel(
     private var fetchJob: Job? = null
 
     init {
-        fetchFeed()
+        loadWithCache()
 
         viewModelScope.launch {
             // drop(1) 丢弃首次初始化的当前值，只监听真正发生的设置修改，避免初始化时重复调用 fetchFeed
@@ -44,35 +48,56 @@ class FeedViewModel(
         }
     }
 
+    private fun cacheKey(lang: String) = "feed_${source}_$lang"
+
+    /** SWR：有缓存先展示 + 顶部指示器自动刷新（不加防闪烁延迟）；无缓存走骨架屏 */
+    private fun loadWithCache() {
+        fetchJob?.cancel()
+        fetchJob = viewModelScope.launch {
+            val cached = cache.get<FeedResponse>(cacheKey(settingsManager.currentContentLang()))
+            if (cached != null) {
+                _uiState.update { it.copy(isLoading = false, isRefreshing = true, items = cached.data) }
+            }
+            fetch()
+        }
+    }
+
     private fun fetchFeed(isRefresh: Boolean = false) {
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             if (isRefresh) {
                 _uiState.update { it.copy(isRefreshing = true, error = null) }
+                // 防指示器闪烁延迟，仅手动下拉/设置变更触发的刷新需要
                 delay(500)
             } else {
                 _uiState.update { it.copy(isLoading = true, error = null) }
             }
-            try {
-                val summaryLang = settingsManager.currentContentLang()
-                val response = repository.getFeed(source, summaryLang)
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        isRefreshing = false,
-                        items = response.data,
-                        error = null
-                    )
-                }
-            } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        isRefreshing = false,
-                        error = e.message ?: "Unknown Error"
-                    )
-                }
+            fetch()
+        }
+    }
+
+    private suspend fun fetch() {
+        try {
+            val summaryLang = settingsManager.currentContentLang()
+            val response = repository.getFeed(source, summaryLang)
+            cache.put(cacheKey(summaryLang), response)
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    isRefreshing = false,
+                    items = response.data,
+                    error = null
+                )
+            }
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    isRefreshing = false,
+                    // 有内容（缓存或旧数据）时刷新失败静默保留，避免整页错误盖掉可用内容
+                    error = if (it.items.isEmpty()) e.message ?: "Unknown Error" else null
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksViewModel.kt
@@ -2,7 +2,9 @@ package whl.trending.ai.ui.picks
 
 import whl.trending.ai.data.model.PicksResponse
 import whl.trending.ai.data.repository.TrendingRepository
+import whl.trending.ai.data.local.LastDataCache
 import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.local.globalLastDataCache
 import whl.trending.ai.data.local.globalSettingsManager
 
 import androidx.lifecycle.ViewModel
@@ -25,7 +27,8 @@ data class PicksUiState(
 
 class PicksViewModel(
     private val repository: TrendingRepository = TrendingRepository(),
-    private val settingsManager: SettingsManager = globalSettingsManager
+    private val settingsManager: SettingsManager = globalSettingsManager,
+    private val cache: LastDataCache = globalLastDataCache
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(PicksUiState())
     val uiState: StateFlow<PicksUiState> = _uiState.asStateFlow()
@@ -33,7 +36,7 @@ class PicksViewModel(
     private var fetchJob: Job? = null
 
     init {
-        fetchPicks()
+        loadWithCache()
 
         viewModelScope.launch {
             // drop(1) 丢弃首次初始化的当前值，只监听真正发生的设置修改，避免初始化时重复调用 fetchPicks
@@ -43,35 +46,56 @@ class PicksViewModel(
         }
     }
 
+    private fun cacheKey(lang: String) = "picks_$lang"
+
+    /** SWR：有缓存先展示 + 顶部指示器自动刷新（不加防闪烁延迟）；无缓存走骨架屏 */
+    private fun loadWithCache() {
+        fetchJob?.cancel()
+        fetchJob = viewModelScope.launch {
+            val cached = cache.get<PicksResponse>(cacheKey(settingsManager.currentContentLang()))
+            if (cached != null) {
+                _uiState.update { it.copy(isLoading = false, isRefreshing = true, picks = cached) }
+            }
+            fetch()
+        }
+    }
+
     private fun fetchPicks(isRefresh: Boolean = false) {
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             if (isRefresh) {
                 _uiState.update { it.copy(isRefreshing = true, error = null) }
+                // 防指示器闪烁延迟，仅手动下拉/设置变更触发的刷新需要
                 delay(500)
             } else {
                 _uiState.update { it.copy(isLoading = true, error = null) }
             }
-            try {
-                val summaryLang = settingsManager.currentContentLang()
-                val response = repository.getPicks(summaryLang)
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        isRefreshing = false,
-                        picks = response,
-                        error = null
-                    )
-                }
-            } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        isRefreshing = false,
-                        error = e.message ?: "Unknown Error"
-                    )
-                }
+            fetch()
+        }
+    }
+
+    private suspend fun fetch() {
+        try {
+            val summaryLang = settingsManager.currentContentLang()
+            val response = repository.getPicks(summaryLang)
+            cache.put(cacheKey(summaryLang), response)
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    isRefreshing = false,
+                    picks = response,
+                    error = null
+                )
+            }
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    isRefreshing = false,
+                    // 有内容（缓存或旧数据）时刷新失败静默保留，避免整页错误盖掉可用内容
+                    error = if (it.picks == null) e.message ?: "Unknown Error" else null
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubFeedItem.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubFeedItem.kt
@@ -1,5 +1,6 @@
 package whl.trending.ai.ui.profile
 
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.intOrNull
@@ -19,7 +20,9 @@ enum class GithubFeedKind {
 /**
  * 归一化后的 feed 条目：kind + primary（分支名/tag/编号/提交数/类型名，按 kind 而定），
  * 文案在 UI 层用 stringResource 按 kind 组装（i18n）。
+ * @Serializable 供 Profile 上次数据缓存（ProfileCache）序列化落盘。
  */
+@Serializable
 data class GithubFeedItem(
     val id: String,
     val actorLogin: String,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileCache.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileCache.kt
@@ -1,0 +1,49 @@
+package whl.trending.ai.ui.profile
+
+import kotlinx.serialization.Serializable
+import whl.trending.ai.data.model.ContributionCalendar
+import whl.trending.ai.data.model.MeUser
+import whl.trending.ai.data.remote.GithubUser
+
+/**
+ * Profile 页「上次数据缓存」快照：用户信息 + GitHub 计数 + 贡献热力图 + feed 首屏。
+ * 换账号必经登出（登出时整体 remove），因此 key 固定为 [KEY]；[login] 仅作冗余校验。
+ */
+@Serializable
+data class ProfileCache(
+    val login: String,
+    val user: MeUser,
+    val githubUser: GithubUser? = null,
+    val contributions: ContributionCalendar? = null,
+    val feedItems: List<GithubFeedItem> = emptyList(),
+    /** 缓存的 feed 属于哪个档（精选/全部），读取时档位不一致则不复用 feed */
+    val highlightsOnly: Boolean = true,
+) {
+    companion object {
+        const val KEY = "profile"
+
+        /** feed 只缓存首屏所需条数，控制文件体积 */
+        const val MAX_FEED_ITEMS = 50
+
+        /**
+         * 从当前 state 组装快照。写入语义是「覆盖 + 只增不减」：Profile 渐进加载，
+         * 刷新中途 contributions/feed 会被清空重拉，此刻落盘若纯覆盖会把完整旧缓存
+         * 冲成 header-only 的残缺快照——因此残缺字段用旧快照补齐后再覆盖。
+         * feed 与档位绑定，仅档位一致时复用旧值；contributions/githubUser 档位无关。
+         */
+        fun from(state: ProfileUiState, previous: ProfileCache?): ProfileCache? {
+            val user = state.user ?: return null
+            val login = user.githubLogin ?: return null
+            val prev = previous?.takeIf { it.login == login }
+            val prevFeed = prev?.takeIf { it.highlightsOnly == state.highlightsOnly }?.feedItems.orEmpty()
+            return ProfileCache(
+                login = login,
+                user = user,
+                githubUser = state.githubUser ?: prev?.githubUser,
+                contributions = state.contributions ?: prev?.contributions,
+                feedItems = state.feedItems.ifEmpty { prevFeed }.take(MAX_FEED_ITEMS),
+                highlightsOnly = state.highlightsOnly,
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -15,7 +15,9 @@ import whl.trending.ai.auth.FollowingProvider
 import whl.trending.ai.auth.GithubTokenProvider
 import whl.trending.ai.auth.OwnRepoEventsProvider
 import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.data.local.LastDataCache
 import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.local.globalLastDataCache
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.ContributionCalendar
 import whl.trending.ai.data.model.MeUser
@@ -64,6 +66,7 @@ class ProfileViewModel(
     private val ownRepoEventsProvider: OwnRepoEventsProvider = OwnRepoEventsProvider.shared,
     private val authManager: () -> AuthManager = { globalAuthManager },
     private val settingsManager: SettingsManager = globalSettingsManager,
+    private val cache: LastDataCache = globalLastDataCache,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(ProfileUiState())
     val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
@@ -97,9 +100,19 @@ class ProfileViewModel(
                     loadJob?.cancel()
                     feedLoadJob?.cancel()
                     _uiState.value = ProfileUiState()
+                    cache.remove(ProfileCache.KEY)
                 }
             }
         }
+    }
+
+    /**
+     * 落盘当前 state 快照（覆盖 + 只增不减，见 [ProfileCache.from]）。
+     * 调用时机：fetchMe 成功、contributions 到达、loadMoreFeed 每轮写回 state 后。
+     */
+    private suspend fun persistSnapshot() {
+        val snapshot = ProfileCache.from(_uiState.value, cache.get(ProfileCache.KEY)) ?: return
+        cache.put(ProfileCache.KEY, snapshot)
     }
 
     fun load() {
@@ -110,6 +123,24 @@ class ProfileViewModel(
         feedLoadJob?.cancel()
         loadJob = viewModelScope.launch {
             val highlightsOnly = settingsManager.getFeedHighlightsOnlySync()
+
+            // SWR：有缓存整页秒出（header/计数/热力图/feed）+ 顶部指示器自动刷新
+            val cached = cache.get<ProfileCache>(ProfileCache.KEY)
+            if (cached != null) {
+                _uiState.value = ProfileUiState(
+                    isLoading = false,
+                    user = cached.user,
+                    githubUser = cached.githubUser,
+                    contributions = cached.contributions,
+                    // feed 与档位绑定，档位不一致时不复用（只用 header 部分，feed 走加载态）
+                    feedItems = if (cached.highlightsOnly == highlightsOnly) cached.feedItems else emptyList(),
+                    highlightsOnly = highlightsOnly,
+                )
+                hasLoaded = true
+                refreshInternal()
+                return@launch
+            }
+
             _uiState.value = ProfileUiState(isLoading = true, highlightsOnly = highlightsOnly)
             nextFeedPage = 1
             consumedRawCount = 0
@@ -129,6 +160,7 @@ class ProfileViewModel(
             }
             _uiState.value = ProfileUiState(isLoading = false, user = user, highlightsOnly = highlightsOnly)
             hasLoaded = true
+            persistSnapshot()
             loadGithubData(user)
         }
     }
@@ -153,6 +185,7 @@ class ProfileViewModel(
             try {
                 val calendar = githubApi.fetchContributionCalendar(githubToken, login)
                 _uiState.value = _uiState.value.copy(contributions = calendar)
+                persistSnapshot()
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
             }
@@ -239,6 +272,7 @@ class ProfileViewModel(
                 }
 
                 _uiState.value = _uiState.value.copy(isFeedLoading = false)
+                persistSnapshot()
             } catch (e: Exception) {
                 // 取消时直接透传，不写 state——isFeedLoading 由取消方的状态重置兜底归 false
                 if (e is kotlinx.coroutines.CancellationException) throw e
@@ -258,34 +292,40 @@ class ProfileViewModel(
         loadJob?.cancel()
         feedLoadJob?.cancel()
         loadJob = viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isRefreshing = true, isError = false)
-            nextFeedPage = 1
-            consumedRawCount = 0
-            followingInfo = null
-            ownRepoItems = emptyList()
-            val token = authManager().getAccessToken()
-            if (token == null) {
-                _uiState.value = _uiState.value.copy(isRefreshing = false, isError = true)
-                return@launch
-            }
-            val user = try {
-                repository.fetchMe(token)
-            } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
-                _uiState.value = _uiState.value.copy(isRefreshing = false, isError = true)
-                return@launch
-            }
-            // 旧内容保留到此刻才清空 feed，随后由 loadGithubData 重新填充，避免下拉时列表闪空
-            _uiState.value = _uiState.value.copy(
-                isRefreshing = false,
-                user = user,
-                feedItems = emptyList(),
-                feedEndReached = false,
-                feedUnavailable = false,
-                contributions = null,
-            )
-            loadGithubData(user)
+            refreshInternal()
         }
+    }
+
+    /** 刷新主体：手动下拉与缓存命中后的自动刷新（SWR）共用 */
+    private suspend fun refreshInternal() {
+        _uiState.value = _uiState.value.copy(isRefreshing = true, isError = false)
+        nextFeedPage = 1
+        consumedRawCount = 0
+        followingInfo = null
+        ownRepoItems = emptyList()
+        val token = authManager().getAccessToken()
+        if (token == null) {
+            _uiState.value = _uiState.value.copy(isRefreshing = false, isError = true)
+            return
+        }
+        val user = try {
+            repository.fetchMe(token)
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            _uiState.value = _uiState.value.copy(isRefreshing = false, isError = true)
+            return
+        }
+        // 旧内容保留到此刻才清空 feed，随后由 loadGithubData 重新填充，避免下拉时列表闪空
+        _uiState.value = _uiState.value.copy(
+            isRefreshing = false,
+            user = user,
+            feedItems = emptyList(),
+            feedEndReached = false,
+            feedUnavailable = false,
+            contributions = null,
+        )
+        persistSnapshot()
+        loadGithubData(user)
     }
 
     /** 切换精选/全部档：取消进行中的拉取，持久化设置，重置 feed 状态并重新拉取第一页 */

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingViewModel.kt
@@ -2,10 +2,13 @@ package whl.trending.ai.ui.trending
 
 import whl.trending.ai.auth.RepoStarService
 import whl.trending.ai.data.model.TrendingRepo
+import whl.trending.ai.data.model.TrendingResponse
 import whl.trending.ai.data.repository.TrendingRepository
 import whl.trending.ai.core.DateTimeUtils
 import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.data.local.LastDataCache
 import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.local.globalLastDataCache
 import whl.trending.ai.data.local.globalSettingsManager
 
 import androidx.lifecycle.ViewModel
@@ -41,6 +44,7 @@ class TrendingViewModel(
     private val repository: TrendingRepository = TrendingRepository(),
     private val settingsManager: SettingsManager = globalSettingsManager,
     private val starService: RepoStarService = RepoStarService.shared,
+    private val cache: LastDataCache = globalLastDataCache,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(TrendingUiState())
     val uiState: StateFlow<TrendingUiState> = _uiState.asStateFlow()
@@ -52,7 +56,7 @@ class TrendingViewModel(
     private var fetchJob: Job? = null
 
     init {
-        fetchData()
+        loadWithCache()
 
         viewModelScope.launch {
             // drop(1) 丢弃首次初始化的当前值，只监听真正发生的设置修改，避免初始化时重复调用 fetchData
@@ -62,45 +66,78 @@ class TrendingViewModel(
         }
     }
 
+    private fun cacheKey(lang: String) = "trending_default_$lang"
+
+    /** 只缓存默认视图：daily + 全语言 + 无历史日期/批次（冷启动看到的就是它） */
+    private fun isDefaultView(period: String, language: String, date: String?, batch: String?): Boolean =
+        period == "daily" && language == "all" && date == null && batch == null
+
+    /** SWR：默认视图有缓存先展示 + 顶部指示器自动刷新（不加防闪烁延迟）；无缓存走骨架屏 */
+    private fun loadWithCache() {
+        fetchJob?.cancel()
+        fetchJob = viewModelScope.launch {
+            val cached = cache.get<TrendingResponse>(cacheKey(settingsManager.currentContentLang()))
+            if (cached != null) {
+                _uiState.update {
+                    it.copy(
+                        repos = cached.data,
+                        since = cached.metadata.since,
+                        capturedAt = DateTimeUtils.formatToLocalTime(cached.metadata.capturedAt),
+                        isLoading = false,
+                        isRefreshing = true,
+                    )
+                }
+            }
+            fetch()
+        }
+    }
+
     fun fetchData(isRefresh: Boolean = false) {
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             if (isRefresh) {
                 _uiState.update { it.copy(isRefreshing = true, error = null) }
+                // 防指示器闪烁延迟，仅手动下拉/设置变更触发的刷新需要
                 delay(500)
             } else {
                 _uiState.update { it.copy(isLoading = true, error = null) }
             }
+            fetch()
+        }
+    }
 
-            try {
-                val summaryLang = settingsManager.currentContentLang()
+    private suspend fun fetch() {
+        // 请求参数在发起时定格为局部值，成功后据此判断是否写缓存，避免请求期间切筛选造成错写
+        val period = _uiState.value.selectedPeriod
+        val language = _uiState.value.selectedLanguage
+        val date = _uiState.value.selectedDate
+        val batch = _uiState.value.selectedBatch
+        try {
+            val summaryLang = settingsManager.currentContentLang()
 
-                val response = repository.getTrending(
-                    _uiState.value.selectedPeriod,
-                    _uiState.value.selectedLanguage,
-                    summaryLang,
-                    _uiState.value.selectedDate,
-                    _uiState.value.selectedBatch
+            val response = repository.getTrending(period, language, summaryLang, date, batch)
+            if (isDefaultView(period, language, date, batch)) {
+                cache.put(cacheKey(summaryLang), response)
+            }
+            _uiState.update {
+                it.copy(
+                    repos = response.data,
+                    since = response.metadata.since,
+                    capturedAt = DateTimeUtils.formatToLocalTime(response.metadata.capturedAt),
+                    isLoading = false,
+                    isRefreshing = false,
+                    error = null
                 )
-                _uiState.update {
-                    it.copy(
-                        repos = response.data,
-                        since = response.metadata.since,
-                        capturedAt = DateTimeUtils.formatToLocalTime(response.metadata.capturedAt),
-                        isLoading = false,
-                        isRefreshing = false,
-                        error = null
-                    )
-                }
-            } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) throw e
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        isRefreshing = false,
-                        error = e.message ?: "Unknown Error"
-                    )
-                }
+            }
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    isRefreshing = false,
+                    // 有内容（缓存或旧数据）时刷新失败静默保留，避免整页错误盖掉可用内容
+                    error = if (it.repos.isEmpty()) e.message ?: "Unknown Error" else null
+                )
             }
         }
     }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/local/LastDataCacheTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/local/LastDataCacheTest.kt
@@ -1,0 +1,96 @@
+package whl.trending.ai.data.local
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** 内存版文件存取：单测替身，同时可断言底层文件状态 */
+class FakeCacheFileStore : CacheFileStore {
+    val files = mutableMapOf<String, String>()
+    override fun read(name: String): String? = files[name]
+    override fun write(name: String, content: String) {
+        files[name] = content
+    }
+    override fun delete(name: String) {
+        files.remove(name)
+    }
+}
+
+@Serializable
+private data class CachePayload(val id: Int, val title: String)
+
+class LastDataCacheTest {
+
+    @Test
+    fun putThenGetReturnsSameValue() = runTest {
+        val cache = LastDataCache(FakeCacheFileStore())
+        cache.put("picks_zh", CachePayload(1, "hello"))
+        assertEquals(CachePayload(1, "hello"), cache.get("picks_zh"))
+    }
+
+    @Test
+    fun getReturnsNullWhenMissing() = runTest {
+        val cache = LastDataCache(FakeCacheFileStore())
+        assertNull(cache.get<CachePayload>("picks_zh"))
+    }
+
+    @Test
+    fun putOverwritesPreviousValue() = runTest {
+        val cache = LastDataCache(FakeCacheFileStore())
+        cache.put("picks_zh", CachePayload(1, "old"))
+        cache.put("picks_zh", CachePayload(2, "new"))
+        assertEquals(CachePayload(2, "new"), cache.get("picks_zh"))
+    }
+
+    @Test
+    fun corruptedContentReturnsNullAndDeletesFile() = runTest {
+        val store = FakeCacheFileStore()
+        val cache = LastDataCache(store)
+        cache.put("picks_zh", CachePayload(1, "ok"))
+        val fileName = store.files.keys.single()
+        store.files[fileName] = "{ not valid json"
+        assertNull(cache.get<CachePayload>("picks_zh"))
+        assertTrue(store.files.isEmpty(), "损坏文件应被删除")
+    }
+
+    @Test
+    fun decodeIgnoresUnknownKeys() = runTest {
+        val store = FakeCacheFileStore()
+        val cache = LastDataCache(store)
+        cache.put("picks_zh", CachePayload(1, "ok"))
+        val fileName = store.files.keys.single()
+        store.files[fileName] = """{"id":1,"title":"ok","futureField":true}"""
+        assertEquals(CachePayload(1, "ok"), cache.get("picks_zh"))
+    }
+
+    @Test
+    fun removeDeletesEntry() = runTest {
+        val store = FakeCacheFileStore()
+        val cache = LastDataCache(store)
+        cache.put("profile", CachePayload(1, "me"))
+        cache.remove("profile")
+        assertNull(cache.get<CachePayload>("profile"))
+        assertTrue(store.files.isEmpty())
+    }
+
+    @Test
+    fun keysAreIsolated() = runTest {
+        val cache = LastDataCache(FakeCacheFileStore())
+        cache.put("feed_hackernews_zh", CachePayload(1, "hn"))
+        cache.put("feed_producthunt_zh", CachePayload(2, "ph"))
+        assertEquals(CachePayload(1, "hn"), cache.get("feed_hackernews_zh"))
+        assertEquals(CachePayload(2, "ph"), cache.get("feed_producthunt_zh"))
+    }
+
+    @Test
+    fun fileNameCarriesSchemaVersionPrefix() = runTest {
+        val store = FakeCacheFileStore()
+        val cache = LastDataCache(store)
+        cache.put("picks_zh", CachePayload(1, "ok"))
+        val fileName = store.files.keys.single()
+        assertTrue(fileName.startsWith("v1_"), "文件名应带 schema 版本前缀，实际：$fileName")
+    }
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/feed/FeedViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/feed/FeedViewModelTest.kt
@@ -1,0 +1,133 @@
+package whl.trending.ai.ui.feed
+
+import com.russhwolf.settings.MapSettings
+import com.russhwolf.settings.ObservableSettings
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import whl.trending.ai.data.local.AppLanguage
+import whl.trending.ai.data.local.FakeCacheFileStore
+import whl.trending.ai.data.local.LastDataCache
+import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.model.FeedItem
+import whl.trending.ai.data.model.FeedResponse
+import whl.trending.ai.data.repository.TrendingRepository
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FeedViewModelTest {
+
+    private class FakeRepo(
+        val onFeed: suspend () -> FeedResponse,
+    ) : TrendingRepository() {
+        override suspend fun getFeed(source: String, summaryLang: String): FeedResponse = onFeed()
+    }
+
+    private fun item(title: String) = FeedItem(source = "hackernews", externalId = title, title = title)
+
+    private fun response(vararg titles: String) =
+        FeedResponse(success = true, count = titles.size, data = titles.map(::item))
+
+    private fun settings(): SettingsManager =
+        SettingsManager(MapSettings() as ObservableSettings).also { it.setLanguage(AppLanguage.CHINESE) }
+
+    private fun TestScope.cache(store: FakeCacheFileStore) =
+        LastDataCache(store, StandardTestDispatcher(testScheduler))
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun cacheHitShowsCachedDataAndTriggersRefresh() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val store = FakeCacheFileStore()
+        val cache = cache(store)
+        cache.put("feed_hackernews_zh", response("cached"))
+        val gate = CompletableDeferred<FeedResponse>()
+
+        val vm = FeedViewModel("hackernews", FakeRepo { gate.await() }, settings(), cache)
+        advanceUntilIdle()
+
+        // 缓存先出，且自动刷新中（顶部指示器），不走骨架屏
+        val mid = vm.uiState.value
+        assertEquals(listOf("cached"), mid.items.map { it.title })
+        assertFalse(mid.isLoading)
+        assertTrue(mid.isRefreshing)
+
+        gate.complete(response("fresh"))
+        advanceUntilIdle()
+
+        val end = vm.uiState.value
+        assertEquals(listOf("fresh"), end.items.map { it.title })
+        assertFalse(end.isRefreshing)
+        // 新数据覆盖缓存
+        assertEquals(response("fresh"), cache.get("feed_hackernews_zh"))
+    }
+
+    @Test
+    fun noCacheKeepsSkeletonThenWritesCache() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val store = FakeCacheFileStore()
+        val cache = cache(store)
+        val gate = CompletableDeferred<FeedResponse>()
+
+        val vm = FeedViewModel("hackernews", FakeRepo { gate.await() }, settings(), cache)
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.isLoading)
+
+        gate.complete(response("fresh"))
+        advanceUntilIdle()
+
+        assertEquals(listOf("fresh"), vm.uiState.value.items.map { it.title })
+        assertEquals(response("fresh"), cache.get("feed_hackernews_zh"))
+    }
+
+    @Test
+    fun refreshFailureKeepsCachedContentSilently() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val store = FakeCacheFileStore()
+        val cache = cache(store)
+        cache.put("feed_hackernews_zh", response("cached"))
+
+        val vm = FeedViewModel("hackernews", FakeRepo { throw RuntimeException("boom") }, settings(), cache)
+        advanceUntilIdle()
+
+        val end = vm.uiState.value
+        // 有内容时刷新失败：静默保留，不显示整页错误
+        assertEquals(listOf("cached"), end.items.map { it.title })
+        assertNull(end.error)
+        assertFalse(end.isRefreshing)
+        // 失败不碰缓存
+        assertEquals(response("cached"), cache.get("feed_hackernews_zh"))
+    }
+
+    @Test
+    fun failureWithoutCacheShowsError() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val vm = FeedViewModel(
+            "hackernews",
+            FakeRepo { throw RuntimeException("boom") },
+            settings(),
+            cache(FakeCacheFileStore()),
+        )
+        advanceUntilIdle()
+
+        assertNotNull(vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isLoading)
+    }
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/picks/PicksViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/picks/PicksViewModelTest.kt
@@ -1,0 +1,92 @@
+package whl.trending.ai.ui.picks
+
+import com.russhwolf.settings.MapSettings
+import com.russhwolf.settings.ObservableSettings
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import whl.trending.ai.data.local.AppLanguage
+import whl.trending.ai.data.local.FakeCacheFileStore
+import whl.trending.ai.data.local.LastDataCache
+import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.model.PickItem
+import whl.trending.ai.data.model.PicksMetadata
+import whl.trending.ai.data.model.PicksResponse
+import whl.trending.ai.data.repository.TrendingRepository
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PicksViewModelTest {
+
+    private class FakeRepo(
+        val onPicks: suspend () -> PicksResponse,
+    ) : TrendingRepository() {
+        override suspend fun getPicks(summaryLang: String): PicksResponse = onPicks()
+    }
+
+    private fun response(date: String) = PicksResponse(
+        success = true,
+        metadata = PicksMetadata(date = date),
+        speedRead = listOf(PickItem(rank = 1, title = "item-$date")),
+    )
+
+    private fun settings(): SettingsManager =
+        SettingsManager(MapSettings() as ObservableSettings).also { it.setLanguage(AppLanguage.CHINESE) }
+
+    private fun TestScope.cache(store: FakeCacheFileStore) =
+        LastDataCache(store, StandardTestDispatcher(testScheduler))
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun cacheHitShowsCachedThenOverwritesWithFresh() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val cache = cache(FakeCacheFileStore())
+        cache.put("picks_zh", response("2026-07-02"))
+        val gate = CompletableDeferred<PicksResponse>()
+
+        val vm = PicksViewModel(FakeRepo { gate.await() }, settings(), cache)
+        advanceUntilIdle()
+
+        val mid = vm.uiState.value
+        assertEquals("2026-07-02", mid.picks?.metadata?.date)
+        assertFalse(mid.isLoading)
+        assertTrue(mid.isRefreshing)
+
+        gate.complete(response("2026-07-03"))
+        advanceUntilIdle()
+
+        assertEquals("2026-07-03", vm.uiState.value.picks?.metadata?.date)
+        assertEquals(response("2026-07-03"), cache.get("picks_zh"))
+    }
+
+    @Test
+    fun refreshFailureKeepsCachedContentSilently() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val cache = cache(FakeCacheFileStore())
+        cache.put("picks_zh", response("2026-07-02"))
+
+        val vm = PicksViewModel(FakeRepo { throw RuntimeException("boom") }, settings(), cache)
+        advanceUntilIdle()
+
+        val end = vm.uiState.value
+        assertEquals("2026-07-02", end.picks?.metadata?.date)
+        assertNull(end.error)
+        assertFalse(end.isRefreshing)
+        assertEquals(response("2026-07-02"), cache.get("picks_zh"))
+    }
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileCacheTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileCacheTest.kt
@@ -1,0 +1,136 @@
+package whl.trending.ai.ui.profile
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import whl.trending.ai.data.local.FakeCacheFileStore
+import whl.trending.ai.data.local.LastDataCache
+import whl.trending.ai.data.model.ContributionCalendar
+import whl.trending.ai.data.model.ContributionDay
+import whl.trending.ai.data.model.ContributionLevel
+import whl.trending.ai.data.model.ContributionWeek
+import whl.trending.ai.data.model.MeUser
+import whl.trending.ai.data.remote.GithubUser
+
+fun profileFeedItem(id: String) = GithubFeedItem(
+    id = id,
+    actorLogin = "actor",
+    actorAvatarUrl = null,
+    repoName = "octo/repo",
+    kind = GithubFeedKind.STARRED,
+    primary = null,
+    createdAt = "2026-07-01T00:00:00Z",
+    targetUrl = "https://github.com/octo/repo",
+)
+
+fun profileCalendar(total: Int = 42) = ContributionCalendar(
+    total = total,
+    weeks = listOf(
+        ContributionWeek(
+            days = listOf(ContributionDay(date = "2026-07-01", weekday = 3, count = 5, level = ContributionLevel.SECOND)),
+        ),
+    ),
+)
+
+fun profileMeUser(login: String? = "octo") = MeUser(userId = "u1", githubLogin = login, displayName = "Octo")
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProfileCacheTest {
+
+    private fun state(
+        user: MeUser? = profileMeUser(),
+        githubUser: GithubUser? = GithubUser(login = "octo", followers = 10),
+        contributions: ContributionCalendar? = profileCalendar(),
+        feedItems: List<GithubFeedItem> = listOf(profileFeedItem("e1")),
+        highlightsOnly: Boolean = true,
+    ) = ProfileUiState(
+        user = user,
+        githubUser = githubUser,
+        contributions = contributions,
+        feedItems = feedItems,
+        highlightsOnly = highlightsOnly,
+    )
+
+    @Test
+    fun fromReturnsNullWithoutUserOrLogin() {
+        assertNull(ProfileCache.from(state(user = null), previous = null))
+        assertNull(ProfileCache.from(state(user = profileMeUser(login = null)), previous = null))
+    }
+
+    @Test
+    fun fromCapsFeedItemsAtLimit() {
+        val many = (1..80).map { profileFeedItem("e$it") }
+        val snapshot = ProfileCache.from(state(feedItems = many), previous = null)!!
+        assertEquals(ProfileCache.MAX_FEED_ITEMS, snapshot.feedItems.size)
+        assertEquals("e1", snapshot.feedItems.first().id)
+    }
+
+    @Test
+    fun fromKeepsPreviousFieldsWhenCurrentMissing() {
+        // 只增不减：刷新中途 contributions/feed 尚未到达时，用旧快照补齐再覆盖
+        val previous = ProfileCache(
+            login = "octo",
+            user = profileMeUser(),
+            githubUser = GithubUser(login = "octo", followers = 3),
+            contributions = profileCalendar(total = 99),
+            feedItems = listOf(profileFeedItem("old")),
+            highlightsOnly = true,
+        )
+        val snapshot = ProfileCache.from(
+            state(githubUser = null, contributions = null, feedItems = emptyList()),
+            previous,
+        )!!
+        assertEquals(99, snapshot.contributions?.total)
+        assertEquals(listOf("old"), snapshot.feedItems.map { it.id })
+        assertEquals(3, snapshot.githubUser?.followers)
+    }
+
+    @Test
+    fun fromDropsPreviousFeedWhenFilterDiffers() {
+        // 档位不一致时旧 feed 不可复用，但档位无关的 contributions 仍补齐
+        val previous = ProfileCache(
+            login = "octo",
+            user = profileMeUser(),
+            githubUser = null,
+            contributions = profileCalendar(total = 99),
+            feedItems = listOf(profileFeedItem("old")),
+            highlightsOnly = true,
+        )
+        val snapshot = ProfileCache.from(
+            state(contributions = null, feedItems = emptyList(), highlightsOnly = false),
+            previous,
+        )!!
+        assertEquals(emptyList(), snapshot.feedItems)
+        assertEquals(99, snapshot.contributions?.total)
+        assertEquals(false, snapshot.highlightsOnly)
+    }
+
+    @Test
+    fun fromIgnoresPreviousOfDifferentLogin() {
+        val previous = ProfileCache(
+            login = "someone-else",
+            user = profileMeUser(login = "someone-else"),
+            githubUser = null,
+            contributions = profileCalendar(total = 99),
+            feedItems = listOf(profileFeedItem("old")),
+            highlightsOnly = true,
+        )
+        val snapshot = ProfileCache.from(
+            state(contributions = null, feedItems = emptyList()),
+            previous,
+        )!!
+        assertNull(snapshot.contributions)
+        assertEquals(emptyList(), snapshot.feedItems)
+    }
+
+    @Test
+    fun roundTripsThroughLastDataCache() = runTest {
+        val cache = LastDataCache(FakeCacheFileStore(), StandardTestDispatcher(testScheduler))
+        val snapshot = ProfileCache.from(state(), previous = null)!!
+        cache.put(ProfileCache.KEY, snapshot)
+        assertEquals(snapshot, cache.get(ProfileCache.KEY))
+    }
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
@@ -1,0 +1,203 @@
+package whl.trending.ai.ui.profile
+
+import com.russhwolf.settings.MapSettings
+import com.russhwolf.settings.ObservableSettings
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import whl.trending.ai.auth.AuthManager
+import whl.trending.ai.auth.AuthState
+import whl.trending.ai.auth.FollowingProvider
+import whl.trending.ai.auth.GithubTokenProvider
+import whl.trending.ai.auth.OwnRepoEventsProvider
+import whl.trending.ai.data.local.FakeCacheFileStore
+import whl.trending.ai.data.local.LastDataCache
+import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.model.ContributionCalendar
+import whl.trending.ai.data.model.MeUser
+import whl.trending.ai.data.remote.GithubApi
+import whl.trending.ai.data.remote.GithubEventDto
+import whl.trending.ai.data.remote.GithubUser
+import whl.trending.ai.data.repository.UserRepository
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProfileViewModelTest {
+
+    private class FakeAuthManager : AuthManager {
+        val state = MutableStateFlow<AuthState>(AuthState.LoggedIn)
+        override val isSupported: Boolean = true
+        override val authState: StateFlow<AuthState> = state
+        override fun signIn() {}
+        override fun signOut() {}
+        override suspend fun getAccessToken(): String? = "token"
+    }
+
+    private class FakeUserRepository(
+        val onFetchMe: suspend () -> MeUser = { profileMeUser() },
+    ) : UserRepository() {
+        override suspend fun fetchMe(accessToken: String): MeUser = onFetchMe()
+    }
+
+    private class FakeGithubApi : GithubApi() {
+        override suspend fun fetchUser(githubToken: String): GithubUser =
+            GithubUser(login = "octo", followers = 10, following = 5, publicRepos = 3)
+
+        override suspend fun fetchContributionCalendar(githubToken: String, login: String): ContributionCalendar =
+            profileCalendar(total = 7)
+
+        override suspend fun fetchReceivedEvents(
+            githubToken: String,
+            login: String,
+            page: Int,
+            perPage: Int,
+        ): List<GithubEventDto> = emptyList()
+    }
+
+    private class FakeTokenProvider : GithubTokenProvider() {
+        override suspend fun get(): String? = "gh-token"
+    }
+
+    private class FakeFollowingProvider : FollowingProvider() {
+        override suspend fun get() = null
+    }
+
+    private class FakeOwnRepoEventsProvider : OwnRepoEventsProvider() {
+        override suspend fun get(): List<GithubEventDto>? = null
+    }
+
+    private fun settings(highlightsOnly: Boolean = true): SettingsManager =
+        SettingsManager(MapSettings() as ObservableSettings).also { it.setFeedHighlightsOnly(highlightsOnly) }
+
+    private fun TestScope.cache(store: FakeCacheFileStore = FakeCacheFileStore()) =
+        LastDataCache(store, StandardTestDispatcher(testScheduler))
+
+    private fun viewModel(
+        cache: LastDataCache,
+        auth: FakeAuthManager = FakeAuthManager(),
+        repository: UserRepository = FakeUserRepository(),
+        settingsManager: SettingsManager = settings(),
+    ) = ProfileViewModel(
+        repository = repository,
+        githubApi = FakeGithubApi(),
+        tokenProvider = FakeTokenProvider(),
+        followingProvider = FakeFollowingProvider(),
+        ownRepoEventsProvider = FakeOwnRepoEventsProvider(),
+        authManager = { auth },
+        settingsManager = settingsManager,
+        cache = cache,
+    )
+
+    private fun cachedSnapshot(highlightsOnly: Boolean = true) = ProfileCache(
+        login = "octo",
+        user = profileMeUser(),
+        githubUser = GithubUser(login = "octo", followers = 3),
+        contributions = profileCalendar(total = 99),
+        feedItems = listOf(profileFeedItem("cached-event")),
+        highlightsOnly = highlightsOnly,
+    )
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun cacheHitFillsWholePageAndAutoRefreshes() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val cache = cache()
+        cache.put(ProfileCache.KEY, cachedSnapshot())
+        val gate = CompletableDeferred<MeUser>()
+
+        val vm = viewModel(cache, repository = FakeUserRepository { gate.await() })
+        vm.load()
+        advanceUntilIdle()
+
+        // 缓存整页秒出：header/计数/热力图/feed 都有，且顶部自动刷新中
+        val mid = vm.uiState.value
+        assertFalse(mid.isLoading)
+        assertTrue(mid.isRefreshing)
+        assertEquals("octo", mid.user?.githubLogin)
+        assertEquals(3, mid.githubUser?.followers)
+        assertEquals(99, mid.contributions?.total)
+        assertEquals(listOf("cached-event"), mid.feedItems.map { it.id })
+
+        gate.complete(profileMeUser())
+        advanceUntilIdle()
+
+        // 刷新完成：热力图/计数替换为最新
+        val end = vm.uiState.value
+        assertFalse(end.isRefreshing)
+        assertEquals(7, end.contributions?.total)
+        assertEquals(10, end.githubUser?.followers)
+    }
+
+    @Test
+    fun loadWithoutCachePersistsSnapshot() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val cache = cache()
+
+        val vm = viewModel(cache)
+        vm.load()
+        advanceUntilIdle()
+
+        val persisted = cache.get<ProfileCache>(ProfileCache.KEY)
+        assertNotNull(persisted)
+        assertEquals("octo", persisted.login)
+        assertEquals(7, persisted.contributions?.total)
+        assertEquals(10, persisted.githubUser?.followers)
+    }
+
+    @Test
+    fun cacheFilterMismatchUsesHeaderOnly() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val cache = cache()
+        cache.put(ProfileCache.KEY, cachedSnapshot(highlightsOnly = true))
+        val gate = CompletableDeferred<MeUser>()
+
+        val vm = viewModel(
+            cache,
+            repository = FakeUserRepository { gate.await() },
+            settingsManager = settings(highlightsOnly = false),
+        )
+        vm.load()
+        advanceUntilIdle()
+
+        // 档位不一致：header/热力图可用，feed 不复用
+        val mid = vm.uiState.value
+        assertEquals("octo", mid.user?.githubLogin)
+        assertEquals(99, mid.contributions?.total)
+        assertEquals(emptyList(), mid.feedItems)
+        assertFalse(mid.highlightsOnly)
+    }
+
+    @Test
+    fun logoutClearsProfileCache() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val cache = cache()
+        cache.put(ProfileCache.KEY, cachedSnapshot())
+        val auth = FakeAuthManager()
+
+        viewModel(cache, auth = auth)
+        advanceUntilIdle()
+
+        auth.state.value = AuthState.LoggedOut
+        advanceUntilIdle()
+
+        assertNull(cache.get<ProfileCache>(ProfileCache.KEY))
+    }
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/trending/TrendingViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/trending/TrendingViewModelTest.kt
@@ -1,0 +1,131 @@
+package whl.trending.ai.ui.trending
+
+import com.russhwolf.settings.MapSettings
+import com.russhwolf.settings.ObservableSettings
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import whl.trending.ai.data.local.AppLanguage
+import whl.trending.ai.data.local.FakeCacheFileStore
+import whl.trending.ai.data.local.LastDataCache
+import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.model.TrendingMetadata
+import whl.trending.ai.data.model.TrendingRepo
+import whl.trending.ai.data.model.TrendingResponse
+import whl.trending.ai.data.repository.TrendingRepository
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TrendingViewModelTest {
+
+    private class FakeRepo(
+        val onTrending: suspend (period: String, language: String) -> TrendingResponse,
+    ) : TrendingRepository() {
+        override suspend fun getTrending(
+            period: String,
+            language: String,
+            summaryLang: String,
+            date: String?,
+            batch: String?,
+        ): TrendingResponse = onTrending(period, language)
+    }
+
+    private fun response(repoName: String) = TrendingResponse(
+        success = true,
+        count = 1,
+        metadata = TrendingMetadata(since = "daily", capturedAt = "2026-07-03T00:17:00Z"),
+        data = listOf(TrendingRepo(rank = 1, author = "a", repoName = repoName)),
+    )
+
+    private fun settings(): SettingsManager =
+        SettingsManager(MapSettings() as ObservableSettings).also { it.setLanguage(AppLanguage.CHINESE) }
+
+    private fun TestScope.cache(store: FakeCacheFileStore) =
+        LastDataCache(store, StandardTestDispatcher(testScheduler))
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun cacheHitOnDefaultViewShowsCachedThenRefreshes() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val cache = cache(FakeCacheFileStore())
+        cache.put("trending_default_zh", response("cached-repo"))
+
+        val vm = TrendingViewModel(FakeRepo { _, _ -> response("fresh-repo") }, settings(), cache = cache)
+        advanceUntilIdle()
+
+        val end = vm.uiState.value
+        assertEquals(listOf("fresh-repo"), end.repos.map { it.repoName })
+        assertFalse(end.isRefreshing)
+        assertEquals(response("fresh-repo"), cache.get("trending_default_zh"))
+    }
+
+    @Test
+    fun nonDefaultViewFetchDoesNotOverwriteCache() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val cache = cache(FakeCacheFileStore())
+
+        val vm = TrendingViewModel(
+            FakeRepo { period, _ -> response("$period-repo") },
+            settings(),
+            cache = cache,
+        )
+        advanceUntilIdle()
+        // 默认视图成功 → 写缓存
+        assertEquals(response("daily-repo"), cache.get("trending_default_zh"))
+
+        vm.updateFilter(period = "weekly", language = "all")
+        advanceUntilIdle()
+        // 非默认视图成功 → 展示 weekly，但缓存仍是默认视图快照
+        assertEquals(listOf("weekly-repo"), vm.uiState.value.repos.map { it.repoName })
+        assertEquals(response("daily-repo"), cache.get("trending_default_zh"))
+    }
+
+    @Test
+    fun refreshFailureKeepsCachedContentSilently() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val cache = cache(FakeCacheFileStore())
+        cache.put("trending_default_zh", response("cached-repo"))
+
+        val vm = TrendingViewModel(FakeRepo { _, _ -> throw RuntimeException("boom") }, settings(), cache = cache)
+        advanceUntilIdle()
+
+        val end = vm.uiState.value
+        assertEquals(listOf("cached-repo"), end.repos.map { it.repoName })
+        assertNull(end.error)
+        assertFalse(end.isRefreshing)
+    }
+
+    @Test
+    fun cacheHitShowsRefreshingIndicatorWhileFetching() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val cache = cache(FakeCacheFileStore())
+        cache.put("trending_default_zh", response("cached-repo"))
+        val gate = kotlinx.coroutines.CompletableDeferred<TrendingResponse>()
+
+        val vm = TrendingViewModel(FakeRepo { _, _ -> gate.await() }, settings(), cache = cache)
+        advanceUntilIdle()
+
+        val mid = vm.uiState.value
+        assertEquals(listOf("cached-repo"), mid.repos.map { it.repoName })
+        assertFalse(mid.isLoading)
+        assertTrue(mid.isRefreshing)
+
+        gate.complete(response("fresh-repo"))
+        advanceUntilIdle()
+        assertEquals(listOf("fresh-repo"), vm.uiState.value.repos.map { it.repoName })
+    }
+}

--- a/shared/src/iosMain/kotlin/whl/trending/ai/data/local/CacheFileStore.ios.kt
+++ b/shared/src/iosMain/kotlin/whl/trending/ai/data/local/CacheFileStore.ios.kt
@@ -7,6 +7,7 @@ import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSString
 import platform.Foundation.NSUTF8StringEncoding
 import platform.Foundation.NSUserDomainMask
+import platform.Foundation.create
 import platform.Foundation.stringWithContentsOfFile
 import platform.Foundation.writeToFile
 
@@ -35,8 +36,8 @@ private class IosCacheFileStore : CacheFileStore {
     override fun write(name: String, content: String) {
         val path = filePath(name) ?: return
         // atomically = true：NSString 自带先写临时文件再替换的原子语义
-        @Suppress("CAST_NEVER_SUCCEEDS")
-        (content as NSString).writeToFile(path, atomically = true, encoding = NSUTF8StringEncoding, error = null)
+        NSString.create(string = content)
+            .writeToFile(path, atomically = true, encoding = NSUTF8StringEncoding, error = null)
     }
 
     override fun delete(name: String) {

--- a/shared/src/iosMain/kotlin/whl/trending/ai/data/local/CacheFileStore.ios.kt
+++ b/shared/src/iosMain/kotlin/whl/trending/ai/data/local/CacheFileStore.ios.kt
@@ -1,5 +1,6 @@
 package whl.trending.ai.data.local
 
+import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSCachesDirectory
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
@@ -11,6 +12,7 @@ import platform.Foundation.writeToFile
 
 actual fun platformCacheFileStore(): CacheFileStore = IosCacheFileStore()
 
+@OptIn(ExperimentalForeignApi::class)
 private class IosCacheFileStore : CacheFileStore {
     private fun filePath(name: String): String? {
         val caches = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, true)

--- a/shared/src/iosMain/kotlin/whl/trending/ai/data/local/CacheFileStore.ios.kt
+++ b/shared/src/iosMain/kotlin/whl/trending/ai/data/local/CacheFileStore.ios.kt
@@ -1,0 +1,44 @@
+package whl.trending.ai.data.local
+
+import platform.Foundation.NSCachesDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.NSUserDomainMask
+import platform.Foundation.stringWithContentsOfFile
+import platform.Foundation.writeToFile
+
+actual fun platformCacheFileStore(): CacheFileStore = IosCacheFileStore()
+
+private class IosCacheFileStore : CacheFileStore {
+    private fun filePath(name: String): String? {
+        val caches = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, true)
+            .firstOrNull() as? String ?: return null
+        val dir = "$caches/lastdata"
+        NSFileManager.defaultManager.createDirectoryAtPath(
+            dir,
+            withIntermediateDirectories = true,
+            attributes = null,
+            error = null,
+        )
+        return "$dir/$name"
+    }
+
+    override fun read(name: String): String? {
+        val path = filePath(name) ?: return null
+        return NSString.stringWithContentsOfFile(path, NSUTF8StringEncoding, null)
+    }
+
+    override fun write(name: String, content: String) {
+        val path = filePath(name) ?: return
+        // atomically = true：NSString 自带先写临时文件再替换的原子语义
+        @Suppress("CAST_NEVER_SUCCEEDS")
+        (content as NSString).writeToFile(path, atomically = true, encoding = NSUTF8StringEncoding, error = null)
+    }
+
+    override fun delete(name: String) {
+        val path = filePath(name) ?: return
+        NSFileManager.defaultManager.removeItemAtPath(path, error = null)
+    }
+}


### PR DESCRIPTION
## 背景

首次进入各页面接口加载慢，用户只能干等骨架屏。本 PR 引入统一的「上次数据缓存」：**进入页面优先展示上次成功获取的数据，同时顶部指示器自动刷新，新数据到达后无感替换**（stale-while-revalidate）。

设计文档： docs/superpowers/specs/2026-07-03-last-data-cache-design.md

## 覆盖范围

- 首页四 tab：Picks / Hacker News / Product Hunt / GitHub Trending（仅默认视图 daily+all）
- Profile 首屏：用户信息 + GitHub 计数 + 贡献热力图 + feed 首屏（50 条上限）

## 实现

**缓存基础设施**
- `CacheFileStore`（expect/actual）：Android `cacheDir/lastdata`（临时文件 rename 原子写）/ iOS `NSCachesDirectory`（atomically 写入）
- `LastDataCache`：JSON 文件缓存，`v1_` schema 版本前缀，解码失败自动删文件回退，IO 走可注入调度器

**写入规则（覆盖语义）**
- 只有网络成功才写缓存，整 key 全量覆盖；失败不碰缓存
- Profile 例外「覆盖 + 只增不减」：渐进加载中途落盘时，残缺字段用旧快照补齐，杜绝完整缓存被冲成 header-only

**行为变化**
- SWR 自动刷新复用 `isRefreshing`（PullToRefreshBox 顶部 LoadingIndicator），跳过手动下拉的 500ms 防闪烁延迟
- 刷新失败且已有内容时静默保留（不置 error），仅无内容时才整页错误——规则收敛在 VM 层，Screen 零改动
- 语言切换 key 天然隔离（`_zh` / `_en`）；登出清 Profile 缓存
- `TrendingRepository` / `UserRepository` 改 open 供测试子类替身

## 测试与验证

- 新增 28 个单测（LastDataCache 8 / 列表页 VM 10 / ProfileCache+VM 10），全套 105 个测试通过
- iOS 目标编译通过（`compileKotlinIosSimulatorArm64`）
- Pixel 9 模拟器端到端验证：
  - 冷启动无缓存 → 骨架屏 → 数据落盘 ✅
  - 杀进程重启 1.2s 内容秒出 + 顶部指示器自动刷新 ✅
  - 飞行模式重启 → 缓存兜底展示、刷新静默失败、无错误页 ✅
  - 手工损坏缓存文件 → 自动删除回退，无崩溃 ✅
  - 三 tab 缓存文件（trending/hackernews/picks）均正确写入 ✅
  - Profile 需登录态，模拟器未验证真机流程（单测覆盖）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

引入统一的「最后数据缓存」层，为首页各 Tab 和个人资料页提供 stale-while-revalidate（过期后再验证）加载机制，在后台刷新数据的同时即时展示先前获取的内容。

**新增功能：**
- 添加跨平台的 `LastDataCache`，基于各平台的缓存目录，为关键页面存储最近一次成功的响应数据。
- 为 Picks、feed 来源、默认 Trending 视图和 Profile 缓存初始数据，使这些页面在首次加载时即可立即显示缓存内容。
- 实现针对 Profile 的快照缓存，持久化用户信息、GitHub 统计数据、贡献日历以及首屏 feed 条目，并支持基于过滤条件的复用。

**增强改进：**
- 更新 `PicksViewModel`、`FeedViewModel` 和 `TrendingViewModel`，在存在缓存数据时优先从缓存加载，然后自动刷新且不再显示骨架屏。
- 调整错误处理逻辑，使刷新失败时保留已有内容，仅在完全没有数据时显示整页错误。
- 将 `TrendingRepository` 和 `UserRepository` 改为 `open`，以便在单元测试中使用测试替身（test doubles）。
- 为贡献模型和 GitHub feed 模型添加序列化支持，以便将它们纳入缓存快照中。

**文档：**
- 添加一份详细的设计文档，描述统一的最后数据缓存架构、缓存键设计、行为以及在相关页面中的 SWR 策略。

**测试：**
- 使用 fake 文件存储，为 `LastDataCache` 的行为和文件语义添加全面的单元测试。
- 为 `PicksViewModel`、`FeedViewModel`、`TrendingViewModel` 和 `ProfileViewModel` 添加单元测试，验证缓存命中流程、刷新行为和错误处理。
- 添加针对 `ProfileCache` 的专门测试，覆盖快照构建、增量更新和缓存往返（写入-读取）流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a unified last-data cache layer to enable stale-while-revalidate loading for home tabs and the Profile screen, showing previously fetched content instantly while refreshing in the background.

New Features:
- Add a cross-platform LastDataCache backed by platform cache directories to store the last successful responses for key screens.
- Cache initial data for Picks, feed sources, default Trending view, and Profile so these pages can display cached content immediately on first load.
- Implement Profile-specific snapshot caching that persists user info, GitHub stats, contribution calendar, and first-page feed items with filter-aware reuse.

Enhancements:
- Update PicksViewModel, FeedViewModel, and TrendingViewModel to load from cache first, then auto-refresh without skeleton screens when cached data exists.
- Adjust error handling so refresh failures keep existing content and only show full-page errors when no data is available.
- Make TrendingRepository and UserRepository open to allow test doubles in unit tests.
- Add serialization support to contribution and GitHub feed models to enable their inclusion in cached snapshots.

Documentation:
- Add a detailed design document describing the unified last-data cache architecture, keys, behaviors, and SWR strategy across affected screens.

Tests:
- Add comprehensive unit tests for LastDataCache behavior and file semantics using a fake file store.
- Add unit tests for PicksViewModel, FeedViewModel, TrendingViewModel, and ProfileViewModel to verify cache hit flows, refresh behavior, and error handling.
- Add ProfileCache-specific tests to cover snapshot construction, incremental updates, and cache round-tripping.

</details>