### PR TITLE
feat(pro): Pro 订阅客户端（Stage 2）— 模型选择器 + 配额卡 Pro CTA

### DIFF
--- a/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
@@ -78,6 +78,21 @@ class MainActivity : AppCompatActivity() {
             }
         }
     }
+
+    /**
+     * 回到前台时对账 Pro：仅「已登录且当前非 Pro」才查——正好覆盖「刚在浏览器完成赞助、返回 app」的路径，
+     * 让权益即时生效，不等 webhook。已 Pro / 未登录直接跳过，避免每次 resume 都打后端。
+     */
+    override fun onResume() {
+        super.onResume()
+        val loggedIn = whl.trending.ai.auth.globalAuthManager.authState.value is whl.trending.ai.auth.AuthState.LoggedIn
+        if (loggedIn && !globalSettingsManager.getIsProSync()) {
+            lifecycleScope.launch {
+                val token = whl.trending.ai.auth.globalAuthManager.getAccessToken()
+                whl.trending.ai.data.repository.UserRepository().refreshPro(token)
+            }
+        }
+    }
 }
 
 @Preview

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -121,6 +121,7 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
             logtoClient.clearCredentials { /* 本地凭证已清除即视为登出 */ }
         }
         globalSettingsManager.setUserAvatarUrl(null)
+        globalSettingsManager.setIsPro(false)
         GithubTokenProvider.shared.clear()
         FollowingProvider.shared.clear()
         OwnRepoEventsProvider.shared.clear()

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -122,6 +122,7 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         }
         globalSettingsManager.setUserAvatarUrl(null)
         globalSettingsManager.setIsPro(false)
+        globalSettingsManager.clearSelectedChatModel()
         GithubTokenProvider.shared.clear()
         FollowingProvider.shared.clear()
         OwnRepoEventsProvider.shared.clear()

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import whl.trending.ai.chat.ChatContext
 import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.data.model.ChatModelOption
+import whl.trending.ai.data.remote.TrendingApi
 import whl.trending.chat.engine.ChatEngine
 import whl.trending.chat.engine.ChatException
 import whl.trending.chat.model.ChatError
@@ -28,6 +30,16 @@ class ChatViewModel(
 
     private val _uiState = MutableStateFlow(ChatUiState(messages = initialMessages))
     val uiState: StateFlow<ChatUiState> = _uiState.asStateFlow()
+
+    // 可选模型目录（驱动模型选择器）。拉取失败保持空列表 → 选择器隐藏、退回默认模型。
+    private val _models = MutableStateFlow<List<ChatModelOption>>(emptyList())
+    val models: StateFlow<List<ChatModelOption>> = _models.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _models.value = runCatching { TrendingApi().fetchChatModels() }.getOrDefault(emptyList())
+        }
+    }
 
     private var idSeq = initialMessages.maxOfOrNull { it.id } ?: 0L
     private fun nextId(): Long = ++idSeq

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -19,13 +19,19 @@ import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.ChatUiState
 import whl.trending.chat.model.Role
 
+/** 模型目录拉取默认走单例 TrendingApi——避免每个 keyed 会话 new 一个从不 close 的 HttpClient。 */
+private val sharedModelsApi by lazy { TrendingApi() }
+
 /**
  * 聊天 ViewModel：内存级单会话。通过 [engine] 注入实现 Demo / 正式切换。
+ *
+ * @param loadModels 模型目录拉取，注入点（便于测试替身）；默认复用单例 TrendingApi。
  */
 class ChatViewModel(
     private val engine: ChatEngine,
     private val context: ChatContext? = null,
     initialMessages: List<ChatMessage> = emptyList(),
+    private val loadModels: suspend () -> List<ChatModelOption> = { sharedModelsApi.fetchChatModels() },
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ChatUiState(messages = initialMessages))
@@ -37,7 +43,7 @@ class ChatViewModel(
 
     init {
         viewModelScope.launch {
-            _models.value = runCatching { TrendingApi().fetchChatModels() }.getOrDefault(emptyList())
+            _models.value = runCatching { loadModels() }.getOrDefault(emptyList())
         }
     }
 

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.launch
 import whl.trending.ai.chat.ChatContext
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.model.ChatModelOption
-import whl.trending.ai.data.remote.TrendingApi
+import whl.trending.ai.data.repository.ChatModelsProvider
 import whl.trending.chat.engine.ChatEngine
 import whl.trending.chat.engine.ChatException
 import whl.trending.chat.model.ChatError
@@ -19,19 +19,17 @@ import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.ChatUiState
 import whl.trending.chat.model.Role
 
-/** 模型目录拉取默认走单例 TrendingApi——避免每个 keyed 会话 new 一个从不 close 的 HttpClient。 */
-private val sharedModelsApi by lazy { TrendingApi() }
-
 /**
  * 聊天 ViewModel：内存级单会话。通过 [engine] 注入实现 Demo / 正式切换。
  *
- * @param loadModels 模型目录拉取，注入点（便于测试替身）；默认复用单例 TrendingApi。
+ * @param loadModels 模型目录拉取，注入点（便于测试替身）；默认走 [ChatModelsProvider] 的进程级缓存，
+ *   避免每个会话都网络冷拉取导致选择器 chip 迟迟不出现（见冷首拉根因）。
  */
 class ChatViewModel(
     private val engine: ChatEngine,
     private val context: ChatContext? = null,
     initialMessages: List<ChatMessage> = emptyList(),
-    private val loadModels: suspend () -> List<ChatModelOption> = { sharedModelsApi.fetchChatModels() },
+    private val loadModels: suspend () -> List<ChatModelOption> = { ChatModelsProvider.get() },
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ChatUiState(messages = initialMessages))

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -57,6 +57,7 @@ class ChatApi(
         val messages: List<WireMessage>,
         val lang: String,
         val context: WireContext? = null,
+        val model: String? = null,
     )
 
     @Serializable
@@ -110,6 +111,8 @@ class ChatApi(
                         context = context?.let {
                             WireContext(it.title, it.summary, it.sourceUrl)
                         },
+                        // 透传所选模型；服务端仍按 tier 强制（免费越权自动回默认）
+                        model = globalSettingsManager.getSelectedChatModelSync(),
                     ),
                 )
             }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatError.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatError.kt
@@ -33,5 +33,6 @@ data class ChatError(
         /** 服务端 429 响应 tier 字段的取值，与 Worker 端 chat.js 保持一致 */
         const val TIER_ANONYMOUS = "anonymous"
         const val TIER_USER = "user"
+        const val TIER_PRO = "pro"
     }
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -110,6 +110,12 @@ fun ChatScreen(
                         )
                     }
                 }
+                // 常驻模型选择器（≤1 个模型时自动隐藏）
+                val models by viewModel.models.collectAsState()
+                ModelPicker(
+                    models = models,
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                )
                 ChatInputBar(
                     input = state.input,
                     canSend = state.canSend,

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -24,6 +25,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import whl.trending.ai.core.Constants
+import whl.trending.ai.data.model.DEFAULT_CHAT_MODEL
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.ChatModelOption
@@ -48,16 +50,30 @@ internal fun ModelPicker(
         .collectAsState(initial = globalSettingsManager.getSelectedChatModelSync())
     var expanded by remember { mutableStateOf(false) }
 
-    val current = models.firstOrNull { it.id == selectedId } ?: models.first()
+    // 自愈守卫：若持久化的选择对本用户已锁定（Pro 过期未登出、或上个 Pro 用户遗留），
+    // 复位到默认免费模型。一处同时修好「chip 显示」与「ChatApi 透传」的一致性。
+    LaunchedEffect(models, isPro) {
+        val sel = models.firstOrNull { it.id == selectedId }
+        if (models.isNotEmpty() && (sel == null || (sel.proOnly && !isPro))) {
+            globalSettingsManager.setSelectedChatModel(DEFAULT_CHAT_MODEL)
+        }
+    }
+
+    // 展示同样带 tier 守卫：锁定项永不显示为当前选择（覆盖自愈生效前的那一帧）
+    val current = models.firstOrNull { it.id == selectedId }?.takeIf { !(it.proOnly && !isPro) }
+        ?: models.firstOrNull { !it.proOnly }
+        ?: models.first()
     val hasLocked = models.any { it.proOnly && !isPro }
 
     Box(modifier) {
         AssistChip(
             onClick = {
                 expanded = true
-                // 打开选择器且存在锁定项 = 模型入口 upsell 曝光
+                // 模型入口 upsell 曝光：每次展开下拉、且存在锁定项，各算一次曝光（类广告 impression）。
+                // 语义与 chat_quota（LaunchedEffect(Unit) 每次挂载去重一次）不同——model_locked 是「每次看」，
+                // 对比 shown→clicked 漏斗时需按 source 分开看，勿直接横比。
                 if (hasLocked) {
-                    trackEvent("pro_upsell_shown", mapOf("trigger" to TRIGGER_MODEL_LOCKED))
+                    trackEvent("pro_upsell_shown", mapOf(UPSELL_SOURCE_KEY to SOURCE_MODEL_LOCKED))
                 }
             },
             label = { Text(current.name) },
@@ -83,7 +99,7 @@ internal fun ModelPicker(
                     onClick = {
                         expanded = false
                         if (locked) {
-                            trackEvent("pro_upsell_clicked", mapOf("trigger" to TRIGGER_MODEL_LOCKED))
+                            trackEvent("pro_upsell_clicked", mapOf(UPSELL_SOURCE_KEY to SOURCE_MODEL_LOCKED))
                             Toast.makeText(
                                 context,
                                 context.getString(R.string.chat_model_pro_locked, model.name),

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -1,0 +1,101 @@
+package whl.trending.chat.ui
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import whl.trending.ai.core.Constants
+import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.model.ChatModelOption
+import whl.trending.chat.R
+
+/**
+ * 常驻模型选择器（对所有用户透出）。默认显示免费 gpt-5.4；Pro 专属项对免费用户锁定，
+ * 点锁定项 → 埋点 + 跳 Sponsors（第二个、更早的转化入口）。
+ *
+ * 只有一个可选模型时不渲染（无从选择、也无 Pro 项可 upsell）。
+ */
+@Composable
+internal fun ModelPicker(
+    models: List<ChatModelOption>,
+    modifier: Modifier = Modifier,
+) {
+    if (models.size <= 1) return
+
+    val context = LocalContext.current
+    val isPro by globalSettingsManager.isPro.collectAsState(initial = globalSettingsManager.getIsProSync())
+    val selectedId by globalSettingsManager.selectedChatModel
+        .collectAsState(initial = globalSettingsManager.getSelectedChatModelSync())
+    var expanded by remember { mutableStateOf(false) }
+
+    val current = models.firstOrNull { it.id == selectedId } ?: models.first()
+    val hasLocked = models.any { it.proOnly && !isPro }
+
+    Box(modifier) {
+        AssistChip(
+            onClick = {
+                expanded = true
+                // 打开选择器且存在锁定项 = 模型入口 upsell 曝光
+                if (hasLocked) {
+                    trackEvent("pro_upsell_shown", mapOf("trigger" to TRIGGER_MODEL_LOCKED))
+                }
+            },
+            label = { Text(current.name) },
+            trailingIcon = {
+                Icon(Icons.Filled.ArrowDropDown, contentDescription = null, modifier = Modifier.size(18.dp))
+            },
+        )
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            models.forEach { model ->
+                val locked = model.proOnly && !isPro
+                DropdownMenuItem(
+                    text = { Text(model.name) },
+                    trailingIcon = if (locked) {
+                        {
+                            Icon(
+                                Icons.Filled.Lock,
+                                contentDescription = "Pro",
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    } else null,
+                    onClick = {
+                        expanded = false
+                        if (locked) {
+                            trackEvent("pro_upsell_clicked", mapOf("trigger" to TRIGGER_MODEL_LOCKED))
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.chat_model_pro_locked, model.name),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                            openUrl(context, Constants.GITHUB_SPONSORS_URL)
+                        } else {
+                            globalSettingsManager.setSelectedChatModel(model.id)
+                        }
+                    },
+                )
+            }
+        }
+    }
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
@@ -57,6 +57,7 @@ internal fun QuotaLimitCard(
 ) {
     val authState by globalAuthManager.authState.collectAsState()
     val context = LocalContext.current
+    val isProTier = error.tier == ChatError.TIER_PRO
     val isUserTier = error.tier == ChatError.TIER_USER
     var showWaitlistDialog by remember { mutableStateOf(false) }
 
@@ -66,6 +67,10 @@ internal fun QuotaLimitCard(
 
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         when {
+            isProTier -> {
+                // Pro 触顶（极罕见）：不透数字的软着陆，无 CTA（已是 Pro，明日恢复）
+                QuotaText(R.string.chat_quota_pro_exceeded)
+            }
             isUserTier -> {
                 // 付费漏斗第一级（曝光）：登录触顶卡带 Pro CTA 渲染。去重靠 LaunchedEffect(Unit)。
                 LaunchedEffect(Unit) {

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
@@ -69,11 +69,11 @@ internal fun QuotaLimitCard(
             isUserTier -> {
                 // 付费漏斗第一级（曝光）：登录触顶卡带 Pro CTA 渲染。去重靠 LaunchedEffect(Unit)。
                 LaunchedEffect(Unit) {
-                    trackEvent("pro_upsell_shown", mapOf("trigger" to TRIGGER_CHAT_QUOTA))
+                    trackEvent("pro_upsell_shown", mapOf(UPSELL_SOURCE_KEY to SOURCE_CHAT_QUOTA))
                 }
                 QuotaText(R.string.chat_pro_upsell_message)
                 Button(onClick = {
-                    trackEvent("pro_upsell_clicked", mapOf("trigger" to TRIGGER_CHAT_QUOTA))
+                    trackEvent("pro_upsell_clicked", mapOf(UPSELL_SOURCE_KEY to SOURCE_CHAT_QUOTA))
                     openUrl(context, Constants.GITHUB_SPONSORS_URL)
                 }) {
                     Text(stringResource(R.string.chat_pro_cta))
@@ -208,9 +208,12 @@ private fun WaitlistDialog(onDismiss: () -> Unit) {
     )
 }
 
-/** 付费漏斗 trigger：区分「配额触顶」入口与「模型锁定」入口 */
-internal const val TRIGGER_CHAT_QUOTA = "chat_quota"
-internal const val TRIGGER_MODEL_LOCKED = "model_locked"
+/** 付费漏斗事件维度 key：全 app 统一用 "source"（与 Picks/Feed/Trending 等 12 处对齐） */
+internal const val UPSELL_SOURCE_KEY = "source"
+
+/** 付费漏斗来源：区分「配额触顶」入口与「模型锁定」入口 */
+internal const val SOURCE_CHAT_QUOTA = "chat_quota"
+internal const val SOURCE_MODEL_LOCKED = "model_locked"
 
 /** 用系统浏览器打开外链（Sponsors 页）。失败静默——不阻塞。 */
 internal fun openUrl(context: Context, url: String) {

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
@@ -1,5 +1,8 @@
 package whl.trending.chat.ui
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -16,6 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,6 +35,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.core.Constants
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.TrendingRepository
@@ -51,6 +56,7 @@ internal fun QuotaLimitCard(
     onRetry: () -> Unit,
 ) {
     val authState by globalAuthManager.authState.collectAsState()
+    val context = LocalContext.current
     val isUserTier = error.tier == ChatError.TIER_USER
     var showWaitlistDialog by remember { mutableStateOf(false) }
 
@@ -61,13 +67,26 @@ internal fun QuotaLimitCard(
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         when {
             isUserTier -> {
-                QuotaText(R.string.chat_quota_user_exceeded)
+                // 付费漏斗第一级（曝光）：登录触顶卡带 Pro CTA 渲染。去重靠 LaunchedEffect(Unit)。
+                LaunchedEffect(Unit) {
+                    trackEvent("pro_upsell_shown", mapOf("trigger" to TRIGGER_CHAT_QUOTA))
+                }
+                QuotaText(R.string.chat_pro_upsell_message)
+                Button(onClick = {
+                    trackEvent("pro_upsell_clicked", mapOf("trigger" to TRIGGER_CHAT_QUOTA))
+                    openUrl(context, Constants.GITHUB_SPONSORS_URL)
+                }) {
+                    Text(stringResource(R.string.chat_pro_cta))
+                }
+                // 次按钮：付不了国际卡的人 → waitlist（捕获支付摩擦样本）
                 TextButton(onClick = {
                     trackEvent("chat_quota_waitlist_click", mapOf("tier" to ChatError.TIER_USER))
                     showWaitlistDialog = true
                 }) {
                     Text(stringResource(R.string.chat_quota_waitlist_cta))
                 }
+                // 激活延迟提示（人工兜底可能有延迟）
+                QuotaText(R.string.chat_pro_activation_hint)
             }
             authState == AuthState.LoggedIn -> {
                 // 匿名触顶后完成了登录：配额键已切换，重发即可继续
@@ -187,6 +206,19 @@ private fun WaitlistDialog(onDismiss: () -> Unit) {
             }
         },
     )
+}
+
+/** 付费漏斗 trigger：区分「配额触顶」入口与「模型锁定」入口 */
+internal const val TRIGGER_CHAT_QUOTA = "chat_quota"
+internal const val TRIGGER_MODEL_LOCKED = "model_locked"
+
+/** 用系统浏览器打开外链（Sponsors 页）。失败静默——不阻塞。 */
+internal fun openUrl(context: Context, url: String) {
+    runCatching {
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+    }
 }
 
 // 与服务端 subscribe.js 的 isValidEmail 同构；服务端仍做完整校验，这里只挡明显无效输入

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -23,6 +23,10 @@
     <string name="chat_quota_login_cta">登录解锁每日 10 条</string>
     <string name="chat_quota_waitlist_cta">想要更多额度？上线时通知我</string>
     <string name="chat_quota_user_exceeded">今日 10 条额度已用完，明天自动恢复。</string>
+    <string name="chat_pro_upsell_message">每天 10 条不够？Pro 每日 100 条，还能用 GPT-5.5 等更强模型。</string>
+    <string name="chat_pro_cta">解锁 Pro · $2/月</string>
+    <string name="chat_pro_activation_hint">赞助后 Pro 通常几分钟内自动生效；如未解锁，我们会人工核对，可能稍有延迟——稍后回来重试即可。</string>
+    <string name="chat_model_pro_locked">%1$s 需要 Pro，$2/月解锁。</string>
     <string name="chat_quota_unlocked">已解锁每日 10 条，重新发送即可继续。</string>
     <string name="chat_waitlist_title">上线时通知我</string>
     <string name="chat_waitlist_message">留下邮箱，更高额度的版本上线时第一时间通知你。</string>

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -23,7 +23,8 @@
     <string name="chat_quota_login_cta">登录解锁每日 10 条</string>
     <string name="chat_quota_waitlist_cta">想要更多额度？上线时通知我</string>
     <string name="chat_quota_user_exceeded">今日 10 条额度已用完，明天自动恢复。</string>
-    <string name="chat_pro_upsell_message">每天 10 条不够？Pro 每日 100 条，还能用 GPT-5.5 等更强模型。</string>
+    <string name="chat_pro_upsell_message">每天 10 条不够？Pro 提供更宽裕的每日额度，还解锁 GPT-5.5 等更强模型。</string>
+    <string name="chat_quota_pro_exceeded">今天聊得有点多，稍后再来～</string>
     <string name="chat_pro_cta">解锁 Pro · $2/月</string>
     <string name="chat_pro_activation_hint">赞助后 Pro 通常几分钟内自动生效；如未解锁，我们会人工核对，可能稍有延迟——稍后回来重试即可。</string>
     <string name="chat_model_pro_locked">%1$s 需要 Pro，$2/月解锁。</string>

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -23,7 +23,7 @@
     <string name="chat_quota_login_cta">登录解锁每日 10 条</string>
     <string name="chat_quota_waitlist_cta">想要更多额度？上线时通知我</string>
     <string name="chat_quota_user_exceeded">今日 10 条额度已用完，明天自动恢复。</string>
-    <string name="chat_pro_upsell_message">每天 10 条不够？Pro 提供更宽裕的每日额度，还解锁 GPT-5.5 等更强模型。</string>
+    <string name="chat_pro_upsell_message">每天 10 条不够？Pro 提供更宽裕的每日额度，还能选用更强、更新的模型。</string>
     <string name="chat_quota_pro_exceeded">今天聊得有点多，稍后再来～</string>
     <string name="chat_pro_cta">解锁 Pro · $2/月</string>
     <string name="chat_pro_activation_hint">赞助后 Pro 通常几分钟内自动生效；如未解锁，我们会人工核对，可能稍有延迟——稍后回来重试即可。</string>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="chat_quota_login_cta">Sign in to unlock 10 chats a day</string>
     <string name="chat_quota_waitlist_cta">Want more? Get notified at launch</string>
     <string name="chat_quota_user_exceeded">You\'ve used all 10 chats for today. It resets tomorrow.</string>
-    <string name="chat_pro_upsell_message">Need more than 10 a day? Pro gives you a much more generous daily allowance, plus stronger models like GPT-5.5.</string>
+    <string name="chat_pro_upsell_message">Need more than 10 a day? Pro gives you a much more generous daily allowance, plus access to newer, more capable models.</string>
     <string name="chat_quota_pro_exceeded">You\'ve been chatting a lot today — check back a bit later.</string>
     <string name="chat_pro_cta">Unlock Pro · $2/mo</string>
     <string name="chat_pro_activation_hint">After sponsoring, Pro usually activates within minutes. If not, we verify manually — just try again shortly.</string>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -23,6 +23,10 @@
     <string name="chat_quota_login_cta">Sign in to unlock 10 chats a day</string>
     <string name="chat_quota_waitlist_cta">Want more? Get notified at launch</string>
     <string name="chat_quota_user_exceeded">You\'ve used all 10 chats for today. It resets tomorrow.</string>
+    <string name="chat_pro_upsell_message">Need more than 10 a day? Pro gives 100 chats/day plus stronger models like GPT-5.5.</string>
+    <string name="chat_pro_cta">Unlock Pro · $2/mo</string>
+    <string name="chat_pro_activation_hint">After sponsoring, Pro usually activates within minutes. If not, we verify manually — just try again shortly.</string>
+    <string name="chat_model_pro_locked">%1$s needs Pro. Unlock for $2/mo.</string>
     <string name="chat_quota_unlocked">Unlocked 10 chats a day — resend to continue.</string>
     <string name="chat_waitlist_title">Notify me at launch</string>
     <string name="chat_waitlist_message">Leave your email and we\'ll notify you when higher quotas launch.</string>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -23,7 +23,8 @@
     <string name="chat_quota_login_cta">Sign in to unlock 10 chats a day</string>
     <string name="chat_quota_waitlist_cta">Want more? Get notified at launch</string>
     <string name="chat_quota_user_exceeded">You\'ve used all 10 chats for today. It resets tomorrow.</string>
-    <string name="chat_pro_upsell_message">Need more than 10 a day? Pro gives 100 chats/day plus stronger models like GPT-5.5.</string>
+    <string name="chat_pro_upsell_message">Need more than 10 a day? Pro gives you a much more generous daily allowance, plus stronger models like GPT-5.5.</string>
+    <string name="chat_quota_pro_exceeded">You\'ve been chatting a lot today — check back a bit later.</string>
     <string name="chat_pro_cta">Unlock Pro · $2/mo</string>
     <string name="chat_pro_activation_hint">After sponsoring, Pro usually activates within minutes. If not, we verify manually — just try again shortly.</string>
     <string name="chat_model_pro_locked">%1$s needs Pro. Unlock for $2/mo.</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -166,6 +166,11 @@ class SettingsManager(private val settings: ObservableSettings) {
         settings.putString(SELECTED_CHAT_MODEL_KEY, id)
     }
 
+    /** 登出时调用：清掉可能残留的 Pro 模型选择，避免下个用户继承（回落到默认 gpt-5.4）。 */
+    fun clearSelectedChatModel() {
+        settings.remove(SELECTED_CHAT_MODEL_KEY)
+    }
+
     val subscribedEmail: Flow<String?> = settings.getStringOrNullFlow(SUBSCRIBED_EMAIL_KEY)
 
     fun getSubscribedEmailSync(): String? = settings.getStringOrNull(SUBSCRIBED_EMAIL_KEY)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -6,6 +6,7 @@ import com.russhwolf.settings.Settings
 import com.russhwolf.settings.coroutines.getBooleanFlow
 import com.russhwolf.settings.coroutines.getIntFlow
 import com.russhwolf.settings.coroutines.getLongFlow
+import com.russhwolf.settings.coroutines.getStringFlow
 import com.russhwolf.settings.coroutines.getStringOrNullFlow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -14,6 +15,7 @@ import kotlinx.serialization.json.Json
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import whl.trending.ai.core.platform.getSystemLanguage
+import whl.trending.ai.data.model.DEFAULT_CHAT_MODEL
 import whl.trending.ai.data.model.FavoriteItem
 
 enum class ThemeMode(val title: String) {
@@ -42,6 +44,8 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val INSTALL_ID_KEY = "prefs_install_id"
     private val USER_AVATAR_KEY = "prefs_user_avatar_url"
     private val FEED_HIGHLIGHTS_ONLY_KEY = "prefs_feed_filter_highlights"
+    private val IS_PRO_KEY = "prefs_is_pro"
+    private val SELECTED_CHAT_MODEL_KEY = "prefs_selected_chat_model"
     private val OPEN_LINKS_IN_CUSTOM_TAB_KEY = "prefs_open_links_in_custom_tab"
     private val TRENDING_NEW_ONLY_DEFAULT_KEY = "prefs_trending_new_only_default"
 
@@ -142,6 +146,24 @@ class SettingsManager(private val settings: ObservableSettings) {
         } else {
             settings.putString(USER_AVATAR_KEY, url)
         }
+    }
+
+    /** Pro 权益态缓存：登录后由 /api/me 写入、登出清除。UI 据此解锁模型切换、切换配额卡形态。 */
+    val isPro: Flow<Boolean> = settings.getBooleanFlow(IS_PRO_KEY, false)
+
+    fun getIsProSync(): Boolean = settings.getBoolean(IS_PRO_KEY, false)
+
+    fun setIsPro(value: Boolean) {
+        settings.putBoolean(IS_PRO_KEY, value)
+    }
+
+    /** 选中的聊天模型 id：发请求时透传（服务端仍按 tier 强制）。默认免费 gpt-5.4。 */
+    val selectedChatModel: Flow<String> = settings.getStringFlow(SELECTED_CHAT_MODEL_KEY, DEFAULT_CHAT_MODEL)
+
+    fun getSelectedChatModelSync(): String = settings.getString(SELECTED_CHAT_MODEL_KEY, DEFAULT_CHAT_MODEL)
+
+    fun setSelectedChatModel(id: String) {
+        settings.putString(SELECTED_CHAT_MODEL_KEY, id)
     }
 
     val subscribedEmail: Flow<String?> = settings.getStringOrNullFlow(SUBSCRIBED_EMAIL_KEY)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/ChatModelOption.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/ChatModelOption.kt
@@ -1,0 +1,24 @@
+package whl.trending.ai.data.model
+
+import kotlinx.serialization.Serializable
+
+/** 免费默认模型（与后端 FREE_MODELS[0] 对齐）。选择器与请求兜底都用它。 */
+const val DEFAULT_CHAT_MODEL = "gpt-5.4"
+
+/**
+ * 一个可选聊天模型（来自 `GET /api/chat/models`，后端从 OpenAI 动态取）。
+ *
+ * @param minTier 使用该模型所需的最低档位：`"user"`=免费可用；`"pro"`=需 Pro 解锁。
+ */
+@Serializable
+data class ChatModelOption(
+    val id: String,
+    val name: String,
+    val minTier: String,
+) {
+    /** 是否 Pro 专属（免费用户看到但锁定） */
+    val proOnly: Boolean get() = minTier == "pro"
+}
+
+@Serializable
+data class ChatModelsResponse(val models: List<ChatModelOption> = emptyList())

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/Me.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/Me.kt
@@ -10,6 +10,10 @@ data class MeResponse(
     val pro: Boolean = false,
 )
 
+/** POST /api/pro/refresh 的响应：后端用维护者 PAT 权威核对赞助后返回的最新 Pro 态。 */
+@Serializable
+data class ProRefreshResponse(val pro: Boolean = false)
+
 @Serializable
 data class MeUser(
     @SerialName("user_id") val userId: String,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/Me.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/Me.kt
@@ -4,7 +4,11 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class MeResponse(val user: MeUser)
+data class MeResponse(
+    val user: MeUser,
+    /** 当前用户是否有生效的 Pro 权益（后端按 github_user_id 查 pro_entitlements） */
+    val pro: Boolean = false,
+)
 
 @Serializable
 data class MeUser(

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -5,6 +5,7 @@ import whl.trending.ai.data.model.FeedResponse
 import whl.trending.ai.data.model.ChatModelOption
 import whl.trending.ai.data.model.ChatModelsResponse
 import whl.trending.ai.data.model.MeResponse
+import whl.trending.ai.data.model.ProRefreshResponse
 import whl.trending.ai.data.model.PicksResponse
 import whl.trending.ai.data.model.ReadmeResponse
 import whl.trending.ai.data.model.SubscribeResponse
@@ -152,6 +153,17 @@ open class TrendingApi {
             throw ApiException(response.status.value, response.bodyAsText())
         }
         return response.body<MeResponse>()
+    }
+
+    /** 即时激活/对账：后端权威核对赞助并 upsert，返回最新 Pro 态。用户从 Sponsors 返回时调用。 */
+    open suspend fun refreshPro(accessToken: String): Boolean {
+        val response = client.post("$baseHost/api/pro/refresh") {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<ProRefreshResponse>().pro
     }
 
     /** 聊天可选模型目录（公开只读；后端从 OpenAI 动态取 + 缓存）。 */

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -2,6 +2,8 @@ package whl.trending.ai.data.remote
 
 import whl.trending.ai.core.platform.getUserAgent
 import whl.trending.ai.data.model.FeedResponse
+import whl.trending.ai.data.model.ChatModelOption
+import whl.trending.ai.data.model.ChatModelsResponse
 import whl.trending.ai.data.model.MeResponse
 import whl.trending.ai.data.model.PicksResponse
 import whl.trending.ai.data.model.ReadmeResponse
@@ -150,6 +152,15 @@ open class TrendingApi {
             throw ApiException(response.status.value, response.bodyAsText())
         }
         return response.body<MeResponse>()
+    }
+
+    /** 聊天可选模型目录（公开只读；后端从 OpenAI 动态取 + 缓存）。 */
+    open suspend fun fetchChatModels(): List<ChatModelOption> {
+        val response = client.get("$baseHost/api/chat/models")
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<ChatModelsResponse>().models
     }
 
     open suspend fun cancelSubscribe(email: String): Result<SubscribeResponse> {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/ChatModelsProvider.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/ChatModelsProvider.kt
@@ -1,5 +1,6 @@
 package whl.trending.ai.data.repository
 
+import kotlin.concurrent.Volatile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/ChatModelsProvider.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/ChatModelsProvider.kt
@@ -1,0 +1,47 @@
+package whl.trending.ai.data.repository
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import whl.trending.ai.data.model.ChatModelOption
+import whl.trending.ai.data.remote.TrendingApi
+
+/**
+ * 聊天模型目录的进程级缓存 + 预热。
+ *
+ * 根因：模型选择器 chip 仅在 `models.size > 1` 时显示，而模型目录原先在每个 [ChatViewModel] 的 init 里
+ * 各自网络拉取。首个打开的会话触发后端冷路径（`/api/chat/models` 冷 isolate 同步拉 OpenAI /models，耗时数秒），
+ * 期间 chip 一直不出现——被误认为「没有模型列表」；后续会话命中后端热缓存才秒出。
+ *
+ * 修法：全进程只拉一次并缓存（[get]），且在应用启动时[warmUp]预热，让 chip 在任何会话打开前就绪。
+ * 失败不缓存空结果，下次自动重试。
+ */
+object ChatModelsProvider {
+    private val api = TrendingApi()
+    private val mutex = Mutex()
+
+    @Volatile
+    private var cache: List<ChatModelOption>? = null
+
+    /** 取模型目录：命中缓存直接返回；否则拉一次，成功才缓存（失败返回空、下次重试）。 */
+    suspend fun get(): List<ChatModelOption> {
+        cache?.let { return it }
+        return mutex.withLock {
+            cache?.let { return it }
+            val fetched = runCatching { api.fetchChatModels() }.getOrDefault(emptyList())
+            if (fetched.isNotEmpty()) cache = fetched
+            fetched
+        }
+    }
+
+    /** 应用启动时预热（fire-and-forget），避免首个 chat 等冷拉取。 */
+    fun warmUp(scope: CoroutineScope) {
+        scope.launch { runCatching { get() } }
+    }
+
+    /** 仅测试用：重置缓存。 */
+    fun resetForTest() {
+        cache = null
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
@@ -1,24 +1,29 @@
 package whl.trending.ai.data.repository
 
 import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.model.MeResponse
 import whl.trending.ai.data.model.MeUser
 import whl.trending.ai.data.remote.TrendingApi
 
 // open：便于测试以子类替身注入（保持手动 DI，不引入 mock 框架）
 open class UserRepository(private val api: TrendingApi = TrendingApi()) {
 
-    open suspend fun fetchMe(accessToken: String): MeUser = api.fetchMe(accessToken).user
+    // 测试注入点：子类覆写此方法即可同时影响 fetchMe 与 syncMe
+    open suspend fun fetchMeResponse(accessToken: String): MeResponse = api.fetchMe(accessToken)
+
+    open suspend fun fetchMe(accessToken: String): MeUser = fetchMeResponse(accessToken).user
 
     /**
-     * 登录成功/应用启动（已登录）时调用：服务端建档 + 刷新 last_login_at，并缓存头像。
+     * 登录成功/应用启动（已登录）时调用：服务端建档 + 刷新 last_login_at，并缓存头像与 Pro 权益态。
      * 失败静默——下次打开 Profile 仍会重试，不阻塞登录主流程。
      */
     suspend fun syncMe(accessToken: String?): MeUser? {
         if (accessToken == null) return null
         return try {
-            val user = fetchMe(accessToken)
-            globalSettingsManager.setUserAvatarUrl(user.avatarUrl)
-            user
+            val me = fetchMeResponse(accessToken)
+            globalSettingsManager.setUserAvatarUrl(me.user.avatarUrl)
+            globalSettingsManager.setIsPro(me.pro)
+            me.user
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             null

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
@@ -8,7 +8,8 @@ import whl.trending.ai.data.remote.TrendingApi
 // open：便于测试以子类替身注入（保持手动 DI，不引入 mock 框架）
 open class UserRepository(private val api: TrendingApi = TrendingApi()) {
 
-    // 测试注入点：子类覆写此方法即可同时影响 fetchMe 与 syncMe
+    // 真正的测试注入点：覆写此方法即可同时影响 fetchMe 与 syncMe（二者都经它取数）。
+    // 注意：只覆写下面的 fetchMe 不影响 syncMe——syncMe 直接调 fetchMeResponse，会打真网络。
     open suspend fun fetchMeResponse(accessToken: String): MeResponse = api.fetchMe(accessToken)
 
     open suspend fun fetchMe(accessToken: String): MeUser = fetchMeResponse(accessToken).user

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
@@ -30,4 +30,20 @@ open class UserRepository(private val api: TrendingApi = TrendingApi()) {
             null
         }
     }
+
+    /**
+     * 即时对账 Pro 权益：调 /api/pro/refresh（后端 PAT 权威核对赞助）并刷新本地 isPro 缓存。
+     * 用户从 Sponsors 页返回（ON_RESUME）时调用，实现「赞助完回来即生效」。失败静默返回 null。
+     */
+    suspend fun refreshPro(accessToken: String?): Boolean? {
+        if (accessToken == null) return null
+        return try {
+            val pro = api.refreshPro(accessToken)
+            globalSettingsManager.setIsPro(pro)
+            pro
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            null
+        }
+    }
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -138,6 +138,13 @@ fun HomeScreen(
         }
     }
 
+    // 预热聊天模型目录：让选择器 chip 在用户首次进入 chat 前就绪，避免冷首拉导致 chip 迟迟不出现。
+    LaunchedEffect(Unit) {
+        if (whl.trending.ai.chat.globalChatScreen != null) {
+            runCatching { whl.trending.ai.data.repository.ChatModelsProvider.get() }
+        }
+    }
+
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(


### PR DESCRIPTION
Pro 付费验证的**客户端消费侧**（Stage 2，配套后端 PR github-ai-trending-api#13）。上线后靠 `/api/me` 的 `pro` 标志渲染 Pro 态；`ON_RESUME` 即时刷新属 Stage 3。

## 数据层（shared）
- `Me.kt`：`MeResponse` 加 `pro`
- `ChatModelOption.kt`（新）：模型目录类型 + `DEFAULT_CHAT_MODEL`
- `TrendingApi.fetchChatModels()`：`GET /api/chat/models`
- `SettingsManager`：`isPro` 缓存（登录写/登出清）+ `selectedChatModel` 持久化
- `UserRepository.syncMe`：缓存 pro；抽 `fetchMeResponse` 保留测试注入点

## UI（chat 模块）
- **ModelPicker**（新）：常驻选择器，默认 gpt-5.4，Pro 项对免费用户锁定（🔒），点锁定项 → 埋点 `pro_upsell_*(model_locked)` + Toast + 跳 Sponsors
- **QuotaLimitCard** 登录触顶态：主 CTA「解锁 Pro·$2/月」→ Sponsors，埋点 `pro_upsell_*(chat_quota)`，保留 waitlist 次按钮，加激活延迟提示
- `ChatApi`：请求透传 `selectedChatModel`（服务端仍按 tier 强制）；登出清 isPro

## 验证
Pixel_9_2 实机：选择器渲染 **GPT-5.4 + GPT-5.5🔒**（免费用户锁定）。全 app 编译通过，shared 测试源编译通过（`fetchMe` 注入点保留）。

## 未含（Stage 3）
`/api/pro/refresh` + `ON_RESUME` 即时刷新 + Sponsors webhook。当前 Pro 态在 app 启动/登录时经 `/api/me` 获取。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

添加支持 Pro 订阅感知的聊天模型选择，以及基于持久化 Pro 状态和服务器提供的模型目录驱动的配额升级（upsell）客户端流程。

New Features:
- 引入一个持久化的聊天模型选择器，展示免费和仅限 Pro 的模型，并将被 Pro 限制的选择引导到 Sponsors 页面。
- 从后端获取可用的聊天模型，并持久化用户选择的模型以用于聊天请求。
- 从 `/api/me` 缓存用户的 Pro 权益状态，并将其暴露给 UI，用于控制 Pro 功能访问。

Enhancements:
- 为已登录用户更新配额上限卡片，加入主要的 Pro 升级 CTA、激活延迟提示以及相关埋点事件。
- 扩展聊天请求负载以包含所选模型，同时保持服务器端的分级（tier）校验与限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Pro subscription-aware chat model selection and quota upsell client flows driven by persisted Pro state and server-provided model catalog.

New Features:
- Introduce a persistent chat model picker that surfaces free and Pro-only models and routes Pro-locked selections to the Sponsors page.
- Fetch available chat models from the backend and persist the user-selected model for use in chat requests.
- Cache the user’s Pro entitlement status from /api/me and expose it to the UI for gating Pro features.

Enhancements:
- Update the quota limit card for logged-in users to include a primary Pro upsell CTA, activation delay hint, and associated tracking events.
- Extend chat request payloads to include the selected model while keeping server-side tier enforcement.

</details>