### PR TITLE
feat(chat): AI 助手回复增加复制按钮

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
@@ -1,8 +1,12 @@
 package whl.trending.chat.ui
 
+import android.content.ClipData
+import android.os.Build
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -10,6 +14,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -18,11 +23,16 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 import whl.trending.ai.core.platform.shareText
 import whl.trending.chat.R
 import whl.trending.chat.markdown.MarkdownText
@@ -80,16 +90,42 @@ private fun AssistantMessage(message: ChatMessage, onRetry: () -> Unit, modifier
                     textStyle = MaterialTheme.typography.bodyLarge,
                 )
             }
-            IconButton(
-                onClick = { shareText(message.content) },
-                modifier = Modifier.size(32.dp),
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.Share,
-                    contentDescription = stringResource(R.string.chat_share),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(18.dp),
-                )
+            Row {
+                val clipboard = LocalClipboard.current
+                val context = LocalContext.current
+                val scope = rememberCoroutineScope()
+                IconButton(
+                    onClick = {
+                        scope.launch {
+                            clipboard.setClipEntry(
+                                ClipEntry(ClipData.newPlainText("chat", message.content)),
+                            )
+                            // Android 13+ 系统自带剪贴板浮层提示，低版本补 Toast
+                            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                                Toast.makeText(context, R.string.chat_copied, Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                    },
+                    modifier = Modifier.size(32.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.ContentCopy,
+                        contentDescription = stringResource(R.string.chat_copy),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+                IconButton(
+                    onClick = { shareText(message.content) },
+                    modifier = Modifier.size(32.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Share,
+                        contentDescription = stringResource(R.string.chat_share),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
             }
         } else {
             Text(

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -17,6 +17,8 @@
     <string name="chat_action_what_can_you_do_prompt">你可以做什么？请简要介绍你的能力和适用场景。</string>
     <string name="chat_retry">重试</string>
     <string name="chat_share">分享</string>
+    <string name="chat_copy">复制</string>
+    <string name="chat_copied">已复制</string>
     <string name="chat_quota_exceeded">今日额度已用完，明天再来吧。</string>
     <string name="chat_beta_badge">Beta</string>
     <string name="chat_quota_notice">实验性功能，每日有限免费额度，用尽次日恢复。</string>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -17,6 +17,8 @@
     <string name="chat_action_what_can_you_do_prompt">What can you do? Briefly introduce your capabilities and typical use cases.</string>
     <string name="chat_retry">Retry</string>
     <string name="chat_share">Share</string>
+    <string name="chat_copy">Copy</string>
+    <string name="chat_copied">Copied</string>
     <string name="chat_quota_exceeded">You\'ve reached today\'s limit. Please come back tomorrow.</string>
     <string name="chat_beta_badge">Beta</string>
     <string name="chat_quota_notice">Experimental feature. Limited free chats each day, resetting tomorrow.</string>


### PR DESCRIPTION
## 背景

Closes #35（需求已调整：不做「选中部分文本后分享」，改为在已有分享按钮旁增加复制按钮）

## 改动

- `MessageItem.kt`：助手回复下方新增复制 IconButton（`Outlined.ContentCopy`，与分享按钮同尺寸同色），点击复制整条回复的 Markdown 原文到剪贴板（复用模块内 CodeBlock 的 `LocalClipboard` + `ClipEntry` 写法）
- Android 13+ 依赖系统剪贴板浮层提示；12 及以下补 Toast「已复制」
- 中英文各新增 `chat_copy` / `chat_copied` 文案

## 验证

Pixel 9 (2) 模拟器（Android 16）实机验证：复制按钮显示正常，点击后系统浮层弹出，预览内容为整条回复原文。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在聊天界面中为 AI 助手回复在分享按钮旁新增“复制到剪贴板”操作。

新功能：
- 在助手消息上添加复制图标按钮，将完整的 Markdown 回复文本复制到剪贴板。
- 在 Android 12 及以下版本上通过 Toast 显示本地化的“已复制”消息，在 Android 13 及以上版本则依赖系统的剪贴板悬浮提示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a copy-to-clipboard action beside the share button for AI assistant replies in the chat UI.

New Features:
- Introduce a copy icon button on assistant messages that copies the full Markdown reply text to the clipboard.
- Show a localized "copied" message via Toast on Android 12 and below while relying on the system clipboard overlay on Android 13+.

</details>