### PR TITLE
refactor(open-url): 外链打开统一收口到 Custom Tab

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import whl.trending.ai.core.Constants
 import whl.trending.ai.core.platform.trackEvent
@@ -43,6 +44,7 @@ internal fun ModelPicker(
     if (models.size <= 1) return
 
     val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
     val isPro by globalSettingsManager.isPro.collectAsState(initial = globalSettingsManager.getIsProSync())
     val selectedId by globalSettingsManager.selectedChatModel
         .collectAsState(initial = globalSettingsManager.getSelectedChatModelSync())
@@ -103,7 +105,7 @@ internal fun ModelPicker(
                                 context.getString(R.string.chat_model_pro_locked, model.name),
                                 Toast.LENGTH_SHORT,
                             ).show()
-                            openUrl(context, Constants.GITHUB_SPONSORS_URL)
+                            uriHandler.openUri(Constants.GITHUB_SPONSORS_URL)
                         } else {
                             globalSettingsManager.setSelectedChatModel(model.id)
                         }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
@@ -1,8 +1,5 @@
 package whl.trending.chat.ui
 
-import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -28,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import java.util.Locale
@@ -56,7 +54,7 @@ internal fun QuotaLimitCard(
     onRetry: () -> Unit,
 ) {
     val authState by globalAuthManager.authState.collectAsState()
-    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
     val isProTier = error.tier == ChatError.TIER_PRO
     val isUserTier = error.tier == ChatError.TIER_USER
     var showWaitlistDialog by remember { mutableStateOf(false) }
@@ -79,7 +77,7 @@ internal fun QuotaLimitCard(
                 QuotaText(R.string.chat_pro_upsell_message)
                 Button(onClick = {
                     trackEvent("pro_upsell_clicked", mapOf(UPSELL_SOURCE_KEY to SOURCE_CHAT_QUOTA))
-                    openUrl(context, Constants.GITHUB_SPONSORS_URL)
+                    uriHandler.openUri(Constants.GITHUB_SPONSORS_URL)
                 }) {
                     Text(stringResource(R.string.chat_pro_cta))
                 }
@@ -219,15 +217,6 @@ internal const val UPSELL_SOURCE_KEY = "source"
 /** 付费漏斗来源：区分「配额触顶」入口与「模型锁定」入口 */
 internal const val SOURCE_CHAT_QUOTA = "chat_quota"
 internal const val SOURCE_MODEL_LOCKED = "model_locked"
-
-/** 用系统浏览器打开外链（Sponsors 页）。失败静默——不阻塞。 */
-internal fun openUrl(context: Context, url: String) {
-    runCatching {
-        context.startActivity(
-            Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-        )
-    }
-}
 
 // 与服务端 subscribe.js 的 isValidEmail 同构；服务端仍做完整校验，这里只挡明显无效输入
 private val EMAIL_REGEX = Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$")

--- a/shared/src/androidMain/kotlin/whl/trending/ai/core/platform/Platform.android.kt
+++ b/shared/src/androidMain/kotlin/whl/trending/ai/core/platform/Platform.android.kt
@@ -34,24 +34,16 @@ actual fun openAppSettings() {
     context.startActivity(intent)
 }
 
-actual fun openUrl(url: String, targetPackage: String?) {
+actual fun openInSystemBrowser(url: String) {
     val context = AndroidContextHolder.get() ?: return
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
-    
-    if (targetPackage != null) {
-        intent.setPackage(targetPackage)
-    }
-    
     try {
         context.startActivity(intent)
     } catch (e: Exception) {
-        // Fallback to system default (browser) if specified app is not installed or fails
-        if (targetPackage != null) {
-            intent.setPackage(null)
-            context.startActivity(intent)
-        }
+        // 设备无浏览器可承接，静默
+        Log.w("Platform", "openInSystemBrowser failed", e)
     }
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
@@ -14,16 +14,18 @@ import whl.trending.ai.ui.theme.TrendingTheme
 import whl.trending.ai.ui.webview.WebViewScreen
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
 import whl.trending.ai.chat.ChatContext
 import whl.trending.ai.chat.globalChatScreen
-import whl.trending.ai.core.platform.openInCustomTab
-import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.core.platform.openUrl
 import whl.trending.ai.ui.common.SignInHintHost
 import whl.trending.ai.ui.common.WhatsNewHost
 
@@ -59,20 +61,26 @@ fun App() {
     // 用户在设置中关闭、或设备无浏览器可承接时，兜底进应用内 WebView。
     // GitHub README 阅读走 RepoDetail 路由，不经此处。
     val openExternalUrl: (url: String, title: String) -> Unit = { url, title ->
-        val useCustomTab = globalSettingsManager.getOpenLinksInCustomTabSync()
-        if (!useCustomTab || !openInCustomTab(url)) {
-            backStack.add(WebPage(url, title))
+        openUrl(url, onInAppFallback = { backStack.add(WebPage(url, title)) })
+    }
+
+    // 覆盖 Compose 默认 UriHandler，让所有 openUri 调用与 Markdown 链接都收口到统一出口，
+    // 无需逐处改造（Profile 列表、聊天回复链接等直接受益）。WebView 兜底无标题位，传空。
+    val customUriHandler = remember(backStack) {
+        object : UriHandler {
+            override fun openUri(uri: String) = openExternalUrl(uri, "")
         }
     }
 
     TrendingTheme {
-        WhatsNewHost()
-        SignInHintHost()
-        NavDisplay(
-            backStack = backStack,
-            onBack = { backStack.safePop() },
-            entryProvider = { key ->
-                when (key) {
+        CompositionLocalProvider(LocalUriHandler provides customUriHandler) {
+            WhatsNewHost()
+            SignInHintHost()
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.safePop() },
+                entryProvider = { key ->
+                    when (key) {
                     is Home -> NavEntry(key) {
                         HomeScreen(
                             onNavigateToSettings = {
@@ -205,8 +213,9 @@ fun App() {
                     else -> {
                         error("Unknown route: $key")
                     }
+                    }
                 }
-            }
-        )
+            )
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/Constants.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/Constants.kt
@@ -1,7 +1,6 @@
 package whl.trending.ai.core
 
 object Constants {
-    const val GITHUB_APP_PACKAGE = "com.github.android"
     const val OFFICIAL_WEBSITE_URL = "https://trendingai.cn/app"
     const val FEEDBACK_URL = "https://github.com/HarlonWang/TrendingAI/issues"
     const val RELEASES_URL = "https://github.com/HarlonWang/TrendingAI/releases/latest"

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
@@ -10,15 +10,37 @@ expect fun getPlatform(): Platform
 
 expect fun openAppSettings()
 
-expect fun openUrl(url: String, targetPackage: String? = null)
+/** 底层原语：系统浏览器直跳外链（Android ACTION_VIEW / iOS openURL）。作为 [openUrl] 的最终兜底，勿直接调用。 */
+expect fun openInSystemBrowser(url: String)
 
 /**
- * 在系统浏览器环境中打开链接（Android Custom Tabs / iOS SFSafariViewController）。
+ * 底层原语：在系统浏览器环境中打开链接（Android Custom Tabs / iOS SFSafariViewController）。
  * 真实浏览器指纹可正常通过 Cloudflare 等人机验证，并自带翻译/密码填充/登录态。
+ * 供 [openUrl] 调用，勿直接调用。
  *
- * @return 是否成功调起；false 时由调用方兜底（进应用内 WebView）。
+ * @return 是否成功调起；false 时由 [openUrl] 兜底。
  */
 expect fun openInCustomTab(url: String): Boolean
+
+/**
+ * 外链统一出口。全 app 打开外链一律调这个，优先级：
+ * ① 非 http/https（mailto/tel 等）→ 交系统处理；
+ * ② 用户开启「用 Custom Tab」且成功调起 → [openInCustomTab]；
+ * ③ 传了 [onInAppFallback] → 应用内 WebView；否则 → [openInSystemBrowser]。
+ *
+ * @param onInAppFallback 应用内 WebView 兜底。组合树外（如更新弹窗）拿不到导航栈时传 null，退化为系统浏览器。
+ */
+fun openUrl(url: String, onInAppFallback: ((url: String) -> Unit)? = null) {
+    val isWeb = url.startsWith("http://") || url.startsWith("https://")
+    if (isWeb && globalSettingsManager.getOpenLinksInCustomTabSync() && openInCustomTab(url)) {
+        return
+    }
+    if (isWeb && onInAppFallback != null) {
+        onInAppFallback(url)
+        return
+    }
+    openInSystemBrowser(url)
+}
 
 /** 调起系统分享面板，把纯文本交给用户选择的目标 App（AI App / 笔记 / IM 等）。 */
 expect fun shareText(text: String)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
@@ -2,8 +2,6 @@ package whl.trending.ai.ui.detail
 
 import whl.trending.ai.chat.ChatContext
 import whl.trending.ai.chat.globalChatScreen
-import whl.trending.ai.core.Constants
-import whl.trending.ai.core.platform.openUrl
 import whl.trending.ai.core.platform.shareText
 import whl.trending.ai.core.platform.trackEvent
 
@@ -43,6 +41,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -87,6 +86,7 @@ fun ReadmeScreen(
         muted  = colorScheme.onSurfaceVariant.toHex(),
     )
     val repoUrl = "https://github.com/$owner/$repo"
+    val uriHandler = LocalUriHandler.current
     // README 摘录涉及多次正则替换，缓存结果避免每次重组重算（分享栏与 FAB 共用）
     val summary = remember(uiState.html) { readmeExcerpt(uiState.html) }
 
@@ -168,7 +168,7 @@ fun ReadmeScreen(
                             contentDescription = stringResource(Res.string.share_to_ai)
                         )
                     }
-                    IconButton(onClick = { openUrl(repoUrl, Constants.GITHUB_APP_PACKAGE) }) {
+                    IconButton(onClick = { uriHandler.openUri(repoUrl) }) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
                             contentDescription = stringResource(Res.string.view_on_github)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feedback/FeedbackScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feedback/FeedbackScreen.kt
@@ -1,7 +1,6 @@
 package whl.trending.ai.ui.feedback
 
 import whl.trending.ai.core.Constants
-import whl.trending.ai.core.platform.openUrl
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -37,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
@@ -61,6 +61,7 @@ fun FeedbackScreen(
     viewModel: FeedbackViewModel = viewModel { FeedbackViewModel() }
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val uriHandler = LocalUriHandler.current
     val snackbarHostState = remember { SnackbarHostState() }
 
     val successMsg = stringResource(Res.string.feedback_success)
@@ -155,7 +156,7 @@ fun FeedbackScreen(
             Spacer(Modifier.height(16.dp))
 
             TextButton(
-                onClick = { openUrl(Constants.FEEDBACK_URL, Constants.GITHUB_APP_PACKAGE) },
+                onClick = { uriHandler.openUri(Constants.FEEDBACK_URL) },
                 modifier = Modifier.align(Alignment.CenterHorizontally)
             ) {
                 Text(stringResource(Res.string.feedback_github_issues))

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -7,7 +7,6 @@ import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.core.platform.isIosPlatform
 import whl.trending.ai.core.platform.openAppSettings
 import whl.trending.ai.core.platform.getAppVersion
-import whl.trending.ai.core.platform.openUrl
 import whl.trending.ai.core.platform.getSystemLanguage
 import whl.trending.ai.core.platform.getSystemLanguageDisplayName
 import whl.trending.ai.core.Constants
@@ -82,6 +81,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalUriHandler
 import kotlinx.coroutines.launch
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -164,6 +164,7 @@ fun SettingsScreen(
     onNavigateToWebPage: (url: String, title: String) -> Unit = { _, _ -> }
 ) {
     val isIos = isIosPlatform()
+    val uriHandler = LocalUriHandler.current
     val themeMode by globalSettingsManager.themeMode.collectAsState(ThemeMode.FOLLOW_SYSTEM)
     val seedColor by globalSettingsManager.seedColor.collectAsState(DEFAULT_SEED_ARGB)
     val appLanguage by globalSettingsManager.appLanguage.collectAsState(AppLanguage.FOLLOW_SYSTEM)
@@ -310,7 +311,7 @@ fun SettingsScreen(
                                     langSubmitting = false
                                     showLangCaptureDialog = false
                                     trackEvent("settings_summary_language_sponsor", mapOf("language" to lang))
-                                    openUrl(Constants.GITHUB_SPONSORS_URL)
+                                    uriHandler.openUri(Constants.GITHUB_SPONSORS_URL)
                                 },
                                 onFailure = { e ->
                                     langSubmitting = false
@@ -350,7 +351,7 @@ fun SettingsScreen(
                             .fillMaxWidth()
                             .clickable {
                                 trackEvent("settings_donate_github")
-                                openUrl(Constants.GITHUB_SPONSORS_URL)
+                                uriHandler.openUri(Constants.GITHUB_SPONSORS_URL)
                             }
                             .padding(vertical = 12.dp)
                     ) {
@@ -655,7 +656,7 @@ fun SettingsScreen(
                         modifier = Modifier.clickable(enabled = !isChecking) {
                             trackEvent("settings_check_update")
                             if (isIos) {
-                                openUrl(Constants.OFFICIAL_WEBSITE_URL)
+                                uriHandler.openUri(Constants.OFFICIAL_WEBSITE_URL)
                             } else {
                                 globalUpdateChecker.manualCheck()
                             }
@@ -669,7 +670,7 @@ fun SettingsScreen(
                     supportingContent = { Text(stringResource(Res.string.about_us_desc)) },
                     leadingContent = { Icon(Icons.Default.Info, null) },
                     modifier = Modifier.clickable {
-                        openUrl(Constants.OFFICIAL_WEBSITE_URL)
+                        uriHandler.openUri(Constants.OFFICIAL_WEBSITE_URL)
                     }
                 )
             }

--- a/shared/src/iosMain/kotlin/whl/trending/ai/core/platform/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/whl/trending/ai/core/platform/Platform.ios.kt
@@ -30,7 +30,7 @@ actual fun openAppSettings() {
     }
 }
 
-actual fun openUrl(url: String, targetPackage: String?) {
+actual fun openInSystemBrowser(url: String) {
     val nsUrl = NSURL.URLWithString(url)
     if (nsUrl != null) {
         UIApplication.sharedApplication.openURL(


### PR DESCRIPTION
## 背景
现状全 app 打开外链有三套并存、风格不统一的出口：
- `openUrl(url, targetPackage)` 直跳 `ACTION_VIEW`（部分还刻意优先 GitHub App）
- `openInCustomTab()` Custom Tabs（仅 App.kt 的列表点击走）
- `LocalUriHandler.openUri()` / Markdown 链接 走系统默认

其中只有 App.kt 的 `openExternalUrl` 尊重「用 Custom Tab」设置与 WebView 兜底，其余全绕开。

## 改动
新增统一出口 `openCustomTabLink(url, onInAppFallback)`（`Platform.kt`），优先级：
1. 非 http/https（mailto/tel 等）→ 交系统
2. 用户开启「用 Custom Tab」且成功调起 → Custom Tabs / SFSafariViewController
3. 传了兜底 → 应用内 WebView；否则 → 系统浏览器

**核心机制**：`App.kt` 根部 `CompositionLocalProvider(LocalUriHandler provides ...)` 覆盖 Compose 默认 UriHandler，所有 `openUri` 与 Markdown 链接**零改动自动收口**。

| 类别 | 处理 |
|---|---|
| Home/Favorites/Settings 列表点击 | `openExternalUrl` 委托 `openCustomTabLink`，行为不变 |
| Profile 列表、聊天回复 Markdown 链接 | 零改动，被 `LocalUriHandler` 覆盖自动收口 |
| Settings(4)/Feedback/Readme | 改用 `uriHandler.openUri`，**移除 GitHub App 优先** |
| chat 配额卡/模型锁 | 改用 `LocalUriHandler`，删私有 `openUrl`（无需引 androidx.browser） |
| updater 更新弹窗（组合树外） | 直调 `openCustomTabLink`，退化 CustomTab→系统浏览器（无 WebView 兜底） |

**连带清理**：`openUrl(url, targetPackage)` 精简为 `openUrl(url)`（仅作系统兜底原语）；删除无引用的 `Constants.GITHUB_APP_PACKAGE`。

## 验证
- `:androidApp:compileGithubDebugKotlin`（含 chat/updater 依赖）✅ exit 0
- `:shared:compileKotlinIosSimulatorArm64` ✅ exit 0
- 仅有与本次改动无关的既有告警

> 尚未做模拟器真机验证（逐入口确认走 Custom Tab、关设置后落 WebView），如需可补。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 总结

通过单一、支持 Custom Tab 的入口统一外部链接处理，并将 Compose 的 URI 处理接入该路径。

新功能：
- 引入 `openCustomTabLink` 作为集中式外部链接打开器，遵循用户的 Custom Tab 设置，并在需要时提供应用内 WebView 备用方案。

增强与改进：
- 在应用根部重写 Compose 的 `LocalUriHandler`，使所有 `openUri` 调用和 Markdown 链接自动通过统一的外部链接处理器。
- 简化平台层的 `openUrl`，在 Android 和 iOS 上都改为与包名无关的系统浏览器回退方案，并在 Android 上记录失败日志。
- 重构设置、反馈、README、聊天配额/模型选择器以及更新流程，使其使用 `LocalUriHandler`/`openCustomTabLink`，替代过去基于 Intent 的临时 URL 打开方式或特定于 GitHub 应用的逻辑。
- 移除现已不再需要的 GitHub 应用包名常量以及聊天中多余的 Android 专用 URL 帮助工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify external link handling through a single Custom Tab–aware entry point and wire Compose URI handling to this pathway.

New Features:
- Introduce openCustomTabLink as the centralized external link opener that respects user Custom Tab settings and provides optional in-app WebView fallback.

Enhancements:
- Override Compose LocalUriHandler at the root of the app so all openUri calls and Markdown links automatically funnel through the unified external link handler.
- Simplify platform openUrl to a package-agnostic system browser fallback on both Android and iOS, logging failures on Android.
- Refactor settings, feedback, readme, chat quota/model picker, and updater flows to use LocalUriHandler/openCustomTabLink instead of ad-hoc intent-based URL opening or GitHub-app-specific logic.
- Remove the now-unneeded GitHub app package constant and redundant Android-only URL helper in chat.

</details>