### PR TITLE
fix(trending): 切换「只看 New」时列表滚回顶部

### DIFF
--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -43,6 +43,8 @@
     <string name="filter_new_only">只看 New</string>
     <string name="no_new_repos">今日暂无新上榜项目</string>
     <string name="new_only_hint">近期首次登上 GitHub 日榜（全语言）的新项目</string>
+    <string name="new_only_default">默认只看 New</string>
+    <string name="new_only_default_desc">启动时自动开启 GitHub 榜的「只看 New」过滤</string>
     <string name="retry">重试</string>
     <string name="error_fetch">获取数据失败: %1$s</string>
     <string name="back">返回</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -43,6 +43,8 @@
     <string name="filter_new_only">New only</string>
     <string name="no_new_repos">No new repos today</string>
     <string name="new_only_hint">Projects new to the GitHub daily all-language trending board</string>
+    <string name="new_only_default">New only by default</string>
+    <string name="new_only_default_desc">Turn on the New filter for the GitHub list at launch</string>
     <string name="retry">Retry</string>
     <string name="error_fetch">Failed to fetch data: %1$s</string>
     <string name="back">Back</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -43,6 +43,7 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val USER_AVATAR_KEY = "prefs_user_avatar_url"
     private val FEED_HIGHLIGHTS_ONLY_KEY = "prefs_feed_filter_highlights"
     private val OPEN_LINKS_IN_CUSTOM_TAB_KEY = "prefs_open_links_in_custom_tab"
+    private val TRENDING_NEW_ONLY_DEFAULT_KEY = "prefs_trending_new_only_default"
 
     /**
      * 安装级匿名标识：首次访问时生成并持久化，之后保持不变（卸载重装才会重新生成）。
@@ -174,6 +175,20 @@ class SettingsManager(private val settings: ObservableSettings) {
 
     fun setOpenLinksInCustomTab(value: Boolean) {
         settings.putBoolean(OPEN_LINKS_IN_CUSTOM_TAB_KEY, value)
+    }
+
+    /**
+     * GitHub 榜「只看 New」的默认状态：true 时进入 app 默认开启该过滤。
+     * 只决定初始值；榜单页手动切换仅影响当前会话，不回写此设置。
+     */
+    val trendingNewOnlyDefault: Flow<Boolean> =
+        settings.getBooleanFlow(TRENDING_NEW_ONLY_DEFAULT_KEY, false)
+
+    fun getTrendingNewOnlyDefaultSync(): Boolean =
+        settings.getBoolean(TRENDING_NEW_ONLY_DEFAULT_KEY, false)
+
+    fun setTrendingNewOnlyDefault(value: Boolean) {
+        settings.putBoolean(TRENDING_NEW_ONLY_DEFAULT_KEY, value)
     }
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ColorLens
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FiberNew
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PrivacyTip
 import androidx.compose.material.icons.filled.Language
@@ -103,6 +104,8 @@ import trendingai.shared.generated.resources.language_option_chinese
 import trendingai.shared.generated.resources.language_option_english
 import trendingai.shared.generated.resources.language_option_follow_system
 import trendingai.shared.generated.resources.language_system_follow
+import trendingai.shared.generated.resources.new_only_default
+import trendingai.shared.generated.resources.new_only_default_desc
 import trendingai.shared.generated.resources.open_links_in_browser
 import trendingai.shared.generated.resources.open_links_in_browser_desc
 import trendingai.shared.generated.resources.open_links_in_browser_message
@@ -141,6 +144,7 @@ fun SettingsScreen(
     val seedColor by globalSettingsManager.seedColor.collectAsState(DEFAULT_SEED_ARGB)
     val appLanguage by globalSettingsManager.appLanguage.collectAsState(AppLanguage.FOLLOW_SYSTEM)
     val openLinksInCustomTab by globalSettingsManager.openLinksInCustomTab.collectAsState(true)
+    val trendingNewOnlyDefault by globalSettingsManager.trendingNewOnlyDefault.collectAsState(false)
     val appVersion = remember { getAppVersion() }
     val isChecking by globalUpdateChecker.isChecking.collectAsState()
     val isUpToDate by globalUpdateChecker.isUpToDate.collectAsState()
@@ -402,6 +406,23 @@ fun SettingsScreen(
                     modifier = Modifier.clickable {
                         trackEvent("settings_open_links_detail")
                         showOpenLinksDialog = true
+                    }
+                )
+            }
+            // 「只看 New」默认开关：只决定进入 app 时的初始状态，榜单页手动切换不回写
+            item {
+                ListItem(
+                    headlineContent = { Text(stringResource(Res.string.new_only_default)) },
+                    supportingContent = { Text(stringResource(Res.string.new_only_default_desc)) },
+                    leadingContent = { Icon(Icons.Default.FiberNew, null) },
+                    trailingContent = {
+                        Switch(
+                            checked = trendingNewOnlyDefault,
+                            onCheckedChange = { enabled ->
+                                trackEvent("settings_new_only_default", mapOf("enabled" to enabled.toString()))
+                                globalSettingsManager.setTrendingNewOnlyDefault(enabled)
+                            }
+                        )
                     }
                 )
             }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -219,6 +220,12 @@ private fun RepoList(
     onStarRepo: ((TrendingRepo) -> Unit)? = null,
 ) {
     val state = rememberPullToRefreshState()
+    val listState = rememberLazyListState()
+    // 切换「只看 New」时滚回顶部：LazyColumn 按 key 会保持可视位置，
+    // 关掉开关后画面几乎不变，用户容易以为切换没生效（#36）
+    LaunchedEffect(uiState.newOnly) {
+        listState.scrollToItem(0)
+    }
 
     PullToRefreshBox(
         isRefreshing = uiState.isRefreshing,
@@ -270,7 +277,7 @@ private fun RepoList(
             else -> {
                 val favorites by globalSettingsManager.favorites.collectAsState(emptyList())
                 val favoriteUrls = remember(favorites) { favorites.map { it.url }.toSet() }
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
                 items(
                     count = displayRepos.size,
                     key = { index -> displayRepos[index].url }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingViewModel.kt
@@ -56,6 +56,11 @@ class TrendingViewModel(
     private var fetchJob: Job? = null
 
     init {
+        // 「只看 New」初始值取自设置项（默认关）；页面内手动切换仅影响当前会话。
+        // 初始视图就是该过滤唯一有效的 daily 全语言榜，直接置位即可。
+        if (settingsManager.getTrendingNewOnlyDefaultSync()) {
+            _uiState.update { it.copy(newOnly = true) }
+        }
         loadWithCache()
 
         viewModelScope.launch {


### PR DESCRIPTION
## 背景

Closes #36

「只看 New」开→关时，`displayRepos` 虽然换回了全量列表，但 LazyColumn 按 item key 保持了当前可视位置，画面几乎不变，用户容易以为切换没生效。

## 改动

### 1. 切换「只看 New」时列表滚回顶部
- `TrendingScreen.kt`：hoist `LazyListState`，`LaunchedEffect(uiState.newOnly)` 里 `scrollToItem(0)`——开/关切换都滚回顶部，让列表变化肉眼可见

### 2. 设置页新增「默认只看 New」开关（默认关）
- `SettingsManager`：新增 `trendingNewOnlyDefault` 持久化项（照 `openLinksInCustomTab` 模式）
- `TrendingViewModel`：init 时读取该设置作为 `newOnly` 初始值；初始视图就是过滤唯一有效的 daily 全语言榜，无冲突
- `SettingsScreen`：App Settings 分组加一行 Switch（FiberNew 图标），埋点 `settings_new_only_default`
- 语义边界：设置只决定**初始值**；榜单页手动切换仅影响当前会话、不回写设置；改设置后下次启动生效
- 中英文案各加 `new_only_default` / `new_only_default_desc`

## 验证

Pixel 9 (2) 模拟器实机验证：
- 开 NEW 后滚动到第 7-8 位，关掉 NEW，列表立即回到顶部第 1 名（非 NEW 项目）
- 设置开关默认关；打开后 force-stop 重启，GitHub 榜启动即 NEW 过滤开启（chip 高亮、列表全 NEW）；关回后重启恢复全量列表

🤖 Generated with [Claude Code](https://claude.com/claude-code)