### PR TITLE
fix(pro): 赞助对账收口 ProSponsor —— 意图窗口内才打后端，赞助页强制外开

### DIFF
--- a/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import whl.trending.ai.chat.globalChatScreen
 import whl.trending.ai.core.App
+import whl.trending.ai.core.ProSponsor
 import whl.trending.ai.data.local.AppLanguage
 import whl.trending.ai.data.local.ThemeMode
 import whl.trending.ai.data.local.globalSettingsManager
@@ -80,16 +81,19 @@ class MainActivity : AppCompatActivity() {
     }
 
     /**
-     * 回到前台时对账 Pro：仅「已登录且当前非 Pro」才查——正好覆盖「刚在浏览器完成赞助、返回 app」的路径，
-     * 让权益即时生效，不等 webhook。已 Pro / 未登录直接跳过，避免每次 resume 都打后端。
+     * 回到前台时对账 Pro：仅「已登录、非 Pro、且处于 ProSponsor 对账窗口内（刚打开过赞助页）」才查，
+     * 让「浏览器完成赞助、返回 app」即时生效，不等 webhook。窗口外零请求——服务端
+     * pro-refresh 每次都消耗 GitHub PAT 配额，不能拿 resume 当轮询点。
      */
     override fun onResume() {
         super.onResume()
         val loggedIn = whl.trending.ai.auth.globalAuthManager.authState.value is whl.trending.ai.auth.AuthState.LoggedIn
-        if (loggedIn && !globalSettingsManager.getIsProSync()) {
+        if (loggedIn && !globalSettingsManager.getIsProSync() && ProSponsor.shouldReconcile()) {
             lifecycleScope.launch {
                 val token = whl.trending.ai.auth.globalAuthManager.getAccessToken()
-                whl.trending.ai.data.repository.UserRepository().refreshPro(token)
+                if (whl.trending.ai.data.repository.UserRepository().refreshPro(token) == true) {
+                    ProSponsor.markReconciled()
+                }
             }
         }
     }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -21,9 +21,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
-import whl.trending.ai.core.Constants
+import whl.trending.ai.core.ProSponsor
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.ChatModelOption
@@ -44,7 +43,6 @@ internal fun ModelPicker(
     if (models.size <= 1) return
 
     val context = LocalContext.current
-    val uriHandler = LocalUriHandler.current
     val isPro by globalSettingsManager.isPro.collectAsState(initial = globalSettingsManager.getIsProSync())
     val selectedId by globalSettingsManager.selectedChatModel
         .collectAsState(initial = globalSettingsManager.getSelectedChatModelSync())
@@ -105,7 +103,7 @@ internal fun ModelPicker(
                                 context.getString(R.string.chat_model_pro_locked, model.name),
                                 Toast.LENGTH_SHORT,
                             ).show()
-                            uriHandler.openUri(Constants.GITHUB_SPONSORS_URL)
+                            ProSponsor.openSponsorPage()
                         } else {
                             globalSettingsManager.setSelectedChatModel(model.id)
                         }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import java.util.Locale
@@ -33,7 +32,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.globalAuthManager
-import whl.trending.ai.core.Constants
+import whl.trending.ai.core.ProSponsor
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.TrendingRepository
@@ -54,7 +53,6 @@ internal fun QuotaLimitCard(
     onRetry: () -> Unit,
 ) {
     val authState by globalAuthManager.authState.collectAsState()
-    val uriHandler = LocalUriHandler.current
     val isProTier = error.tier == ChatError.TIER_PRO
     val isUserTier = error.tier == ChatError.TIER_USER
     var showWaitlistDialog by remember { mutableStateOf(false) }
@@ -77,7 +75,7 @@ internal fun QuotaLimitCard(
                 QuotaText(R.string.chat_pro_upsell_message)
                 Button(onClick = {
                     trackEvent("pro_upsell_clicked", mapOf(UPSELL_SOURCE_KEY to SOURCE_CHAT_QUOTA))
-                    uriHandler.openUri(Constants.GITHUB_SPONSORS_URL)
+                    ProSponsor.openSponsorPage()
                 }) {
                     Text(stringResource(R.string.chat_pro_cta))
                 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/ProSponsor.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/ProSponsor.kt
@@ -1,0 +1,40 @@
+package whl.trending.ai.core
+
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import whl.trending.ai.core.platform.openUrl
+import whl.trending.ai.data.local.globalSettingsManager
+
+/**
+ * Pro 赞助页统一入口 + 权益对账窗口。
+ *
+ * 打开赞助页必须经 [openSponsorPage]：它记录赞助意图时间戳，并强制在应用外打开
+ * （Custom Tab / 系统浏览器，不传 onInAppFallback）——一是 GitHub Sponsors 依赖
+ * 浏览器的 github.com 登录态，内置 WebView 里没有；二是保证返回 app 时必然触发
+ * ON_RESUME，前台对账（MainActivity.onResume → refreshPro）才有机会执行。
+ *
+ * 对账只在 [shouldReconcile] 的窗口内进行：没打开过赞助页的用户回前台零后端请求
+ * （服务端 pro-refresh 每次都要消耗 GitHub PAT 配额，不能拿 resume 当轮询点）。
+ */
+object ProSponsor {
+
+    /** 打开赞助页后允许对账的时间窗口：覆盖赞助生效的「几分钟内」延迟，又给请求数封顶。 */
+    private val RECONCILE_WINDOW = 30.minutes
+
+    fun openSponsorPage() {
+        globalSettingsManager.setSponsorPageOpenedAt(Clock.System.now().toEpochMilliseconds())
+        openUrl(Constants.GITHUB_SPONSORS_URL)
+    }
+
+    /** 是否处于「刚打开过赞助页」的对账窗口内。 */
+    fun shouldReconcile(): Boolean {
+        val openedAt = globalSettingsManager.getSponsorPageOpenedAtSync()
+        return openedAt > 0 &&
+            Clock.System.now().toEpochMilliseconds() - openedAt < RECONCILE_WINDOW.inWholeMilliseconds
+    }
+
+    /** 对账确认已是 Pro 后调用，结束窗口。 */
+    fun markReconciled() {
+        globalSettingsManager.clearSponsorPageOpenedAt()
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -45,6 +45,7 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val USER_AVATAR_KEY = "prefs_user_avatar_url"
     private val FEED_HIGHLIGHTS_ONLY_KEY = "prefs_feed_filter_highlights"
     private val IS_PRO_KEY = "prefs_is_pro"
+    private val SPONSOR_PAGE_OPENED_AT_KEY = "prefs_sponsor_page_opened_at"
     private val SELECTED_CHAT_MODEL_KEY = "prefs_selected_chat_model"
     private val OPEN_LINKS_IN_CUSTOM_TAB_KEY = "prefs_open_links_in_custom_tab"
     private val TRENDING_NEW_ONLY_DEFAULT_KEY = "prefs_trending_new_only_default"
@@ -155,6 +156,17 @@ class SettingsManager(private val settings: ObservableSettings) {
 
     fun setIsPro(value: Boolean) {
         settings.putBoolean(IS_PRO_KEY, value)
+    }
+
+    /** 最近一次打开 GitHub Sponsors 赞助页的时间戳（epoch millis），0 表示无待对账的赞助意图。 */
+    fun getSponsorPageOpenedAtSync(): Long = settings.getLong(SPONSOR_PAGE_OPENED_AT_KEY, 0L)
+
+    fun setSponsorPageOpenedAt(time: Long) {
+        settings.putLong(SPONSOR_PAGE_OPENED_AT_KEY, time)
+    }
+
+    fun clearSponsorPageOpenedAt() {
+        settings.putLong(SPONSOR_PAGE_OPENED_AT_KEY, 0L)
     }
 
     /** 选中的聊天模型 id：发请求时透传（服务端仍按 tier 强制）。默认免费 gpt-5.4。 */

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -10,6 +10,7 @@ import whl.trending.ai.core.platform.getAppVersion
 import whl.trending.ai.core.platform.getSystemLanguage
 import whl.trending.ai.core.platform.getSystemLanguageDisplayName
 import whl.trending.ai.core.Constants
+import whl.trending.ai.core.ProSponsor
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.globalAuthManager
@@ -311,7 +312,7 @@ fun SettingsScreen(
                                     langSubmitting = false
                                     showLangCaptureDialog = false
                                     trackEvent("settings_summary_language_sponsor", mapOf("language" to lang))
-                                    uriHandler.openUri(Constants.GITHUB_SPONSORS_URL)
+                                    ProSponsor.openSponsorPage()
                                 },
                                 onFailure = { e ->
                                     langSubmitting = false
@@ -351,7 +352,7 @@ fun SettingsScreen(
                             .fillMaxWidth()
                             .clickable {
                                 trackEvent("settings_donate_github")
-                                uriHandler.openUri(Constants.GITHUB_SPONSORS_URL)
+                                ProSponsor.openSponsorPage()
                             }
                             .padding(vertical = 12.dp)
                     ) {

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
@@ -5,8 +5,10 @@ import com.russhwolf.settings.ObservableSettings
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -25,6 +27,7 @@ import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.FollowingProvider
 import whl.trending.ai.auth.GithubTokenProvider
 import whl.trending.ai.auth.OwnRepoEventsProvider
+import whl.trending.ai.auth.SignInFailureReason
 import whl.trending.ai.data.local.FakeCacheFileStore
 import whl.trending.ai.data.local.LastDataCache
 import whl.trending.ai.data.local.SettingsManager
@@ -42,6 +45,7 @@ class ProfileViewModelTest {
         val state = MutableStateFlow<AuthState>(AuthState.LoggedIn)
         override val isSupported: Boolean = true
         override val authState: StateFlow<AuthState> = state
+        override val signInFailures: Flow<SignInFailureReason> = emptyFlow()
         override fun signIn() {}
         override fun signOut() {}
         override suspend fun getAccessToken(): String? = "token"


### PR DESCRIPTION
## 背景

发布前 review（0.18.0..HEAD）发现 Pro 激活链路的两个问题，同根同源：

1. **refreshPro 无节流**：`MainActivity.onResume` 的守卫只有 `loggedIn && !isPro`，所有登录免费用户每次回前台都会打一次 `POST /api/pro/refresh`，服务端每次执行 GitHub PAT GraphQL 查询（共享 5000 点/小时配额）+ 无条件 D1 写入。DAU 上涨后 PAT 配额耗尽，真实赞助者的即时激活会静默失败。
2. **内置 WebView 路径激活失效**：关闭「用浏览器打开外链」的用户点「解锁 Pro」时，赞助页以 WebPage 压入同 Activity 的返回栈，返回不触发 onResume，唯一的对账触发点整个会话不执行。

根因：对账的前提——「用户刚打开过赞助页」——从未被记录，只能用宽泛条件近似。

## 改动

- 新增 `ProSponsor`（shared core）统一入口：
  - `openSponsorPage()` 记录赞助意图时间戳，并**强制应用外打开**（Custom Tab / 系统浏览器，不传 `onInAppFallback`）。GitHub Sponsors 依赖浏览器的 github.com 登录态，内置 WebView 里没有；离开 Activity 也保证返回必触发 ON_RESUME
  - `shouldReconcile()`：打开赞助页后 30 分钟对账窗口，覆盖「几分钟内生效」的延迟，又给请求数封顶
- `MainActivity.onResume` 守卫收紧为 `loggedIn && !isPro && shouldReconcile()`，对账成功清窗口；窗口外**零后端请求**
- 四个赞助入口（QuotaLimitCard / ModelPicker / SettingsScreen 语言弹窗与捐助弹窗）全部收口到 `ProSponsor.openSponsorPage()`
- `SettingsManager` 新增 `prefs_sponsor_page_opened_at` 时间戳读写
- 顺手修存量问题：eabb490 给 `AuthManager` 加 `signInFailures` 时漏改 `ProfileViewModelTest.FakeAuthManager`，shared 测试自那时起编译不过，已补 override

## 行为对比

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 普通免费用户切换应用/解锁屏幕 | 每次 resume 打一次后端 | 零请求 |
| 赞助完从 Custom Tab 返回 | 立即激活 | 立即激活，窗口内可重查，成功即清标记 |
| 关闭 Custom Tab 设置的用户点「解锁 Pro」 | 进内置 WebView，返回不激活 | 强制外开，返回即对账 |
| 打开赞助页但未付款 | — | 窗口内每次 resume 查一次，30 分钟后自动归零 |

## 验证

- `:androidApp:assembleDebug` 编译通过
- `:shared:testAndroidHostTest` + `:androidLibrary:chat:testDebugUnitTest` 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在受时间限制的赞助意图窗口下进行 Pro 权限对账，并统一处理赞助页面。

New Features:
- 引入共享的 `ProSponsor` 辅助工具，用于统一打开 GitHub Sponsors 页面，并管理 Pro 激活时的对账时间窗口。

Bug Fixes:
- 通过只在最近访问过赞助页面且仍在指定时间窗口内时才执行对账，防止在应用恢复时过多地刷新 Pro 状态。
- 通过强制使用外部浏览器打开，确保当用户在应用外打开赞助页面或禁用应用内 WebView 时，Pro 激活仍能正常工作。
- 通过更新假的 `AuthManager` 以实现新的登录失败流接口，修复 `ProfileViewModel` 测试。

Enhancements:
- 在 `SettingsManager` 中持久化最后一次打开赞助页面的时间，以支持受控的对账行为。
- 更新所有现有的赞助入口，统一通过 `ProSponsor` 路由，以在应用中实现一致的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate Pro entitlement reconciliation behind a time-limited sponsor-intent window and centralize sponsor page handling.

New Features:
- Introduce a shared ProSponsor helper to centralize opening the GitHub Sponsors page and managing a reconciliation window for Pro activation.

Bug Fixes:
- Prevent excessive Pro refresh calls on app resume by only reconciling after a recent sponsor page visit within a defined window.
- Ensure Pro activation works when users open the sponsor page from outside the app or with in-app WebView disabled by forcing external browser opening.
- Fix ProfileViewModel tests by updating the fake AuthManager to implement the new sign-in failure stream interface.

Enhancements:
- Persist the last sponsor page open time in SettingsManager to support controlled reconciliation behavior.
- Update all existing sponsor entry points to route through ProSponsor for consistent behavior across the app.

</details>