### PR TITLE
feat(chat): 配额触顶卡片 — 登录解锁每日 10 条 + Pro waitlist

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -74,7 +74,7 @@ class ChatViewModel(
                     ?: ChatError(ChatErrorCategory.UNKNOWN, detail = e.toString())
                 // 付费意愿漏斗第一级：个人配额触顶（在 VM 记一次，避免 UI 重组重复上报）
                 if (error.code == "quota_device") {
-                    trackEvent("chat_quota_hit", mapOf("tier" to (error.tier ?: "anonymous")))
+                    trackEvent("chat_quota_hit", mapOf("tier" to (error.tier ?: ChatError.TIER_ANONYMOUS)))
                 }
                 ChatMessage(nextId(), Role.ASSISTANT, "", error = error)
             },

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import whl.trending.ai.chat.ChatContext
+import whl.trending.ai.core.platform.trackEvent
 import whl.trending.chat.engine.ChatEngine
 import whl.trending.chat.engine.ChatException
 import whl.trending.chat.model.ChatError
@@ -53,9 +54,11 @@ class ChatViewModel(
         request()
     }
 
-    /** 对可重试的失败消息重试：移除该错误条，按当前历史重新请求。 */
+    /** 对可重试的失败消息重试：移除该错误条，按当前历史重新请求。
+     *  quota_device 例外放行：匿名触顶后完成登录，配额键已切换，重发即可续聊。 */
     fun retry(message: ChatMessage) {
-        if (message.error?.category?.retryable != true) return
+        val error = message.error ?: return
+        if (!error.category.retryable && error.code != "quota_device") return
         _uiState.update {
             it.copy(messages = it.messages.filterNot { m -> m.id == message.id }, isSending = true)
         }
@@ -69,6 +72,10 @@ class ChatViewModel(
             onFailure = { e ->
                 val error = (e as? ChatException)?.error
                     ?: ChatError(ChatErrorCategory.UNKNOWN, detail = e.toString())
+                // 付费意愿漏斗第一级：个人配额触顶（在 VM 记一次，避免 UI 重组重复上报）
+                if (error.code == "quota_device") {
+                    trackEvent("chat_quota_hit", mapOf("tier" to (error.tier ?: "anonymous")))
+                }
                 ChatMessage(nextId(), Role.ASSISTANT, "", error = error)
             },
         )

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.util.Locale
+import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.chat.ChatContext
 import whl.trending.ai.data.local.AppLanguage
 import whl.trending.ai.data.local.globalSettingsManager
@@ -69,7 +70,11 @@ class ChatApi(
     private data class ChatResponse(val content: String)
 
     @Serializable
-    private data class ErrorResponse(val error: String? = null, val code: String? = null)
+    private data class ErrorResponse(
+        val error: String? = null,
+        val code: String? = null,
+        val tier: String? = null,
+    )
 
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -90,6 +95,8 @@ class ChatApi(
         try {
             val response: HttpResponse = client.post("$baseUrl/chat") {
                 header("X-Install-Id", globalSettingsManager.getOrCreateInstallId())
+                // 已登录则带 token 走登录档配额（每日 10 条）；token 无效时服务端静默降级匿名档
+                globalAuthManager.getAccessToken()?.let { header("Authorization", "Bearer $it") }
                 contentType(ContentType.Application.Json)
                 setBody(
                     ChatRequest(
@@ -115,7 +122,9 @@ class ChatApi(
             val raw = runCatching { response.bodyAsText() }.getOrNull()
             val parsed = raw?.let { runCatching { json.decodeFromString<ErrorResponse>(it) }.getOrNull() }
             val bodyError = parsed?.error ?: raw
-            throw ChatException(ChatErrors.forStatus(response.status.value, parsed?.code, bodyError))
+            throw ChatException(
+                ChatErrors.forStatus(response.status.value, parsed?.code, bodyError, parsed?.tier),
+            )
         } catch (e: ChatException) {
             logFailure(e.error)
             throw e

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatErrors.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatErrors.kt
@@ -18,15 +18,16 @@ object ChatErrors {
      * 非 2xx 响应 → 分类。
      * @param code 服务端机器可读错误码（可空），透传给 UI 选具体文案
      * @param bodyError 服务端 error 文案（用于 detail）
+     * @param tier 429 响应体的配额档位（可空），透传给 UI 选触顶卡片形态
      */
-    fun forStatus(status: Int, code: String?, bodyError: String?): ChatError {
+    fun forStatus(status: Int, code: String?, bodyError: String?, tier: String? = null): ChatError {
         val category = when {
             status == 429 -> ChatErrorCategory.QUOTA
             status in 500..599 -> ChatErrorCategory.SERVER
             status in 400..499 -> ChatErrorCategory.BAD_REQUEST
             else -> ChatErrorCategory.UNKNOWN
         }
-        return ChatError(category, code = code, httpStatus = status, detail = bodyError)
+        return ChatError(category, code = code, httpStatus = status, detail = bodyError, tier = tier)
     }
 
     /** 传输/未知异常 → 分类。SocketTimeout 先于 IOException 判断（前者是后者子类）。 */

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatError.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatError.kt
@@ -28,4 +28,10 @@ data class ChatError(
     val httpStatus: Int? = null,
     val detail: String? = null,
     val tier: String? = null,
-)
+) {
+    companion object {
+        /** 服务端 429 响应 tier 字段的取值，与 Worker 端 chat.js 保持一致 */
+        const val TIER_ANONYMOUS = "anonymous"
+        const val TIER_USER = "user"
+    }
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatError.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatError.kt
@@ -20,10 +20,12 @@ enum class ChatErrorCategory(val retryable: Boolean) {
  * @param code 服务端机器可读错误码（如 `content_too_long`/`quota_global`），优先据此选具体文案
  * @param httpStatus 有 HTTP 响应时的状态码
  * @param detail 服务端 error 文案或异常摘要，仅用于日志/调试，不直接展示给用户
+ * @param tier 429 触顶时的配额档位（`anonymous`/`user`），驱动触顶卡片形态（登录 CTA vs waitlist CTA）
  */
 data class ChatError(
     val category: ChatErrorCategory,
     val code: String? = null,
     val httpStatus: Int? = null,
     val detail: String? = null,
+    val tier: String? = null,
 )

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
@@ -127,6 +127,9 @@ private fun AssistantMessage(message: ChatMessage, onRetry: () -> Unit, modifier
                     )
                 }
             }
+        } else if (error.code == "quota_device") {
+            // 个人配额触顶走专属卡片（登录 CTA / waitlist），全局熔断仍走普通错误文案
+            QuotaLimitCard(error = error, onRetry = onRetry)
         } else {
             Text(
                 text = stringResource(errorMessageRes(error)),

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
@@ -1,0 +1,168 @@
+package whl.trending.chat.ui
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import java.util.Locale
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import whl.trending.ai.auth.AuthState
+import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.repository.TrendingRepository
+import whl.trending.chat.R
+import whl.trending.chat.model.ChatError
+
+/**
+ * 个人配额触顶卡片（`quota_device`），按档位分形态：
+ * - 匿名触顶：登录 CTA（转化点）+ waitlist 次按钮
+ * - 匿名触顶后完成登录：提示已解锁，给重试按钮直接续聊
+ * - 登录触顶：waitlist CTA（付费意愿温度计）
+ *
+ * 全局熔断（`quota_global`）不走本卡片，仍是普通错误文案——语义上与个人额度承诺切开。
+ */
+@Composable
+internal fun QuotaLimitCard(
+    error: ChatError,
+    onRetry: () -> Unit,
+) {
+    val authState by globalAuthManager.authState.collectAsState()
+    val isUserTier = error.tier == "user"
+    var showWaitlistDialog by remember { mutableStateOf(false) }
+
+    if (showWaitlistDialog) {
+        WaitlistDialog(onDismiss = { showWaitlistDialog = false })
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        when {
+            isUserTier -> {
+                QuotaText(R.string.chat_quota_user_exceeded)
+                TextButton(onClick = {
+                    trackEvent("chat_quota_waitlist_click", mapOf("tier" to "user"))
+                    showWaitlistDialog = true
+                }) {
+                    Text(stringResource(R.string.chat_quota_waitlist_cta))
+                }
+            }
+            authState == AuthState.LoggedIn -> {
+                // 匿名触顶后完成了登录：配额键已切换，重发即可继续
+                QuotaText(R.string.chat_quota_unlocked)
+                TextButton(onClick = onRetry) {
+                    Text(stringResource(R.string.chat_retry))
+                }
+            }
+            else -> {
+                QuotaText(R.string.chat_quota_exceeded)
+                if (globalAuthManager.isSupported) {
+                    Button(onClick = {
+                        trackEvent("chat_quota_login_click")
+                        globalAuthManager.signIn()
+                    }) {
+                        Text(stringResource(R.string.chat_quota_login_cta))
+                    }
+                }
+                TextButton(onClick = {
+                    trackEvent("chat_quota_waitlist_click", mapOf("tier" to "anonymous"))
+                    showWaitlistDialog = true
+                }) {
+                    Text(stringResource(R.string.chat_quota_waitlist_cta))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuotaText(resId: Int) {
+    Text(
+        text = stringResource(resId),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+/** Pro waitlist 登记：邮箱写入 subscribers（source=pro_waitlist），复用邮件订阅通道。 */
+@Composable
+private fun WaitlistDialog(onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val repository = remember { TrendingRepository() }
+    var email by remember {
+        mutableStateOf(globalSettingsManager.getSubscribedEmailSync().orEmpty())
+    }
+    var isSubmitting by remember { mutableStateOf(false) }
+    val successText = stringResource(R.string.chat_waitlist_success)
+    val errorText = stringResource(R.string.chat_waitlist_error)
+
+    AlertDialog(
+        onDismissRequest = { if (!isSubmitting) onDismiss() },
+        title = { Text(stringResource(R.string.chat_waitlist_title)) },
+        text = {
+            Column {
+                Text(stringResource(R.string.chat_waitlist_message))
+                OutlinedTextField(
+                    value = email,
+                    onValueChange = { email = it },
+                    label = { Text(stringResource(R.string.chat_waitlist_email_hint)) },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = !isSubmitting && email.contains('@'),
+                onClick = {
+                    isSubmitting = true
+                    scope.launch {
+                        val result = repository.subscribe(email.trim(), "pro_waitlist", resolveLang())
+                        isSubmitting = false
+                        if (result.isSuccess) {
+                            trackEvent("chat_quota_waitlist_submitted")
+                            Toast.makeText(context, successText, Toast.LENGTH_SHORT).show()
+                            onDismiss()
+                        } else {
+                            Toast.makeText(context, errorText, Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                },
+            ) {
+                Text(stringResource(R.string.chat_waitlist_submit))
+            }
+        },
+        dismissButton = {
+            TextButton(enabled = !isSubmitting, onClick = onDismiss) {
+                Text(stringResource(R.string.chat_waitlist_cancel))
+            }
+        },
+    )
+}
+
+private suspend fun resolveLang(): String {
+    val appLang = globalSettingsManager.appLanguage.first()
+    return appLang.isoCode
+        ?: if (Locale.getDefault().language == "zh") "zh" else "en"
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
@@ -47,7 +47,7 @@ internal fun QuotaLimitCard(
     onRetry: () -> Unit,
 ) {
     val authState by globalAuthManager.authState.collectAsState()
-    val isUserTier = error.tier == "user"
+    val isUserTier = error.tier == ChatError.TIER_USER
     var showWaitlistDialog by remember { mutableStateOf(false) }
 
     if (showWaitlistDialog) {
@@ -59,7 +59,7 @@ internal fun QuotaLimitCard(
             isUserTier -> {
                 QuotaText(R.string.chat_quota_user_exceeded)
                 TextButton(onClick = {
-                    trackEvent("chat_quota_waitlist_click", mapOf("tier" to "user"))
+                    trackEvent("chat_quota_waitlist_click", mapOf("tier" to ChatError.TIER_USER))
                     showWaitlistDialog = true
                 }) {
                     Text(stringResource(R.string.chat_quota_waitlist_cta))
@@ -83,7 +83,7 @@ internal fun QuotaLimitCard(
                     }
                 }
                 TextButton(onClick = {
-                    trackEvent("chat_quota_waitlist_click", mapOf("tier" to "anonymous"))
+                    trackEvent("chat_quota_waitlist_click", mapOf("tier" to ChatError.TIER_ANONYMOUS))
                     showWaitlistDialog = true
                 }) {
                     Text(stringResource(R.string.chat_quota_waitlist_cta))
@@ -134,7 +134,7 @@ private fun WaitlistDialog(onDismiss: () -> Unit) {
         },
         confirmButton = {
             TextButton(
-                enabled = !isSubmitting && email.contains('@'),
+                enabled = !isSubmitting && EMAIL_REGEX.matches(email.trim()),
                 onClick = {
                     isSubmitting = true
                     scope.launch {
@@ -160,6 +160,9 @@ private fun WaitlistDialog(onDismiss: () -> Unit) {
         },
     )
 }
+
+// 与服务端 subscribe.js 的 isValidEmail 同构；服务端仍做完整校验，这里只挡明显无效输入
+private val EMAIL_REGEX = Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$")
 
 private suspend fun resolveLang(): String {
     val appLang = globalSettingsManager.appLanguage.first()

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -18,6 +21,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -111,6 +115,8 @@ private fun WaitlistDialog(onDismiss: () -> Unit) {
     var email by remember {
         mutableStateOf(globalSettingsManager.getSubscribedEmailSync().orEmpty())
     }
+    // 每日邮件严格 opt-in：默认不勾选，登记 waitlist 不自动开通 newsletter
+    var wantsNewsletter by remember { mutableStateOf(false) }
     var isSubmitting by remember { mutableStateOf(false) }
     val successText = stringResource(R.string.chat_waitlist_success)
     val errorText = stringResource(R.string.chat_waitlist_error)
@@ -130,6 +136,23 @@ private fun WaitlistDialog(onDismiss: () -> Unit) {
                         .fillMaxWidth()
                         .padding(top = 12.dp),
                 )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 4.dp)
+                        .clickable(enabled = !isSubmitting) { wantsNewsletter = !wantsNewsletter },
+                ) {
+                    Checkbox(
+                        checked = wantsNewsletter,
+                        onCheckedChange = { wantsNewsletter = it },
+                        enabled = !isSubmitting,
+                    )
+                    Text(
+                        text = stringResource(R.string.chat_waitlist_newsletter_optin),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
             }
         },
         confirmButton = {
@@ -138,7 +161,12 @@ private fun WaitlistDialog(onDismiss: () -> Unit) {
                 onClick = {
                     isSubmitting = true
                     scope.launch {
-                        val result = repository.subscribe(email.trim(), "pro_waitlist", resolveLang())
+                        val result = repository.subscribe(
+                            email.trim(),
+                            "pro_waitlist",
+                            resolveLang(),
+                            newsletter = wantsNewsletter,
+                        )
                         isSubmitting = false
                         if (result.isSuccess) {
                             trackEvent("chat_quota_waitlist_submitted")

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -19,7 +19,18 @@
     <string name="chat_share">分享</string>
     <string name="chat_copy">复制</string>
     <string name="chat_copied">已复制</string>
-    <string name="chat_quota_exceeded">今日额度已用完，明天再来吧。</string>
+    <string name="chat_quota_exceeded">今日免费额度已用完，明天自动恢复。</string>
+    <string name="chat_quota_login_cta">登录解锁每日 10 条</string>
+    <string name="chat_quota_waitlist_cta">想要更多额度？上线时通知我</string>
+    <string name="chat_quota_user_exceeded">今日 10 条额度已用完，明天自动恢复。</string>
+    <string name="chat_quota_unlocked">已解锁每日 10 条，重新发送即可继续。</string>
+    <string name="chat_waitlist_title">上线时通知我</string>
+    <string name="chat_waitlist_message">留下邮箱，更高额度的版本上线时第一时间通知你；同时为你开通每日精选邮件，可随时退订。</string>
+    <string name="chat_waitlist_email_hint">邮箱</string>
+    <string name="chat_waitlist_submit">提交</string>
+    <string name="chat_waitlist_cancel">取消</string>
+    <string name="chat_waitlist_success">已登记，上线后会第一时间通知你。</string>
+    <string name="chat_waitlist_error">提交失败，请稍后重试。</string>
     <string name="chat_beta_badge">Beta</string>
     <string name="chat_quota_notice">实验性功能，每日有限免费额度，用尽次日恢复。</string>
 </resources>

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -25,7 +25,8 @@
     <string name="chat_quota_user_exceeded">今日 10 条额度已用完，明天自动恢复。</string>
     <string name="chat_quota_unlocked">已解锁每日 10 条，重新发送即可继续。</string>
     <string name="chat_waitlist_title">上线时通知我</string>
-    <string name="chat_waitlist_message">留下邮箱，更高额度的版本上线时第一时间通知你；同时为你开通每日精选邮件，可随时退订。</string>
+    <string name="chat_waitlist_message">留下邮箱，更高额度的版本上线时第一时间通知你。</string>
+    <string name="chat_waitlist_newsletter_optin">同时订阅每日精选邮件（可随时退订）</string>
     <string name="chat_waitlist_email_hint">邮箱</string>
     <string name="chat_waitlist_submit">提交</string>
     <string name="chat_waitlist_cancel">取消</string>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -25,7 +25,8 @@
     <string name="chat_quota_user_exceeded">You\'ve used all 10 chats for today. It resets tomorrow.</string>
     <string name="chat_quota_unlocked">Unlocked 10 chats a day — resend to continue.</string>
     <string name="chat_waitlist_title">Notify me at launch</string>
-    <string name="chat_waitlist_message">Leave your email and we\'ll notify you when higher quotas launch. You\'ll also get our daily picks newsletter — unsubscribe anytime.</string>
+    <string name="chat_waitlist_message">Leave your email and we\'ll notify you when higher quotas launch.</string>
+    <string name="chat_waitlist_newsletter_optin">Also subscribe to the daily picks newsletter (unsubscribe anytime)</string>
     <string name="chat_waitlist_email_hint">Email</string>
     <string name="chat_waitlist_submit">Submit</string>
     <string name="chat_waitlist_cancel">Cancel</string>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -19,7 +19,18 @@
     <string name="chat_share">Share</string>
     <string name="chat_copy">Copy</string>
     <string name="chat_copied">Copied</string>
-    <string name="chat_quota_exceeded">You\'ve reached today\'s limit. Please come back tomorrow.</string>
+    <string name="chat_quota_exceeded">You\'ve used up today\'s free quota. It resets tomorrow.</string>
+    <string name="chat_quota_login_cta">Sign in to unlock 10 chats a day</string>
+    <string name="chat_quota_waitlist_cta">Want more? Get notified at launch</string>
+    <string name="chat_quota_user_exceeded">You\'ve used all 10 chats for today. It resets tomorrow.</string>
+    <string name="chat_quota_unlocked">Unlocked 10 chats a day — resend to continue.</string>
+    <string name="chat_waitlist_title">Notify me at launch</string>
+    <string name="chat_waitlist_message">Leave your email and we\'ll notify you when higher quotas launch. You\'ll also get our daily picks newsletter — unsubscribe anytime.</string>
+    <string name="chat_waitlist_email_hint">Email</string>
+    <string name="chat_waitlist_submit">Submit</string>
+    <string name="chat_waitlist_cancel">Cancel</string>
+    <string name="chat_waitlist_success">You\'re on the list — we\'ll be in touch at launch.</string>
+    <string name="chat_waitlist_error">Submission failed. Please try again later.</string>
     <string name="chat_beta_badge">Beta</string>
     <string name="chat_quota_notice">Experimental feature. Limited free chats each day, resetting tomorrow.</string>
 </resources>

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatErrorsTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatErrorsTest.kt
@@ -22,6 +22,19 @@ class ChatErrorsTest {
     }
 
     @Test
+    fun status_429_carries_tier_for_quota_card_selection() {
+        val anon = ChatErrors.forStatus(429, "quota_device", null, tier = "anonymous")
+        assertEquals("anonymous", anon.tier)
+        val user = ChatErrors.forStatus(429, "quota_device", null, tier = "user")
+        assertEquals("user", user.tier)
+    }
+
+    @Test
+    fun tier_defaults_to_null_when_absent() {
+        assertEquals(null, ChatErrors.forStatus(429, "quota_device", null).tier)
+    }
+
+    @Test
     fun status_400_is_bad_request() {
         assertEquals(ChatErrorCategory.BAD_REQUEST, ChatErrors.forStatus(400, null, null).category)
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -114,7 +114,13 @@ open class TrendingApi {
         }
     }
 
-    open suspend fun submitSubscribe(email: String, source: String, lang: String): Result<SubscribeResponse> {
+    /** [newsletter] 仅 waitlist 场景使用：显式 true 才开通每日邮件（服务端严格 opt-in），null 不传字段 */
+    open suspend fun submitSubscribe(
+        email: String,
+        source: String,
+        lang: String,
+        newsletter: Boolean? = null,
+    ): Result<SubscribeResponse> {
         return try {
             val response = client.post("$baseHost/api/subscribe") {
                 contentType(ContentType.Application.Json)
@@ -122,6 +128,7 @@ open class TrendingApi {
                     put("email", email)
                     put("source", source)
                     put("lang", lang)
+                    newsletter?.let { put("newsletter", it) }
                 })
             }
             if (response.status.value in 200..299) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/TrendingRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/TrendingRepository.kt
@@ -35,8 +35,13 @@ open class TrendingRepository(private val api: TrendingApi = TrendingApi()) {
         return api.submitFeedback(content, email)
     }
 
-    suspend fun subscribe(email: String, source: String, lang: String): Result<SubscribeResponse> {
-        return api.submitSubscribe(email, source, lang)
+    suspend fun subscribe(
+        email: String,
+        source: String,
+        lang: String,
+        newsletter: Boolean? = null,
+    ): Result<SubscribeResponse> {
+        return api.submitSubscribe(email, source, lang, newsletter)
     }
 
     suspend fun cancelSubscribe(email: String): Result<SubscribeResponse> {


### PR DESCRIPTION
## 背景

6 月数据：AI 对话渗透率 23%，52 个 install-day 触到每日 5 条免费上限，但触顶时用户只看到冷拒绝文案。本 PR 把触顶从流失点变成登录转化点 + 付费意愿温度计。

设计 spec：TrendingProjects/docs/superpowers/specs/2026-07-04-chat-quota-login-tier-design.md

## 改动

- **ChatApi**：请求携带 Logto access token；服务端据此走登录档配额（匿名 5 条/日 → 登录 10 条/日），token 无效由服务端静默降级，不打断聊天
- **触顶卡片**（新 `QuotaLimitCard`）：`quota_device` 错误按档位分形态
  - 匿名触顶：无数字文案 + 主按钮「登录解锁每日 10 条」+ 次按钮「想要更多额度？上线时通知我」
  - 匿名触顶后完成登录：提示已解锁 + 重试按钮直接续聊
  - 登录触顶：waitlist CTA（付费意愿信号）
  - 全局熔断 `quota_global` 不走卡片，保持"服务繁忙"语义隔离
- **Waitlist**：复用 subscribe 接口（source=pro_waitlist），弹窗明示同时开通每日邮件可退订；邮箱预填本地订阅记录
- **埋点**：`chat_quota_hit(tier)` / `chat_quota_login_click` / `chat_quota_waitlist_click` / `chat_quota_waitlist_submitted`
- **ChatError.tier**：透传服务端 429 响应的档位字段；`retry()` 对 quota_device 放行（登录后配额键切换，重发即续聊）

## 依赖

需配合 github-ai-trending-api 的配套 PR 部署（配额分层 + pro_waitlist_at 迁移）后才能完整生效；未部署前客户端向后兼容（tier=null 按匿名/解锁分支处理，已在旧生产 API 上实测）。

## 验证

- chat 模块单测全绿（ChatErrors tier 透传 TDD）
- Pixel_9_2 模拟器实测：打满 5 条触发卡片、已登录分支文案正确、重试重发正常、埋点触发
- Worker 端 8 场景 curl 矩阵见配套 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

引入分级聊天配额处理机制，通过登录升级配额，并新增专用的配额上限卡片，同时为配额相关事件添加埋点。

New Features:
- 支持携带 Logto 访问令牌的已认证聊天请求，在登录后解锁更高的每日配额。
- 新增配额上限卡片 UI，根据用户的配额等级展示登录入口和 Pro 候补名单流程。
- 引入 Pro 候补名单弹窗，复用现有邮件订阅渠道，用于更高配额通知。

Enhancements:
- 在聊天错误处理流程中传递服务端提供的配额等级信息，以驱动不同的 UI 变体。
- 更新配额相关的用户文案，覆盖匿名用户和已登录用户的英文与中文版本。
- 允许针对配额设备错误进行重试，使用户在登录后可以继续聊天。

Tests:
- 扩展聊天错误测试用例，覆盖配额等级字段的传递与默认回退逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce tiered chat quota handling with login-based upgrades and a dedicated quota limit card, plus instrumentation for quota-related events.

New Features:
- Support authenticated chat requests that unlock a higher daily quota when a Logto access token is present.
- Add a quota limit card UI that presents login and Pro waitlist flows based on the user’s quota tier.
- Introduce a Pro waitlist dialog that reuses the email subscription channel for higher quota notifications.

Enhancements:
- Propagate server-provided quota tier information through chat error handling to drive UI variants.
- Update quota-related user-facing copy for both anonymous and logged-in users in English and Chinese.
- Allow retries for quota-device errors so users can continue chatting after logging in.

Tests:
- Extend chat error tests to cover propagation and defaulting of the quota tier field.

</details>