### PR TITLE
fix: 付费漏斗正确性四连修 —— 登录降级识别 / 失败提示总线 / 身份缓存 / 订阅落地

### DIFF
--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -10,11 +10,8 @@ import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import kotlin.coroutines.resume
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import whl.trending.ai.BuildConfig
@@ -51,11 +48,6 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
     override val authState: StateFlow<AuthState> = _authState.asStateFlow()
     override val isSupported: Boolean = true
 
-    // extraBufferCapacity=1：即使此刻没有收集者（如提示宿主尚未组合），失败事件也不丢，
-    // 待收集者上线后仍能拿到最近一次。
-    private val _signInFailures = MutableSharedFlow<SignInFailureReason>(extraBufferCapacity = 1)
-    override val signInFailures: Flow<SignInFailureReason> = _signInFailures.asSharedFlow()
-
     override fun signIn() {
         val activity = activityRef.get() ?: return
         _authState.value = AuthState.LoggingIn
@@ -66,24 +58,30 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
             } else {
                 _authState.value = AuthState.LoggedOut
                 if (logtoException != null) {
-                    val reason = classifySignInFailure(logtoException)
-                    trackEvent("sign_in_failed", signInFailureProps(logtoException, reason))
-                    _signInFailures.tryEmit(reason)
+                    val (reason, props) = analyzeSignInFailure(logtoException)
+                    trackEvent("sign_in_failed", props)
+                    // 走进程级总线而非实例字段：配置变更重建 Activity 后回调可能落在旧实例上（见 SignInFailureBus）
+                    SignInFailureBus.emit(reason)
                 }
             }
         }
     }
 
     /**
-     * 把 Logto 登录异常归为粗粒度失败类别——单一事实来源，同时喂埋点 `reason` 与失败后的连通性提示。
+     * 把 Logto 登录异常归为粗粒度失败类别，并生成 sign_in_failed 埋点属性——logtoType 与 cause 链
+     * 只推导一次，归因与埋点保证同源。
      *
-     * 注意：Logto SDK 构造多数 `LogtoException` 时不透传底层 `Throwable`（如授权码换 token 失败直接传
-     * `null` cause），故「超时 vs 网络」通常只能落到同一 `NETWORK` 桶，只有 cause 恰好保留时才进一步区分为 `TIMEOUT`。
+     * 归因（`reason`，同时喂连通性提示）：Logto SDK 构造多数 `LogtoException` 时不透传底层
+     * `Throwable`（如授权码换 token 失败直接传 `null` cause），故「超时 vs 网络」通常只能落到同一
+     * `NETWORK` 桶，只有 cause 恰好保留时才进一步区分为 `TIMEOUT`。
+     *
+     * 埋点属性（用于登录漏斗排障）：`reason` 粗粒度类别做漏斗看板；`logto_type` 为 Logto 原始异常
+     * 类型名（`LogtoException.message` 即 `Type.name()`），保留细粒度；`cause` 底层异常类名，尽力而为。
      */
-    private fun classifySignInFailure(exception: LogtoException): SignInFailureReason {
+    private fun analyzeSignInFailure(exception: LogtoException): Pair<SignInFailureReason, Map<String, Any>> {
         val logtoType = exception.message ?: LogtoException::class.java.simpleName
         val causeChain = generateSequence(exception.cause) { it.cause }.toList()
-        return when {
+        val reason = when {
             logtoType == LogtoException.Type.USER_CANCELED.name -> SignInFailureReason.USER_CANCELED
             causeChain.any { it is SocketTimeoutException } -> SignInFailureReason.TIMEOUT
             causeChain.any { it is UnknownHostException || it is ConnectException || it is IOException } -> SignInFailureReason.NETWORK
@@ -92,22 +90,12 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
             logtoType in CONFIG_LOGTO_TYPES -> SignInFailureReason.CONFIG
             else -> SignInFailureReason.OTHER
         }
-    }
-
-    /**
-     * 登录失败埋点属性，用于登录漏斗排障：
-     * - `reason`：粗粒度失败类别（见 [classifySignInFailure]），做漏斗看板；
-     * - `logto_type`：Logto 原始异常类型名（`LogtoException.message` 即 `Type.name()`），保留细粒度；
-     * - `cause`：底层异常类名，尽力而为。
-     */
-    private fun signInFailureProps(exception: LogtoException, reason: SignInFailureReason): Map<String, Any> {
-        val logtoType = exception.message ?: LogtoException::class.java.simpleName
-        val rootCause = generateSequence(exception.cause) { it.cause }.lastOrNull()
-        return buildMap {
+        val props = buildMap<String, Any> {
             put("reason", reason.name.lowercase())
             put("logto_type", logtoType)
-            rootCause?.let { put("cause", it::class.java.simpleName) }
+            causeChain.lastOrNull()?.let { put("cause", it::class.java.simpleName) }
         }
+        return reason to props
     }
 
     override fun signOut() {
@@ -121,6 +109,7 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
             logtoClient.clearCredentials { /* 本地凭证已清除即视为登出 */ }
         }
         globalSettingsManager.setUserAvatarUrl(null)
+        globalSettingsManager.setGithubIdentity(null, null)
         globalSettingsManager.setIsPro(false)
         globalSettingsManager.clearSelectedChatModel()
         GithubTokenProvider.shared.clear()

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.util.Locale
+import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.chat.ChatContext
 import whl.trending.ai.data.local.AppLanguage
@@ -94,6 +95,8 @@ class ChatApi(
 
     override suspend fun send(history: List<ChatMessage>, context: ChatContext?): String {
         try {
+            // 发送时的登录自认知：与 429 的 tier=anonymous 对照可识别「token 缺失/被拒被静默降级」
+            val sentAsLoggedIn = globalAuthManager.authState.value is AuthState.LoggedIn
             val response: HttpResponse = client.post("$baseUrl/chat") {
                 header("X-Install-Id", globalSettingsManager.getOrCreateInstallId())
                 // 已登录则带 token 走登录档配额（每日 10 条）；token 无效时服务端静默降级匿名档
@@ -126,7 +129,10 @@ class ChatApi(
             val parsed = raw?.let { runCatching { json.decodeFromString<ErrorResponse>(it) }.getOrNull() }
             val bodyError = parsed?.error ?: raw
             throw ChatException(
-                ChatErrors.forStatus(response.status.value, parsed?.code, bodyError, parsed?.tier),
+                ChatErrors.markAuthDegraded(
+                    ChatErrors.forStatus(response.status.value, parsed?.code, bodyError, parsed?.tier),
+                    sentAsLoggedIn,
+                ),
             )
         } catch (e: ChatException) {
             logFailure(e.error)

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatErrors.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatErrors.kt
@@ -30,6 +30,18 @@ object ChatErrors {
         return ChatError(category, code = code, httpStatus = status, detail = bodyError, tier = tier)
     }
 
+    /**
+     * 已登录却拿到匿名档的 429 → 标记 [ChatError.authDegraded]：token 缺失（刷新失败）或被服务端
+     * 拒绝后静默降级，重发大概率还是匿名档。仅在「发请求时自认已登录 && 响应 tier=anonymous」时标记；
+     * 匿名触顶后才登录的正常路径（发请求时未登录）不受影响。
+     */
+    fun markAuthDegraded(error: ChatError, sentAsLoggedIn: Boolean): ChatError =
+        if (sentAsLoggedIn && error.tier == ChatError.TIER_ANONYMOUS) {
+            error.copy(authDegraded = true)
+        } else {
+            error
+        }
+
     /** 传输/未知异常 → 分类。SocketTimeout 先于 IOException 判断（前者是后者子类）。 */
     fun forThrowable(t: Throwable): ChatError {
         val category = when (t) {

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatError.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatError.kt
@@ -21,6 +21,8 @@ enum class ChatErrorCategory(val retryable: Boolean) {
  * @param httpStatus 有 HTTP 响应时的状态码
  * @param detail 服务端 error 文案或异常摘要，仅用于日志/调试，不直接展示给用户
  * @param tier 429 触顶时的配额档位（`anonymous`/`user`），驱动触顶卡片形态（登录 CTA vs waitlist CTA）
+ * @param authDegraded 发请求时 app 自认已登录、服务端却按匿名档处理（token 缺失或被拒后静默降级）。
+ *   驱动触顶卡片给「登录态未生效」的如实提示，而非「登录后已解锁、重发即可」的误导循环。
  */
 data class ChatError(
     val category: ChatErrorCategory,
@@ -28,6 +30,7 @@ data class ChatError(
     val httpStatus: Int? = null,
     val detail: String? = null,
     val tier: String? = null,
+    val authDegraded: Boolean = false,
 ) {
     companion object {
         /** 服务端 429 响应 tier 字段的取值，与 Worker 端 chat.js 保持一致 */

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
@@ -90,8 +90,14 @@ internal fun QuotaLimitCard(
                 QuotaText(R.string.chat_pro_activation_hint)
             }
             authState == AuthState.LoggedIn -> {
-                // 匿名触顶后完成了登录：配额键已切换，重发即可继续
-                QuotaText(R.string.chat_quota_unlocked)
+                if (error.authDegraded) {
+                    // 发请求时就自认已登录、却被按匿名档处理（token 刷新失败/被拒）：
+                    // 如实提示登录态未生效，不给「已解锁、重发即可」的死循环误导
+                    QuotaText(R.string.chat_quota_auth_degraded)
+                } else {
+                    // 匿名触顶后完成了登录：配额键已切换，重发即可继续
+                    QuotaText(R.string.chat_quota_unlocked)
+                }
                 TextButton(onClick = onRetry) {
                     Text(stringResource(R.string.chat_retry))
                 }
@@ -190,6 +196,10 @@ private fun WaitlistDialog(onDismiss: () -> Unit) {
                         isSubmitting = false
                         if (result.isSuccess) {
                             trackEvent("chat_quota_waitlist_submitted")
+                            // 顺带开通了 newsletter：同步本地订阅态，订阅页才能识别已订阅、给出退订入口
+                            if (wantsNewsletter) {
+                                globalSettingsManager.setSubscribedEmail(email.trim())
+                            }
                             Toast.makeText(context, successText, Toast.LENGTH_SHORT).show()
                             onDismiss()
                         } else {

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -29,6 +29,7 @@
     <string name="chat_pro_activation_hint">赞助后 Pro 通常几分钟内自动生效；如未解锁，我们会人工核对，可能稍有延迟——稍后回来重试即可。</string>
     <string name="chat_model_pro_locked">%1$s 需要 Pro，$2/月解锁。</string>
     <string name="chat_quota_unlocked">已解锁每日 10 条，重新发送即可继续。</string>
+    <string name="chat_quota_auth_degraded">登录状态未生效，本次请求被按未登录处理——请检查网络后重试，必要时退出后重新登录。</string>
     <string name="chat_waitlist_title">上线时通知我</string>
     <string name="chat_waitlist_message">留下邮箱，更高额度的版本上线时第一时间通知你。</string>
     <string name="chat_waitlist_newsletter_optin">同时订阅每日精选邮件（可随时退订）</string>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="chat_pro_activation_hint">After sponsoring, Pro usually activates within minutes. If not, we verify manually — just try again shortly.</string>
     <string name="chat_model_pro_locked">%1$s needs Pro. Unlock for $2/mo.</string>
     <string name="chat_quota_unlocked">Unlocked 10 chats a day — resend to continue.</string>
+    <string name="chat_quota_auth_degraded">Signed in, but this request was treated as signed out — check your network and retry, or sign out and sign in again.</string>
     <string name="chat_waitlist_title">Notify me at launch</string>
     <string name="chat_waitlist_message">Leave your email and we\'ll notify you when higher quotas launch.</string>
     <string name="chat_waitlist_newsletter_optin">Also subscribe to the daily picks newsletter (unsubscribe anytime)</string>

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatErrorsTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatErrorsTest.kt
@@ -87,6 +87,24 @@ class ChatErrorsTest {
     }
 
     @Test
+    fun logged_in_but_anonymous_tier_is_marked_auth_degraded() {
+        val e = ChatErrors.forStatus(429, "quota_device", null, tier = "anonymous")
+        assertTrue(ChatErrors.markAuthDegraded(e, sentAsLoggedIn = true).authDegraded)
+    }
+
+    @Test
+    fun anonymous_tier_sent_while_logged_out_is_not_auth_degraded() {
+        val e = ChatErrors.forStatus(429, "quota_device", null, tier = "anonymous")
+        assertFalse(ChatErrors.markAuthDegraded(e, sentAsLoggedIn = false).authDegraded)
+    }
+
+    @Test
+    fun user_tier_quota_is_never_auth_degraded() {
+        val e = ChatErrors.forStatus(429, "quota_device", null, tier = "user")
+        assertFalse(ChatErrors.markAuthDegraded(e, sentAsLoggedIn = true).authDegraded)
+    }
+
+    @Test
     fun quota_and_bad_request_are_not_retryable() {
         assertFalse(ChatErrorCategory.QUOTA.retryable)
         assertFalse(ChatErrorCategory.BAD_REQUEST.retryable)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/auth/AuthManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/auth/AuthManager.kt
@@ -1,9 +1,10 @@
 package whl.trending.ai.auth
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.asSharedFlow
 
 sealed interface AuthState {
     data object LoggedOut : AuthState
@@ -20,18 +21,35 @@ enum class SignInFailureReason {
 }
 
 /**
+ * 进程级登录失败事件总线：每次失败 emit 一个归因，供 UI 弹连通性提示。
+ * 用一次性事件而非 authState，是因为「失败」与「未登录」的稳态都是 LoggedOut，无法区分。
+ *
+ * 不挂在 [AuthManager] 实例字段上：配置变更（旋转/深色切换）会重建 Activity 并替换
+ * [globalAuthManager] 实例，而 OAuth 回调可能仍落在旧实例——实例级流上的事件必然丢失。
+ * replay=1 让「先失败、后组合」的收集者也能拿到最近一次；收集侧处理后调 [consume]
+ * 清掉重放缓存，避免之后重建的收集者把旧失败再弹一遍。
+ */
+object SignInFailureBus {
+    private val _events = MutableSharedFlow<SignInFailureReason>(replay = 1, extraBufferCapacity = 1)
+    val events: Flow<SignInFailureReason> = _events.asSharedFlow()
+
+    fun emit(reason: SignInFailureReason) {
+        _events.tryEmit(reason)
+    }
+
+    fun consume() {
+        _events.resetReplayCache()
+    }
+}
+
+/**
  * 登录态抽象：shared/UI 只依赖本接口，Logto SDK 只存在于 androidApp。
  * iOS 未接入前使用 NoopAuthManager（isSupported=false，UI 隐藏登录入口）。
+ * 登录失败事件不经本接口，统一走 [SignInFailureBus]。
  */
 interface AuthManager {
     val isSupported: Boolean
     val authState: StateFlow<AuthState>
-
-    /**
-     * 登录失败的一次性事件流：每次失败 emit 一个归因，供 UI 弹连通性提示。
-     * 用一次性事件而非 authState，是因为「失败」与「未登录」的稳态都是 LoggedOut，无法区分。
-     */
-    val signInFailures: Flow<SignInFailureReason>
 
     fun signIn()
     fun signOut()
@@ -41,7 +59,6 @@ interface AuthManager {
 object NoopAuthManager : AuthManager {
     override val isSupported: Boolean = false
     override val authState: StateFlow<AuthState> = MutableStateFlow(AuthState.LoggedOut)
-    override val signInFailures: Flow<SignInFailureReason> = emptyFlow()
     override fun signIn() {}
     override fun signOut() {}
     override suspend fun getAccessToken(): String? = null

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -43,6 +43,8 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val SUBSCRIBED_EMAIL_KEY = "prefs_subscribed_email"
     private val INSTALL_ID_KEY = "prefs_install_id"
     private val USER_AVATAR_KEY = "prefs_user_avatar_url"
+    private val USER_GITHUB_LOGIN_KEY = "prefs_user_github_login"
+    private val USER_GITHUB_USER_ID_KEY = "prefs_user_github_user_id"
     private val FEED_HIGHLIGHTS_ONLY_KEY = "prefs_feed_filter_highlights"
     private val IS_PRO_KEY = "prefs_is_pro"
     private val SPONSOR_PAGE_OPENED_AT_KEY = "prefs_sponsor_page_opened_at"
@@ -146,6 +148,27 @@ class SettingsManager(private val settings: ObservableSettings) {
             settings.remove(USER_AVATAR_KEY)
         } else {
             settings.putString(USER_AVATAR_KEY, url)
+        }
+    }
+
+    /**
+     * 已登录用户 GitHub 身份缓存（login + 数字 id）：syncMe 时随头像一起写入，登出清除。
+     * 供需要带身份的同步场景（如语言意图采集的反馈正文）直接读取，免去现场再拉一次 /api/me。
+     */
+    fun getGithubLoginSync(): String? = settings.getStringOrNull(USER_GITHUB_LOGIN_KEY)
+
+    fun getGithubUserIdSync(): Long? = settings.getLongOrNull(USER_GITHUB_USER_ID_KEY)
+
+    fun setGithubIdentity(login: String?, userId: Long?) {
+        if (login.isNullOrBlank()) {
+            settings.remove(USER_GITHUB_LOGIN_KEY)
+        } else {
+            settings.putString(USER_GITHUB_LOGIN_KEY, login)
+        }
+        if (userId == null) {
+            settings.remove(USER_GITHUB_USER_ID_KEY)
+        } else {
+            settings.putLong(USER_GITHUB_USER_ID_KEY, userId)
         }
     }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
@@ -23,6 +23,7 @@ open class UserRepository(private val api: TrendingApi = TrendingApi()) {
         return try {
             val me = fetchMeResponse(accessToken)
             globalSettingsManager.setUserAvatarUrl(me.user.avatarUrl)
+            globalSettingsManager.setGithubIdentity(me.user.githubLogin, me.user.githubUserId)
             globalSettingsManager.setIsPro(me.pro)
             me.user
         } catch (e: Exception) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SignInHintHost.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SignInHintHost.kt
@@ -14,11 +14,11 @@ import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.sign_in_hint_connectivity
 import trendingai.shared.generated.resources.sign_in_hint_dismiss
 import trendingai.shared.generated.resources.sign_in_hint_title
+import whl.trending.ai.auth.SignInFailureBus
 import whl.trending.ai.auth.SignInFailureReason
-import whl.trending.ai.auth.globalAuthManager
 
 /**
- * 全局登录失败提示宿主：收集 [globalAuthManager] 的失败事件，命中「连通性类」失败时弹一个轻量弹窗
+ * 全局登录失败提示宿主：收集 [SignInFailureBus] 的失败事件，命中「连通性类」失败时弹一个轻量弹窗
  * 引导用户检查网络。
  *
  * 用弹窗（独立窗口）而非 Snackbar：① 不占/不盖 app 布局；② 登录失败值得被明确看见，Snackbar 易被错过。
@@ -30,7 +30,9 @@ fun SignInHintHost() {
     var show by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
-        globalAuthManager.signInFailures.collect { reason ->
+        SignInFailureBus.events.collect { reason ->
+            // 收到即消费：清掉 replay 缓存，避免之后重建的收集者（旋转/主题切换）把旧失败再弹一遍
+            SignInFailureBus.consume()
             if (reason.shouldHintConnectivity()) show = true
         }
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -16,7 +16,6 @@ import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.data.remote.ApiException
 import whl.trending.ai.data.repository.TrendingRepository
-import whl.trending.ai.data.repository.UserRepository
 import whl.trending.ai.ui.theme.PRESET_PALETTE
 import whl.trending.ai.ui.theme.ThemeSeed
 import whl.trending.ai.update.globalUpdateChecker
@@ -189,7 +188,6 @@ fun SettingsScreen(
     var langError by remember { mutableStateOf<String?>(null) }
     val langScope = rememberCoroutineScope()
     val feedbackRepository = remember { TrendingRepository() }
-    val userRepository = remember { UserRepository() }
     val emailRegex = remember { Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$") }
     val langErrGeneric = stringResource(Res.string.feedback_error)
     val langErrRate = stringResource(Res.string.feedback_rate_limit)
@@ -293,12 +291,14 @@ fun SettingsScreen(
                         langSubmitting = true
                         langError = null
                         langScope.launch {
+                            // 身份直接读 syncMe 落好的本地缓存：免一次串行 /api/me 往返；id 可能缺失（后端
+                            // 兜底 username 建档时无数字 id），缺就只带 login，别写出「id null」污染赞助匹配
                             val identityLine = if (isLoggedIn) {
-                                val me = globalAuthManager.getAccessToken()?.let { token ->
-                                    runCatching { userRepository.fetchMeResponse(token).user }.getOrNull()
-                                }
+                                val login = globalSettingsManager.getGithubLoginSync()
+                                val userId = globalSettingsManager.getGithubUserIdSync()
                                 when {
-                                    me?.githubLogin != null -> "GitHub：@${me.githubLogin}（id ${me.githubUserId}）"
+                                    login != null && userId != null -> "GitHub：@${login}（id ${userId}）"
+                                    login != null -> "GitHub：@${login}"
                                     else -> "GitHub：已登录（未取到身份）"
                                 }
                             } else null

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
@@ -5,10 +5,8 @@ import com.russhwolf.settings.ObservableSettings
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -27,7 +25,6 @@ import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.FollowingProvider
 import whl.trending.ai.auth.GithubTokenProvider
 import whl.trending.ai.auth.OwnRepoEventsProvider
-import whl.trending.ai.auth.SignInFailureReason
 import whl.trending.ai.data.local.FakeCacheFileStore
 import whl.trending.ai.data.local.LastDataCache
 import whl.trending.ai.data.local.SettingsManager
@@ -45,7 +42,6 @@ class ProfileViewModelTest {
         val state = MutableStateFlow<AuthState>(AuthState.LoggedIn)
         override val isSupported: Boolean = true
         override val authState: StateFlow<AuthState> = state
-        override val signInFailures: Flow<SignInFailureReason> = emptyFlow()
         override fun signIn() {}
         override fun signOut() {}
         override suspend fun getAccessToken(): String? = "token"


### PR DESCRIPTION
## 背景

发布前 review 遗留的 P1 正确性问题（PR #46 修了前两条，本 PR 修剩余四条），外加两条同文件顺手的清理（重复推导合并、身份缓存支撑）。

## 修复内容

### 1. 配额卡「已解锁请重发」死循环（chat）
token 刷新失败/被拒时，服务端 chat.js 把请求**静默降级匿名档**（不返回 401），429 带 `tier=anonymous`；此时客户端 authState 仍是 LoggedIn，配额卡误判为「匿名触顶后完成登录」，提示重发——但重发永远带不上 token，无限循环。

修法：ChatApi 发送时记录登录自认知（`sentAsLoggedIn`），与响应 tier 对照，`ChatErrors.markAuthDegraded` 标记 `ChatError.authDegraded`；卡片对降级态如实提示「登录状态未生效，请检查网络或重新登录」（中英双语新文案）。匿名触顶后才登录的正常重发路径不受影响。纯函数逻辑补了 3 个单测。

### 2. 登录失败提示丢事件（auth）
原实例级 `MutableSharedFlow(extraBufferCapacity=1)` 两处丢事件：replay=0 时无收集者的 tryEmit 直接丢弃（代码注释宣称的「晚到收集者可拿到」是错误的 SharedFlow 语义）；且旋转/深色切换重建 MainActivity 会替换 LogtoAuthManager 实例，OAuth 回调落在旧实例的流上必然丢失——连通性提示恰在目标场景失效。

修法：改进程级 `SignInFailureBus`（replay=1），SignInHintHost 消费后清 replay 缓存防重弹；`signInFailures` 从 AuthManager 接口移除（NoopAuthManager / 测试 Fake 同步简化）。顺带合并 `classifySignInFailure` 与 `signInFailureProps` 的重复推导为 `analyzeSignInFailure`，归因与埋点同源。

### 3. 反馈记录写出「id null」（settings）
语言意图采集的身份行只判了 `githubLogin != null` 就插值可空的 `githubUserId`，而后端以 github_user_id 为授权主键，含「id null」的记录无法匹配赞助者。

修法：syncMe 时把 GitHub 身份（login + 数字 id）随头像一起持久化进 SettingsManager，登出清除；身份行改读本地缓存，id 缺失时只带 login。顺带消掉了提交前串行的一次 /api/me 网络往返（原清理项 16）。

### 4. waitlist 顺带订阅不落地（chat）
勾选「同时订阅每日精选」提交成功后未写 `setSubscribedEmail`，订阅页仍显示未订阅表单、无退订入口。修法：成功回调补写本地订阅态。

## 验证

- `:androidApp:assembleDebug` 编译通过
- `:androidLibrary:chat:testDebugUnitTest`（含 3 个新增 markAuthDegraded 用例）+ `:shared:testAndroidHostTest` 全绿
- `:shared:compileKotlinIosSimulatorArm64` 通过（shared 公共代码有改动）
- 全仓无 `signInFailures` 残留引用

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

修复付费使用漏斗中与登录降级处理、登录失败通知、身份缓存以及候补名单订阅相关的多处正确性问题。

Bug Fixes:
- 当请求以「已登录」身份发送但收到匿名层级的 429 响应时，将聊天配额错误标记为 auth-degraded，并为该状态展示清晰且不会循环的配额提示消息。
- 通过用进程级的 SignInFailureBus 替换实例级的失败流程并更新各个使用方，确保登录连接性提示能够被可靠地投递。
- 通过在 Settings 中缓存 GitHub 身份（login 和数字 id），并在组合反馈身份信息行时使用该缓存，防止反馈记录写入 “id null”。
- 当用户通过聊天候补名单对话框选择订阅邮件更新时，持久化新闻邮件订阅状态，以便订阅 UI 能正确反映当前状态。

Enhancements:
- 将登录失败分类和分析数据（analytics payload）构建统一到一个 analyzeSignInFailure 助手中，以保持归因和追踪的一致性。
- 在 SettingsManager 中添加 GitHub 身份缓存管理，并在注销时清除，以便在依赖身份的流程中复用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix multiple correctness issues in the paid usage funnel around login degradation handling, sign-in failure notifications, identity caching, and waitlist subscriptions.

Bug Fixes:
- Mark chat quota errors as auth-degraded when a request is sent as logged-in but receives anonymous-tier 429 responses, and surface a clear non-looping quota message for this state.
- Ensure sign-in connectivity hints are reliably delivered by replacing instance-scoped failure flows with a process-wide SignInFailureBus and updating consumers.
- Prevent feedback records from writing "id null" by caching GitHub identity (login and numeric id) in Settings and using it when composing feedback identity lines.
- Persist newsletter subscription state when users opt into email updates via the chat waitlist dialog so the subscription UI reflects the correct status.

Enhancements:
- Unify sign-in failure classification and analytics payload construction into a single analyzeSignInFailure helper to keep attribution and tracking consistent.
- Add cached GitHub identity management to SettingsManager and clear it on sign-out for reuse across identity-dependent flows.

</details>