### PR TITLE
fix: 外链与模型目录加固 —— APK 直链外开 / scheme 大小写 / 目录解码容错 / 生效模型判定下沉

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -25,6 +25,8 @@ import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.chat.ChatContext
 import whl.trending.ai.data.local.AppLanguage
 import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.model.resolveEffectiveChatModel
+import whl.trending.ai.data.repository.ChatModelsProvider
 import whl.trending.chat.model.ChatError
 import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.Role
@@ -114,8 +116,13 @@ class ChatApi(
                         context = context?.let {
                             WireContext(it.title, it.summary, it.sourceUrl)
                         },
-                        // 透传所选模型；服务端仍按 tier 强制（免费越权自动回默认）
-                        model = globalSettingsManager.getSelectedChatModelSync(),
+                        // 发送前按目录缓存解析实际生效模型（与选择器同一套判定），避免选择器未挂载时
+                        // 把过期的 Pro 专属选择原样发出；目录未拉到则透传，服务端仍按 tier 强制兜底
+                        model = resolveEffectiveChatModel(
+                            ChatModelsProvider.cachedOrEmpty(),
+                            globalSettingsManager.getSelectedChatModelSync(),
+                            globalSettingsManager.getIsProSync(),
+                        ),
                     ),
                 )
             }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -26,7 +26,7 @@ import whl.trending.ai.core.ProSponsor
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.ChatModelOption
-import whl.trending.ai.data.model.DEFAULT_CHAT_MODEL
+import whl.trending.ai.data.model.resolveEffectiveChatModel
 import whl.trending.chat.R
 
 /**
@@ -49,11 +49,12 @@ internal fun ModelPicker(
     var expanded by remember { mutableStateOf(false) }
 
     // 自愈守卫：若持久化的选择对本用户已锁定（Pro 过期未登出、或上个 Pro 用户遗留），
-    // 复位到默认免费模型。一处同时修好「chip 显示」与「ChatApi 透传」的一致性。
+    // 复位到默认免费模型。判定与 ChatApi 发送共用 resolveEffectiveChatModel——
+    // 即使本组件未挂载，发送侧也会按同一规则兜底。
     LaunchedEffect(models, isPro) {
-        val sel = models.firstOrNull { it.id == selectedId }
-        if (models.isNotEmpty() && (sel == null || (sel.proOnly && !isPro))) {
-            globalSettingsManager.setSelectedChatModel(DEFAULT_CHAT_MODEL)
+        val effective = resolveEffectiveChatModel(models, selectedId, isPro)
+        if (effective != selectedId) {
+            globalSettingsManager.setSelectedChatModel(effective)
         }
     }
 

--- a/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateDialog.kt
+++ b/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateDialog.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import whl.trending.ai.core.Constants
+import whl.trending.ai.core.platform.openDownloadUrl
 import whl.trending.ai.core.platform.openUrl
 
 @Composable
@@ -21,7 +22,8 @@ fun UpdateDialog(updateInfo: UpdateInfo, downloadUrl: String, onDismiss: () -> U
         },
         confirmButton = {
             TextButton(onClick = {
-                openUrl(downloadUrl)
+                // APK 直链走系统浏览器接管下载，不进 Custom Tab（见 openDownloadUrl）
+                openDownloadUrl(downloadUrl)
                 onDismiss()
             }) {
                 Text(stringResource(R.string.update_dialog_download))

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
@@ -47,6 +47,9 @@ fun openUrl(url: String, onInAppFallback: ((url: String) -> Unit)? = null) {
 /**
  * 文件直链下载统一出口（如 APK）：跳过 Custom Tab / 应用内 WebView，直接交系统浏览器接管下载。
  * 直链文件在 Custom Tab 里体验糟糕——Chrome 下载后留一个空白页挂在前台，其他 provider 行为不定。
+ *
+ * 约定仅用于 http(s) 直链；非 web scheme 请走 [openUrl]（两者对非 web 最终都是同一条
+ * [openInSystemBrowser] 路径，行为一致，此约定只为语义清晰）。
  */
 fun openDownloadUrl(url: String) {
     openInSystemBrowser(url)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
@@ -31,7 +31,9 @@ expect fun openInCustomTab(url: String): Boolean
  * @param onInAppFallback 应用内 WebView 兜底。组合树外（如更新弹窗）拿不到导航栈时传 null，退化为系统浏览器。
  */
 fun openUrl(url: String, onInAppFallback: ((url: String) -> Unit)? = null) {
-    val isWeb = url.startsWith("http://") || url.startsWith("https://")
+    // ignoreCase：scheme 大小写不敏感（RFC 3986）。大写 scheme 若被判非 web，会绕过
+    // Custom Tab 与 WebView 兜底直落 ACTION_VIEW，而 intent filter 按小写匹配 → 点击静默无响应
+    val isWeb = url.startsWith("http://", ignoreCase = true) || url.startsWith("https://", ignoreCase = true)
     if (isWeb && globalSettingsManager.getOpenLinksInCustomTabSync() && openInCustomTab(url)) {
         return
     }
@@ -39,6 +41,14 @@ fun openUrl(url: String, onInAppFallback: ((url: String) -> Unit)? = null) {
         onInAppFallback(url)
         return
     }
+    openInSystemBrowser(url)
+}
+
+/**
+ * 文件直链下载统一出口（如 APK）：跳过 Custom Tab / 应用内 WebView，直接交系统浏览器接管下载。
+ * 直链文件在 Custom Tab 里体验糟糕——Chrome 下载后留一个空白页挂在前台，其他 provider 行为不定。
+ */
+fun openDownloadUrl(url: String) {
     openInSystemBrowser(url)
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/ChatModelOption.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/ChatModelOption.kt
@@ -17,10 +17,16 @@ const val DEFAULT_CHAT_MODEL = "gpt-5.4"
 data class ChatModelOption(
     val id: String,
     val name: String = id,
-    val minTier: String = "user",
+    val minTier: String = TIER_USER,
 ) {
     /** 是否 Pro 专属（免费用户看到但锁定） */
-    val proOnly: Boolean get() = minTier == "pro"
+    val proOnly: Boolean get() = minTier == TIER_PRO
+
+    companion object {
+        /** minTier 的取值词汇，与后端 models.js 契约对齐；集中定义避免逻辑与测试各写各的字面量。 */
+        const val TIER_USER = "user"
+        const val TIER_PRO = "pro"
+    }
 }
 
 @Serializable

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/ChatModelOption.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/ChatModelOption.kt
@@ -8,13 +8,16 @@ const val DEFAULT_CHAT_MODEL = "gpt-5.4"
 /**
  * 一个可选聊天模型（来自 `GET /api/chat/models`，后端从 OpenAI 动态取）。
  *
+ * `name`/`minTier` 带缺省容错：目录由后端动态拼装，单条缺字段不该让整个目录解码失败、
+ * 选择器整个消失（服务端仍按 tier 强制，缺省按免费展示最多被静默降级，不越权）。
+ *
  * @param minTier 使用该模型所需的最低档位：`"user"`=免费可用；`"pro"`=需 Pro 解锁。
  */
 @Serializable
 data class ChatModelOption(
     val id: String,
-    val name: String,
-    val minTier: String,
+    val name: String = id,
+    val minTier: String = "user",
 ) {
     /** 是否 Pro 专属（免费用户看到但锁定） */
     val proOnly: Boolean get() = minTier == "pro"
@@ -22,3 +25,15 @@ data class ChatModelOption(
 
 @Serializable
 data class ChatModelsResponse(val models: List<ChatModelOption> = emptyList())
+
+/**
+ * 计算实际生效的模型 id：持久化的选择对当前用户不可用（Pro 专属但非 Pro、或已不在目录中）时
+ * 回落 [DEFAULT_CHAT_MODEL]；目录为空（尚未拉到）时原样透传，交服务端按 tier 强制。
+ *
+ * 选择器的自愈与 ChatApi 的发送共用本函数——「界面显示的」与「请求发出的」始终同一套判定。
+ */
+fun resolveEffectiveChatModel(models: List<ChatModelOption>, selectedId: String, isPro: Boolean): String {
+    if (models.isEmpty()) return selectedId
+    val sel = models.firstOrNull { it.id == selectedId }
+    return if (sel == null || (sel.proOnly && !isPro)) DEFAULT_CHAT_MODEL else selectedId
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/ChatModelsProvider.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/ChatModelsProvider.kt
@@ -36,6 +36,9 @@ object ChatModelsProvider {
         }
     }
 
+    /** 已缓存的目录（无网络副作用）；尚未拉到时为空列表。发送热路径用它，避免冷拉阻塞聊天请求。 */
+    fun cachedOrEmpty(): List<ChatModelOption> = cache ?: emptyList()
+
     /** 应用启动时预热（fire-and-forget），避免首个 chat 等冷拉取。 */
     fun warmUp(scope: CoroutineScope) {
         scope.launch { runCatching { get() } }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/model/ChatModelOptionTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/model/ChatModelOptionTest.kt
@@ -1,0 +1,47 @@
+package whl.trending.ai.data.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+
+/** 模型目录的解码容错与 [resolveEffectiveChatModel] 生效判定单测。 */
+class ChatModelOptionTest {
+
+    private val free = ChatModelOption(id = "gpt-5.4", name = "GPT-5.4", minTier = "user")
+    private val pro = ChatModelOption(id = "gpt-6", name = "GPT-6", minTier = "pro")
+    private val catalog = listOf(free, pro)
+
+    @Test
+    fun entry_missing_name_and_minTier_decodes_with_defaults() {
+        val parsed = Json.decodeFromString<ChatModelsResponse>("""{"models":[{"id":"m1"}]}""")
+        val model = parsed.models.single()
+        assertEquals("m1", model.name)
+        assertEquals("user", model.minTier)
+        assertEquals(false, model.proOnly)
+    }
+
+    @Test
+    fun free_selection_passes_through() {
+        assertEquals("gpt-5.4", resolveEffectiveChatModel(catalog, "gpt-5.4", isPro = false))
+    }
+
+    @Test
+    fun pro_selection_kept_for_pro_user() {
+        assertEquals("gpt-6", resolveEffectiveChatModel(catalog, "gpt-6", isPro = true))
+    }
+
+    @Test
+    fun stale_pro_selection_falls_back_to_default_for_free_user() {
+        assertEquals(DEFAULT_CHAT_MODEL, resolveEffectiveChatModel(catalog, "gpt-6", isPro = false))
+    }
+
+    @Test
+    fun selection_absent_from_catalog_falls_back_to_default() {
+        assertEquals(DEFAULT_CHAT_MODEL, resolveEffectiveChatModel(catalog, "removed-model", isPro = true))
+    }
+
+    @Test
+    fun empty_catalog_passes_selection_through_unchanged() {
+        assertEquals("gpt-6", resolveEffectiveChatModel(emptyList(), "gpt-6", isPro = false))
+    }
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/model/ChatModelOptionTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/model/ChatModelOptionTest.kt
@@ -7,8 +7,8 @@ import kotlinx.serialization.json.Json
 /** 模型目录的解码容错与 [resolveEffectiveChatModel] 生效判定单测。 */
 class ChatModelOptionTest {
 
-    private val free = ChatModelOption(id = "gpt-5.4", name = "GPT-5.4", minTier = "user")
-    private val pro = ChatModelOption(id = "gpt-6", name = "GPT-6", minTier = "pro")
+    private val free = ChatModelOption(id = "gpt-5.4", name = "GPT-5.4", minTier = ChatModelOption.TIER_USER)
+    private val pro = ChatModelOption(id = "gpt-6", name = "GPT-6", minTier = ChatModelOption.TIER_PRO)
     private val catalog = listOf(free, pro)
 
     @Test
@@ -16,7 +16,7 @@ class ChatModelOptionTest {
         val parsed = Json.decodeFromString<ChatModelsResponse>("""{"models":[{"id":"m1"}]}""")
         val model = parsed.models.single()
         assertEquals("m1", model.name)
-        assertEquals("user", model.minTier)
+        assertEquals(ChatModelOption.TIER_USER, model.minTier)
         assertEquals(false, model.proOnly)
     }
 


### PR DESCRIPTION
## 背景

发布前 review 遗留的 P2 加固项（四条），性质一致：当前线上数据不会触发，但依赖的隐式契约一旦变化就会以难排查的方式坏掉。

## 改动

### 1. APK 直链下载改走系统浏览器（ openDownloadUrl ）
open-url 收口 Custom Tab 后，UpdateDialog 的 .apk 直链被默认带进 Custom Tab：Chrome 下载后留空白页挂前台，非 Chrome provider 行为不定。新增 `openDownloadUrl` 出口（直接 `openInSystemBrowser`），更新弹窗的下载按钮改用它；查看更新日志仍走常规 `openUrl`。

### 2. openUrl 的 http/https 判定加 ignoreCase
大写 scheme（RFC 3986 允许）原先被判非 web，绕过 Custom Tab 与 WebView 兜底直落 ACTION_VIEW，而 intent filter 按小写匹配 → 点击静默无响应（0.18.0 之前会落 WebView 被正常化）。

### 3. ChatModelOption 解码容错
`name`/`minTier` 无默认值时，后端动态拼装的目录只要单条缺字段，整个目录 MissingFieldException → ChatModelsProvider 返回空列表 → 模型选择器静默消失且无报错。加缺省（`name = id`、`minTier = "user"`）；缺省按免费展示最多被服务端静默降级，不会越权。

### 4. 生效模型判定下沉 resolveEffectiveChatModel
原自愈逻辑只活在 ModelPicker 的 LaunchedEffect 里（且被 `models.size <= 1` 早返回挡着）：目录拉取失败或选择器未挂载时，ChatApi 仍把过期的 Pro 专属选择原样发出，UI 与实际请求脱节。抽成纯函数后选择器自愈与 ChatApi 发送共用同一判定；ChatModelsProvider 新增无副作用的 `cachedOrEmpty()`，发送热路径不做冷拉取。

## 验证

- `:androidApp:assembleDebug` / `:shared:compileKotlinIosSimulatorArm64` 编译通过
- chat / updater / shared 单测全绿，新增 6 个用例（解码缺省 + 判定矩阵）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

加强外部链接处理和聊天模型选择逻辑，以避免在底层约定发生变化时出现静默失败。

Bug 修复：
- 为聊天模型名称和最低等级添加默认值，这样即使服务器响应中字段不完整，也不会再导致整个模型目录失效或隐藏模型选择器。
- 在 URL 处理逻辑中规范 HTTP/HTTPS 协议检查为大小写不敏感，从而确保大写协议仍然能够正确通过 Custom Tabs 或应用内 WebView 打开。
- 将 APK 下载链接改为通过系统浏览器打开，而不是通过 Custom Tabs，以避免糟糕的下载体验和依赖提供商的不可预测行为。
- 确保聊天请求与 UI 共享统一的有效模型解析路径，这样当选择的是过期或仅限 Pro 的不可用模型时，会回退到默认模型，而不是被静默发送。

增强：
- 引入共享的 `resolveEffectiveChatModel` 辅助方法，供模型选择器和 `ChatApi` 共同使用，以保持展示的模型与实际发送的模型一致，包括在模型目录为空时的行为。
- 在 `ChatModelsProvider` 上暴露 `cachedOrEmpty` 访问器，使聊天发送可以查询最新的缓存模型目录，而不会触发网络请求。

测试：
- 添加单元测试，用于覆盖聊天模型解码默认值，以及在不同用户类型（免费/专业）与模型目录状态下的有效模型解析矩阵。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden external link handling and chat model selection logic to avoid silent failures when underlying contracts change.

Bug Fixes:
- Add default values for chat model name and minimum tier so partially populated server responses no longer break the entire model catalog or hide the picker.
- Normalize HTTP/HTTPS scheme checks in URL handling to be case-insensitive so uppercase schemes still route through Custom Tabs or in-app WebView correctly.
- Route APK download links through the system browser instead of Custom Tabs to avoid poor download UX and provider-dependent behavior.
- Ensure chat requests and the UI share a single effective-model resolution path so stale or ineligible Pro-only selections fall back to the default model instead of being sent silently.

Enhancements:
- Introduce a shared resolveEffectiveChatModel helper used by both the model picker and ChatApi to keep displayed and sent models consistent, including behavior when the catalog is empty.
- Expose a cachedOrEmpty accessor on ChatModelsProvider so chat sends can consult the latest cached catalog without triggering network fetches.

Tests:
- Add unit tests covering chat model decoding defaults and the effective model resolution matrix across free/pro users and catalog states.

</details>