### PR TITLE
feat(home): 双击底部 tab 触发当前列表下拉刷新

### DIFF
--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
@@ -87,6 +88,7 @@ import whl.trending.ai.ui.picks.PicksViewModel
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.ui.trending.TrendingScreen
 import whl.trending.ai.ui.trending.TrendingViewModel
+import kotlin.time.Clock
 
 enum class HomeTab {
     GitHub, HackerNews, ProductHunt, Picks
@@ -114,6 +116,14 @@ fun HomeScreen(
         viewModel { PicksViewModel() }
     } else null
     val picksUiState = picksViewModel?.uiState?.collectAsState()?.value
+
+    // HN / PH 同样按需创建；提升到这里是为了 bottomBar 双击刷新能拿到同一实例
+    val hnViewModel: FeedViewModel? = if (selectedTab == HomeTab.HackerNews) {
+        viewModel(key = "hackernews") { FeedViewModel("hackernews") }
+    } else null
+    val phViewModel: FeedViewModel? = if (selectedTab == HomeTab.ProductHunt) {
+        viewModel(key = "producthunt") { FeedViewModel("producthunt") }
+    } else null
 
     val authManager = globalAuthManager
     val authState by authManager.authState.collectAsState()
@@ -205,10 +215,32 @@ fun HomeScreen(
             }
         },
         bottomBar = {
+            // 双击当前 tab 触发下拉刷新（#38）：仅当两次点击都落在已选中的 tab 上才算，
+            // 双击未选中的 tab 只切换不刷新（切换会重置计时）
+            val doubleTapMillis = LocalViewConfiguration.current.doubleTapTimeoutMillis
+            var lastTapTime by remember { mutableStateOf(0L) }
+            val refreshCurrentTab = {
+                trackEvent("tab_double_tap_refresh", mapOf("tab" to selectedTab.name.lowercase()))
+                when (selectedTab) {
+                    HomeTab.GitHub -> trendingViewModel.fetchData(isRefresh = true)
+                    HomeTab.HackerNews -> hnViewModel?.refresh()
+                    HomeTab.ProductHunt -> phViewModel?.refresh()
+                    HomeTab.Picks -> picksViewModel?.refresh()
+                }
+            }
             val switchTo = { tab: HomeTab ->
                 if (selectedTab != tab) {
                     trackEvent("tab_switch", mapOf("tab" to tab.name.lowercase()))
                     selectedTabName = tab.name
+                    lastTapTime = 0L
+                } else {
+                    val now = Clock.System.now().toEpochMilliseconds()
+                    if (now - lastTapTime <= doubleTapMillis) {
+                        refreshCurrentTab()
+                        lastTapTime = 0L // 已触发一次，三连击不重复刷新
+                    } else {
+                        lastTapTime = now
+                    }
                 }
             }
             NavigationBar {
@@ -249,22 +281,16 @@ fun HomeScreen(
                 modifier = Modifier.padding(innerPadding),
                 viewModel = trendingViewModel
             )
-            HomeTab.HackerNews -> {
-                val hnViewModel: FeedViewModel = viewModel(key = "hackernews") { FeedViewModel("hackernews") }
-                FeedScreen(
-                    modifier = Modifier.padding(innerPadding),
-                    viewModel = hnViewModel,
-                    onOpenUrl = onOpenUrl
-                )
-            }
-            HomeTab.ProductHunt -> {
-                val phViewModel: FeedViewModel = viewModel(key = "producthunt") { FeedViewModel("producthunt") }
-                FeedScreen(
-                    modifier = Modifier.padding(innerPadding),
-                    viewModel = phViewModel,
-                    onOpenUrl = onOpenUrl
-                )
-            }
+            HomeTab.HackerNews -> FeedScreen(
+                modifier = Modifier.padding(innerPadding),
+                viewModel = hnViewModel!!,
+                onOpenUrl = onOpenUrl
+            )
+            HomeTab.ProductHunt -> FeedScreen(
+                modifier = Modifier.padding(innerPadding),
+                viewModel = phViewModel!!,
+                onOpenUrl = onOpenUrl
+            )
             HomeTab.Picks -> PicksScreen(
                 onNavigateToDetail = onNavigateToDetail,
                 onOpenUrl = onOpenUrl,


### PR DESCRIPTION
## 背景

Closes #38

## 改动

- `HomeScreen.kt` bottomBar：双击检测（窗口取系统 `LocalViewConfiguration.doubleTapTimeoutMillis`），双击**已选中**的 tab 时调用对应 ViewModel 的刷新；双击未选中 tab 只切换不刷新（切换会重置计时），避免误触
- 四个 tab 的刷新分发：GitHub → `TrendingViewModel.fetchData(isRefresh=true)`，HN/PH → `FeedViewModel.refresh()`，Picks → `PicksViewModel.refresh()`
- HN/PH 的 `FeedViewModel` 从 content lambda 提升到 HomeScreen 层按需创建（与 Picks 相同模式，`viewModel(key=...)` 同 key 拿到的是同一实例），bottomBar 才能调到
- 新增埋点 `tab_double_tap_refresh`（带 tab 名）

## 验证

Pixel 9 (2) 模拟器实机验证：
- GitHub tab：单击已选中 tab 无反应；双击出现下拉刷新指示器
- HN tab：切换正常，双击同样触发刷新指示器

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在首页底部标签栏中添加双击刷新行为，并在首页层级暴露各个 feed 的视图模型，以便底部栏可以触发当前标签的刷新。

New Features:
- 当用户双击当前选中的首页底部导航项时，对该标签触发下拉刷新；单击行为仍然只用于切换标签。
- 在每次触发双击刷新时，发送带有标签名称的 `tab_double_tap_refresh` 埋点事件。

Enhancements:
- 将 HackerNews 和 ProductHunt 的 `FeedViewModel` 实例提升到 `HomeScreen` 作用域，以便在内容区域和底部栏交互之间复用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add double-tap-refresh behavior to the home screen bottom tabs and expose feed view models at the home level so the bottom bar can trigger refreshes on the active tab.

New Features:
- Trigger a pull-to-refresh on the currently selected home tab when its bottom navigation item is double-tapped, while single taps continue to only switch tabs.
- Emit a tab_double_tap_refresh analytics event with the tab name whenever a double-tap refresh is triggered.

Enhancements:
- Lift HackerNews and ProductHunt FeedViewModel instances to the HomeScreen scope for reuse between content and bottom bar interactions.

</details>