### PR TITLE
chore: 清理与去重 —— 共享校验/实例/图标、埋点收口、死代码清除

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -74,7 +74,7 @@ class ChatViewModel(
      *  quota_device 例外放行：匿名触顶后完成登录，配额键已切换，重发即可续聊。 */
     fun retry(message: ChatMessage) {
         val error = message.error ?: return
-        if (!error.category.retryable && error.code != "quota_device") return
+        if (!error.category.retryable && error.code != ChatError.CODE_QUOTA_DEVICE) return
         _uiState.update {
             it.copy(messages = it.messages.filterNot { m -> m.id == message.id }, isSending = true)
         }
@@ -89,7 +89,7 @@ class ChatViewModel(
                 val error = (e as? ChatException)?.error
                     ?: ChatError(ChatErrorCategory.UNKNOWN, detail = e.toString())
                 // 付费意愿漏斗第一级：个人配额触顶（在 VM 记一次，避免 UI 重组重复上报）
-                if (error.code == "quota_device") {
+                if (error.code == ChatError.CODE_QUOTA_DEVICE) {
                     trackEvent("chat_quota_hit", mapOf("tier" to (error.tier ?: ChatError.TIER_ANONYMOUS)))
                 }
                 ChatMessage(nextId(), Role.ASSISTANT, "", error = error)

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatError.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatError.kt
@@ -37,5 +37,8 @@ data class ChatError(
         const val TIER_ANONYMOUS = "anonymous"
         const val TIER_USER = "user"
         const val TIER_PRO = "pro"
+
+        /** 个人配额触顶的机器码（服务端 chat.js quotaError）；重试放行与专属卡片选择都以它为判据 */
+        const val CODE_QUOTA_DEVICE = "quota_device"
     }
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
@@ -127,7 +127,7 @@ private fun AssistantMessage(message: ChatMessage, onRetry: () -> Unit, modifier
                     )
                 }
             }
-        } else if (error.code == "quota_device") {
+        } else if (error.code == ChatError.CODE_QUOTA_DEVICE) {
             // 个人配额触顶走专属卡片（登录 CTA / waitlist），全局熔断仍走普通错误文案
             QuotaLimitCard(error = error, onRetry = onRetry)
         } else {
@@ -149,7 +149,7 @@ private fun AssistantMessage(message: ChatMessage, onRetry: () -> Unit, modifier
 private fun errorMessageRes(error: ChatError): Int = when (error.code) {
     "content_too_long" -> R.string.chat_error_content_too_long
     "quota_global" -> R.string.chat_error_quota_global
-    "quota_device" -> R.string.chat_quota_exceeded
+    ChatError.CODE_QUOTA_DEVICE -> R.string.chat_quota_exceeded
     "upstream_timeout" -> R.string.chat_error_timeout
     "upstream_error" -> R.string.chat_error_server
     else -> when (error.category) {

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -72,7 +72,7 @@ internal fun ModelPicker(
                 // 语义与 chat_quota（LaunchedEffect(Unit) 每次挂载去重一次）不同——model_locked 是「每次看」，
                 // 对比 shown→clicked 漏斗时需按 source 分开看，勿直接横比。
                 if (hasLocked) {
-                    trackEvent("pro_upsell_shown", mapOf(UPSELL_SOURCE_KEY to SOURCE_MODEL_LOCKED))
+                    ProSponsor.trackUpsellShown(ProSponsor.SOURCE_MODEL_LOCKED)
                 }
             },
             label = { Text(current.name) },
@@ -98,13 +98,12 @@ internal fun ModelPicker(
                     onClick = {
                         expanded = false
                         if (locked) {
-                            trackEvent("pro_upsell_clicked", mapOf(UPSELL_SOURCE_KEY to SOURCE_MODEL_LOCKED))
                             Toast.makeText(
                                 context,
                                 context.getString(R.string.chat_model_pro_locked, model.name),
                                 Toast.LENGTH_SHORT,
                             ).show()
-                            ProSponsor.openSponsorPage()
+                            ProSponsor.openSponsorPage(ProSponsor.SOURCE_MODEL_LOCKED)
                         } else {
                             globalSettingsManager.setSelectedChatModel(model.id)
                         }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
@@ -7,9 +7,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -27,12 +30,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import java.util.Locale
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.core.ProSponsor
+import whl.trending.ai.core.isValidEmail
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.TrendingRepository
@@ -70,12 +72,11 @@ internal fun QuotaLimitCard(
             isUserTier -> {
                 // 付费漏斗第一级（曝光）：登录触顶卡带 Pro CTA 渲染。去重靠 LaunchedEffect(Unit)。
                 LaunchedEffect(Unit) {
-                    trackEvent("pro_upsell_shown", mapOf(UPSELL_SOURCE_KEY to SOURCE_CHAT_QUOTA))
+                    ProSponsor.trackUpsellShown(ProSponsor.SOURCE_CHAT_QUOTA)
                 }
                 QuotaText(R.string.chat_pro_upsell_message)
                 Button(onClick = {
-                    trackEvent("pro_upsell_clicked", mapOf(UPSELL_SOURCE_KEY to SOURCE_CHAT_QUOTA))
-                    ProSponsor.openSponsorPage()
+                    ProSponsor.openSponsorPage(ProSponsor.SOURCE_CHAT_QUOTA)
                 }) {
                     Text(stringResource(R.string.chat_pro_cta))
                 }
@@ -133,11 +134,11 @@ private fun QuotaText(resId: Int) {
 }
 
 /** Pro waitlist 登记：邮箱写入 subscribers（source=pro_waitlist），复用邮件订阅通道。 */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun WaitlistDialog(onDismiss: () -> Unit) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val repository = remember { TrendingRepository() }
     var email by remember {
         mutableStateOf(globalSettingsManager.getSubscribedEmailSync().orEmpty())
     }
@@ -183,14 +184,15 @@ private fun WaitlistDialog(onDismiss: () -> Unit) {
         },
         confirmButton = {
             TextButton(
-                enabled = !isSubmitting && EMAIL_REGEX.matches(email.trim()),
+                enabled = !isSubmitting && isValidEmail(email),
                 onClick = {
                     isSubmitting = true
                     scope.launch {
-                        val result = repository.subscribe(
+                        val result = TrendingRepository.shared.subscribe(
                             email.trim(),
                             "pro_waitlist",
-                            resolveLang(),
+                            // 与 SubscribeViewModel 同口径：同一 subscribers 表不留两种 lang 推导
+                            globalSettingsManager.currentContentLang(),
                             newsletter = wantsNewsletter,
                         )
                         isSubmitting = false
@@ -208,7 +210,11 @@ private fun WaitlistDialog(onDismiss: () -> Unit) {
                     }
                 },
             ) {
-                Text(stringResource(R.string.chat_waitlist_submit))
+                if (isSubmitting) {
+                    LoadingIndicator(modifier = Modifier.size(24.dp))
+                } else {
+                    Text(stringResource(R.string.chat_waitlist_submit))
+                }
             }
         },
         dismissButton = {
@@ -219,18 +225,3 @@ private fun WaitlistDialog(onDismiss: () -> Unit) {
     )
 }
 
-/** 付费漏斗事件维度 key：全 app 统一用 "source"（与 Picks/Feed/Trending 等 12 处对齐） */
-internal const val UPSELL_SOURCE_KEY = "source"
-
-/** 付费漏斗来源：区分「配额触顶」入口与「模型锁定」入口 */
-internal const val SOURCE_CHAT_QUOTA = "chat_quota"
-internal const val SOURCE_MODEL_LOCKED = "model_locked"
-
-// 与服务端 subscribe.js 的 isValidEmail 同构；服务端仍做完整校验，这里只挡明显无效输入
-private val EMAIL_REGEX = Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$")
-
-private suspend fun resolveLang(): String {
-    val appLang = globalSettingsManager.appLanguage.first()
-    return appLang.isoCode
-        ?: if (Locale.getDefault().language == "zh") "zh" else "en"
-}

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -22,7 +22,6 @@
     <string name="chat_quota_exceeded">今日免费额度已用完，明天自动恢复。</string>
     <string name="chat_quota_login_cta">登录解锁每日 10 条</string>
     <string name="chat_quota_waitlist_cta">想要更多额度？上线时通知我</string>
-    <string name="chat_quota_user_exceeded">今日 10 条额度已用完，明天自动恢复。</string>
     <string name="chat_pro_upsell_message">每天 10 条不够？Pro 提供更宽裕的每日额度，还能选用更强、更新的模型。</string>
     <string name="chat_quota_pro_exceeded">今天聊得有点多，稍后再来～</string>
     <string name="chat_pro_cta">解锁 Pro · $2/月</string>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -22,7 +22,6 @@
     <string name="chat_quota_exceeded">You\'ve used up today\'s free quota. It resets tomorrow.</string>
     <string name="chat_quota_login_cta">Sign in to unlock 10 chats a day</string>
     <string name="chat_quota_waitlist_cta">Want more? Get notified at launch</string>
-    <string name="chat_quota_user_exceeded">You\'ve used all 10 chats for today. It resets tomorrow.</string>
     <string name="chat_pro_upsell_message">Need more than 10 a day? Pro gives you a much more generous daily allowance, plus access to newer, more capable models.</string>
     <string name="chat_quota_pro_exceeded">You\'ve been chatting a lot today — check back a bit later.</string>
     <string name="chat_pro_cta">Unlock Pro · $2/mo</string>

--- a/docs/analytics-notes.md
+++ b/docs/analytics-notes.md
@@ -32,3 +32,18 @@ Logto SDK 会**本地缓存 OIDC discovery 配置**。这导致断网登录的�
 ### `timeout` vs `network` 的边界
 
 `timeout` 只有当异常 `cause` 链里恰好保留了 `SocketTimeoutException` 时才会命中。Logto SDK 构造多数异常时**丢弃底层 `Throwable`**（如授权码换 token 失败直接传 `null` cause），因此超时常常并入 `network` 桶。需要精确区分时看 `logto_type`。
+
+## Pro upsell 漏斗的 source 词汇统一（2026-07-07）
+
+`pro_upsell_shown` / `pro_upsell_clicked` 的 `source` 维度统一收口到 `ProSponsor`（shared/core），全部赞助入口共用同一词汇：
+
+| source | 入口 |
+|--------|------|
+| `chat_quota` | 聊天配额触顶卡的「解锁 Pro」 |
+| `model_locked` | 模型选择器点锁定项 |
+| `settings_language` | 设置 · 摘要语言弹窗的「赞助 Pro」 |
+| `settings_donate` | 设置 · 捐助弹窗的 GitHub Sponsors 渠道 |
+
+注意事项：
+- `settings_*` 两个入口自 2026-07-07 起**新增**上报 `pro_upsell_clicked`；此前只有各自的 `settings_summary_language_sponsor` / `settings_donate_github` 事件（两者保留未动，看板续用不受影响）。跨该日期对比 clicked 总量时需注意口径变化。
+- 曝光语义各入口不同：`chat_quota` 按卡片挂载去重一次，`model_locked` 是每次展开下拉都算（类广告 impression），settings 入口无 shown 事件。对比 shown→clicked 转化率须按 source 分开看。

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/ProSponsor.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/ProSponsor.kt
@@ -3,6 +3,7 @@ package whl.trending.ai.core
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import whl.trending.ai.core.platform.openUrl
+import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
 
 /**
@@ -21,7 +22,26 @@ object ProSponsor {
     /** 打开赞助页后允许对账的时间窗口：覆盖赞助生效的「几分钟内」延迟，又给请求数封顶。 */
     private val RECONCILE_WINDOW = 30.minutes
 
-    fun openSponsorPage() {
+    /**
+     * upsell 漏斗的 source 词汇——曝光（pro_upsell_shown）与点击（pro_upsell_clicked）共用，
+     * 集中在此避免各入口自造事件名导致漏斗无法统一查询。新增赞助入口时在这里登记。
+     */
+    const val SOURCE_CHAT_QUOTA = "chat_quota"
+    const val SOURCE_MODEL_LOCKED = "model_locked"
+    const val SOURCE_SETTINGS_LANGUAGE = "settings_language"
+    const val SOURCE_SETTINGS_DONATE = "settings_donate"
+
+    /** upsell 曝光埋点（何时算一次曝光由调用方定义：挂载去重或每次展开）。 */
+    fun trackUpsellShown(source: String) {
+        trackEvent("pro_upsell_shown", mapOf("source" to source))
+    }
+
+    /**
+     * 打开赞助页统一入口。[upsellSource] 非空时上报统一的 pro_upsell_clicked——各入口
+     * 不再自报点击事件，shown→clicked→refreshPro 漏斗才能按同一词汇横向对比。
+     */
+    fun openSponsorPage(upsellSource: String? = null) {
+        upsellSource?.let { trackEvent("pro_upsell_clicked", mapOf("source" to it)) }
         globalSettingsManager.setSponsorPageOpenedAt(Clock.System.now().toEpochMilliseconds())
         openUrl(Constants.GITHUB_SPONSORS_URL)
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/Validation.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/Validation.kt
@@ -1,0 +1,7 @@
+package whl.trending.ai.core
+
+/** 与 Worker 端 subscribe.js 的 isValidEmail 同口径；此前四处入口各存一份正则，改档需四处齐改。 */
+private val EMAIL_REGEX = Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$")
+
+/** 邮箱格式校验（先 trim 再匹配）。反馈 / 订阅 / waitlist / 语言采集共用。 */
+fun isValidEmail(value: String): Boolean = EMAIL_REGEX.matches(value.trim())

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/ChatModelsProvider.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/ChatModelsProvider.kt
@@ -43,9 +43,4 @@ object ChatModelsProvider {
     fun warmUp(scope: CoroutineScope) {
         scope.launch { runCatching { get() } }
     }
-
-    /** 仅测试用：重置缓存。 */
-    fun resetForTest() {
-        cache = null
-    }
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/TrendingRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/TrendingRepository.kt
@@ -9,6 +9,15 @@ import whl.trending.ai.data.remote.TrendingApi
 
 // open：便于测试以子类替身注入（保持手动 DI，不引入 mock 框架）
 open class TrendingRepository(private val api: TrendingApi = TrendingApi()) {
+
+    companion object {
+        /**
+         * 进程级共享实例：TrendingApi 每个实例各建一个从不关闭的 HttpClient，组合树里随手 new
+         * 会积累引擎/连接池（仿 ChatApi.shared 的收敛方式）。无状态可安全共享；测试注入仍走构造参数。
+         */
+        val shared: TrendingRepository by lazy { TrendingRepository() }
+    }
+
     open suspend fun getFeed(source: String, summaryLang: String = "zh"): FeedResponse {
         return api.fetchFeed(source, summaryLang)
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feedback/FeedbackViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feedback/FeedbackViewModel.kt
@@ -1,5 +1,6 @@
 package whl.trending.ai.ui.feedback
 
+import whl.trending.ai.core.isValidEmail
 import whl.trending.ai.data.remote.ApiException
 import whl.trending.ai.data.repository.TrendingRepository
 
@@ -26,7 +27,7 @@ data class FeedbackUiState(
 )
 
 class FeedbackViewModel(
-    private val repository: TrendingRepository = TrendingRepository()
+    private val repository: TrendingRepository = TrendingRepository.shared
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(FeedbackUiState())
@@ -40,7 +41,7 @@ class FeedbackViewModel(
     }
 
     fun updateEmail(value: String) {
-        val valid = value.isBlank() || EMAIL_REGEX.matches(value.trim())
+        val valid = value.isBlank() || isValidEmail(value)
         _uiState.update { it.copy(email = value, isEmailValid = valid) }
     }
 
@@ -68,7 +69,4 @@ class FeedbackViewModel(
         }
     }
 
-    companion object {
-        private val EMAIL_REGEX = Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$")
-    }
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/BrandIcons.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/BrandIcons.kt
@@ -1,13 +1,30 @@
 package whl.trending.ai.ui.home
 
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathFillType
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.painterResource
+import trendingai.shared.generated.resources.GitHub_Invertocat_Black
+import trendingai.shared.generated.resources.GitHub_Invertocat_White
+import trendingai.shared.generated.resources.Res
 
 val HackerNewsOrange = Color(0xFFFF6600)
+
+/** GitHub Invertocat 按当前主题深浅选黑/白版；首页顶栏与设置捐助弹窗共用，避免各处复制判定。 */
+@Composable
+fun githubLogoPainter(): Painter {
+    val isDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
+    return painterResource(
+        if (isDark) Res.drawable.GitHub_Invertocat_White else Res.drawable.GitHub_Invertocat_Black
+    )
+}
 
 /**
  * 纯 Y 字母图标，用于底部导航栏（颜色由 tint 控制）

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -57,8 +57,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import trendingai.shared.generated.resources.GitHub_Invertocat_Black
-import trendingai.shared.generated.resources.GitHub_Invertocat_White
 import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.picks_title
 import trendingai.shared.generated.resources.hackernews_title
@@ -79,7 +77,9 @@ import trendingai.shared.generated.resources.profile_title
 import trendingai.shared.generated.resources.sign_in
 import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.chat.globalChatScreen
 import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.repository.ChatModelsProvider
 import whl.trending.ai.data.repository.UserRepository
 import whl.trending.ai.ui.feed.FeedScreen
 import whl.trending.ai.ui.feed.FeedViewModel
@@ -140,8 +140,8 @@ fun HomeScreen(
 
     // 预热聊天模型目录：让选择器 chip 在用户首次进入 chat 前就绪，避免冷首拉导致 chip 迟迟不出现。
     LaunchedEffect(Unit) {
-        if (whl.trending.ai.chat.globalChatScreen != null) {
-            runCatching { whl.trending.ai.data.repository.ChatModelsProvider.get() }
+        if (globalChatScreen != null) {
+            ChatModelsProvider.warmUp(this)
         }
     }
 
@@ -212,7 +212,7 @@ fun HomeScreen(
             }
         },
         floatingActionButton = {
-            if (whl.trending.ai.chat.globalChatScreen != null) {
+            if (globalChatScreen != null) {
                 FloatingActionButton(onClick = onNavigateToChat) {
                     Icon(
                         imageVector = Icons.Default.AutoAwesome,
@@ -326,7 +326,6 @@ private fun TrendingTopBar(
     userAvatarUrl: String?,
     onProfileClick: () -> Unit,
 ) {
-    val isDarkTheme = MaterialTheme.colorScheme.background.luminance() < 0.5f
     val periodLabel = when (selectedPeriod) {
         "daily" -> stringResource(Res.string.period_daily)
         "weekly" -> stringResource(Res.string.period_weekly)
@@ -374,10 +373,7 @@ private fun TrendingTopBar(
         navigationIcon = {
             Box(modifier = Modifier.padding(horizontal = 12.dp), contentAlignment = Alignment.Center) {
                 Icon(
-                    painter = painterResource(
-                        if (isDarkTheme) Res.drawable.GitHub_Invertocat_White
-                        else Res.drawable.GitHub_Invertocat_Black
-                    ),
+                    painter = githubLogoPainter(),
                     contentDescription = "GitHub",
                     modifier = Modifier.size(24.dp)
                 )

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -10,12 +10,14 @@ import whl.trending.ai.core.platform.getAppVersion
 import whl.trending.ai.core.platform.getSystemLanguage
 import whl.trending.ai.core.platform.getSystemLanguageDisplayName
 import whl.trending.ai.core.Constants
+import whl.trending.ai.core.isValidEmail
 import whl.trending.ai.core.ProSponsor
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.data.remote.ApiException
 import whl.trending.ai.data.repository.TrendingRepository
+import whl.trending.ai.ui.home.githubLogoPainter
 import whl.trending.ai.ui.theme.PRESET_PALETTE
 import whl.trending.ai.ui.theme.ThemeSeed
 import whl.trending.ai.update.globalUpdateChecker
@@ -96,8 +98,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import trendingai.shared.generated.resources.GitHub_Invertocat_Black
-import trendingai.shared.generated.resources.GitHub_Invertocat_White
 import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.about
 import trendingai.shared.generated.resources.about_us
@@ -181,16 +181,6 @@ fun SettingsScreen(
     val authState by globalAuthManager.authState.collectAsState()
     val isLoggedIn = authState is AuthState.LoggedIn
     var showLangCaptureDialog by remember { mutableStateOf(false) }
-    var langInput by remember { mutableStateOf("") }
-    var langEmail by remember { mutableStateOf("") }
-    var langEmailInvalid by remember { mutableStateOf(false) }
-    var langSubmitting by remember { mutableStateOf(false) }
-    var langError by remember { mutableStateOf<String?>(null) }
-    val langScope = rememberCoroutineScope()
-    val feedbackRepository = remember { TrendingRepository() }
-    val emailRegex = remember { Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$") }
-    val langErrGeneric = stringResource(Res.string.feedback_error)
-    val langErrRate = stringResource(Res.string.feedback_rate_limit)
 
     if (showOpenLinksDialog) {
         AlertDialog(
@@ -213,10 +203,6 @@ fun SettingsScreen(
             confirmButton = {
                 TextButton(onClick = {
                     showSummaryLanguageDialog = false
-                    langInput = getSystemLanguageDisplayName()
-                    langEmail = ""
-                    langEmailInvalid = false
-                    langError = null
                     showLangCaptureDialog = true
                 }) {
                     Text(stringResource(Res.string.summary_language_sponsor))
@@ -235,110 +221,10 @@ fun SettingsScreen(
     }
 
     if (showLangCaptureDialog) {
-        AlertDialog(
-            onDismissRequest = { if (!langSubmitting) showLangCaptureDialog = false },
-            title = { Text(stringResource(Res.string.summary_lang_capture_title)) },
-            text = {
-                Column {
-                    Text(stringResource(Res.string.summary_lang_capture_message))
-                    Spacer(Modifier.height(16.dp))
-                    OutlinedTextField(
-                        value = langInput,
-                        onValueChange = { langInput = it; langError = null },
-                        label = { Text(stringResource(Res.string.summary_lang_capture_label)) },
-                        singleLine = true,
-                        isError = langError != null,
-                        enabled = !langSubmitting,
-                        supportingText = langError?.let { { Text(it, color = MaterialTheme.colorScheme.error) } },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    if (isLoggedIn) {
-                        Spacer(Modifier.height(8.dp))
-                        Text(
-                            stringResource(Res.string.summary_lang_capture_identity_note),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    } else {
-                        Spacer(Modifier.height(12.dp))
-                        OutlinedTextField(
-                            value = langEmail,
-                            onValueChange = { langEmail = it; langEmailInvalid = false },
-                            label = { Text(stringResource(Res.string.feedback_email_placeholder)) },
-                            singleLine = true,
-                            isError = langEmailInvalid,
-                            enabled = !langSubmitting,
-                            supportingText = if (langEmailInvalid) {
-                                { Text(stringResource(Res.string.feedback_email_invalid), color = MaterialTheme.colorScheme.error) }
-                            } else null,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    }
-                }
-            },
-            confirmButton = {
-                TextButton(
-                    enabled = langInput.isNotBlank() && !langSubmitting,
-                    onClick = {
-                        val lang = langInput.trim()
-                        if (lang.isEmpty()) return@TextButton
-                        val email = langEmail.trim()
-                        // 未登录：邮箱选填，但填了就必须格式正确
-                        if (!isLoggedIn && email.isNotEmpty() && !emailRegex.matches(email)) {
-                            langEmailInvalid = true
-                            return@TextButton
-                        }
-                        langSubmitting = true
-                        langError = null
-                        langScope.launch {
-                            // 身份直接读 syncMe 落好的本地缓存：免一次串行 /api/me 往返；id 可能缺失（后端
-                            // 兜底 username 建档时无数字 id），缺就只带 login，别写出「id null」污染赞助匹配
-                            val identityLine = if (isLoggedIn) {
-                                val login = globalSettingsManager.getGithubLoginSync()
-                                val userId = globalSettingsManager.getGithubUserIdSync()
-                                when {
-                                    login != null && userId != null -> "GitHub：@${login}（id ${userId}）"
-                                    login != null -> "GitHub：@${login}"
-                                    else -> "GitHub：已登录（未取到身份）"
-                                }
-                            } else null
-                            val content = buildString {
-                                append("【摘要语言支持请求】期望语言：$lang · 系统语言：${getSystemLanguage()}")
-                                identityLine?.let { append(" · $it") }
-                            }
-                            val submitEmail = if (!isLoggedIn) email.ifEmpty { null } else null
-                            feedbackRepository.submitFeedback(content, submitEmail).fold(
-                                onSuccess = {
-                                    langSubmitting = false
-                                    showLangCaptureDialog = false
-                                    trackEvent("settings_summary_language_sponsor", mapOf("language" to lang))
-                                    ProSponsor.openSponsorPage()
-                                },
-                                onFailure = { e ->
-                                    langSubmitting = false
-                                    langError = if ((e as? ApiException)?.statusCode == 429) langErrRate else langErrGeneric
-                                },
-                            )
-                        }
-                    }
-                ) {
-                    if (langSubmitting) {
-                        LoadingIndicator(modifier = Modifier.size(24.dp))
-                    } else {
-                        Text(stringResource(Res.string.summary_language_sponsor))
-                    }
-                }
-            },
-            dismissButton = {
-                TextButton(enabled = !langSubmitting, onClick = { showLangCaptureDialog = false }) {
-                    Text(stringResource(Res.string.cancel))
-                }
-            }
-        )
+        LanguageCaptureDialog(isLoggedIn = isLoggedIn, onDismiss = { showLangCaptureDialog = false })
     }
 
     if (showDonateDialog) {
-        val isDarkTheme = MaterialTheme.colorScheme.background.luminance() < 0.5f
         AlertDialog(
             onDismissRequest = { showDonateDialog = false },
             title = { Text(stringResource(Res.string.donate)) },
@@ -352,15 +238,12 @@ fun SettingsScreen(
                             .fillMaxWidth()
                             .clickable {
                                 trackEvent("settings_donate_github")
-                                ProSponsor.openSponsorPage()
+                                ProSponsor.openSponsorPage(ProSponsor.SOURCE_SETTINGS_DONATE)
                             }
                             .padding(vertical = 12.dp)
                     ) {
                         Icon(
-                            painter = painterResource(
-                                if (isDarkTheme) Res.drawable.GitHub_Invertocat_White
-                                else Res.drawable.GitHub_Invertocat_Black
-                            ),
+                            painter = githubLogoPainter(),
                             contentDescription = null,
                             tint = Color.Unspecified,
                             modifier = Modifier.size(24.dp)
@@ -792,5 +675,123 @@ fun SettingsHeader(text: String) {
         style = MaterialTheme.typography.labelLarge,
         color = MaterialTheme.colorScheme.primary,
         modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+    )
+}
+
+/**
+ * 摘要语言意图采集弹窗：期望语言（+ 未登录的选填邮箱）经反馈接口提交，成功后跳赞助页。
+ * 状态自持有——挂载即全新、关闭即丢弃，宿主只管 show 标记，无需在打开前手动重置各字段。
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun LanguageCaptureDialog(isLoggedIn: Boolean, onDismiss: () -> Unit) {
+    var langInput by remember { mutableStateOf(getSystemLanguageDisplayName()) }
+    var langEmail by remember { mutableStateOf("") }
+    var langEmailInvalid by remember { mutableStateOf(false) }
+    var langSubmitting by remember { mutableStateOf(false) }
+    var langError by remember { mutableStateOf<String?>(null) }
+    val scope = rememberCoroutineScope()
+    val errGeneric = stringResource(Res.string.feedback_error)
+    val errRate = stringResource(Res.string.feedback_rate_limit)
+
+    AlertDialog(
+        onDismissRequest = { if (!langSubmitting) onDismiss() },
+        title = { Text(stringResource(Res.string.summary_lang_capture_title)) },
+        text = {
+            Column {
+                Text(stringResource(Res.string.summary_lang_capture_message))
+                Spacer(Modifier.height(16.dp))
+                OutlinedTextField(
+                    value = langInput,
+                    onValueChange = { langInput = it; langError = null },
+                    label = { Text(stringResource(Res.string.summary_lang_capture_label)) },
+                    singleLine = true,
+                    isError = langError != null,
+                    enabled = !langSubmitting,
+                    supportingText = langError?.let { { Text(it, color = MaterialTheme.colorScheme.error) } },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (isLoggedIn) {
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        stringResource(Res.string.summary_lang_capture_identity_note),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    Spacer(Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = langEmail,
+                        onValueChange = { langEmail = it; langEmailInvalid = false },
+                        label = { Text(stringResource(Res.string.feedback_email_placeholder)) },
+                        singleLine = true,
+                        isError = langEmailInvalid,
+                        enabled = !langSubmitting,
+                        supportingText = if (langEmailInvalid) {
+                            { Text(stringResource(Res.string.feedback_email_invalid), color = MaterialTheme.colorScheme.error) }
+                        } else null,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = langInput.isNotBlank() && !langSubmitting,
+                onClick = {
+                    val lang = langInput.trim()
+                    if (lang.isEmpty()) return@TextButton
+                    val email = langEmail.trim()
+                    // 未登录：邮箱选填，但填了就必须格式正确
+                    if (!isLoggedIn && email.isNotEmpty() && !isValidEmail(email)) {
+                        langEmailInvalid = true
+                        return@TextButton
+                    }
+                    langSubmitting = true
+                    langError = null
+                    scope.launch {
+                        // 身份直接读 syncMe 落好的本地缓存：免一次串行 /api/me 往返；id 可能缺失（后端
+                        // 兜底 username 建档时无数字 id），缺就只带 login，别写出「id null」污染赞助匹配
+                        val identityLine = if (isLoggedIn) {
+                            val login = globalSettingsManager.getGithubLoginSync()
+                            val userId = globalSettingsManager.getGithubUserIdSync()
+                            when {
+                                login != null && userId != null -> "GitHub：@${login}（id ${userId}）"
+                                login != null -> "GitHub：@${login}"
+                                else -> "GitHub：已登录（未取到身份）"
+                            }
+                        } else null
+                        val content = buildString {
+                            append("【摘要语言支持请求】期望语言：$lang · 系统语言：${getSystemLanguage()}")
+                            identityLine?.let { append(" · $it") }
+                        }
+                        val submitEmail = if (!isLoggedIn) email.ifEmpty { null } else null
+                        TrendingRepository.shared.submitFeedback(content, submitEmail).fold(
+                            onSuccess = {
+                                langSubmitting = false
+                                onDismiss()
+                                trackEvent("settings_summary_language_sponsor", mapOf("language" to lang))
+                                ProSponsor.openSponsorPage(ProSponsor.SOURCE_SETTINGS_LANGUAGE)
+                            },
+                            onFailure = { e ->
+                                langSubmitting = false
+                                langError = if ((e as? ApiException)?.statusCode == 429) errRate else errGeneric
+                            },
+                        )
+                    }
+                }
+            ) {
+                if (langSubmitting) {
+                    LoadingIndicator(modifier = Modifier.size(24.dp))
+                } else {
+                    Text(stringResource(Res.string.summary_language_sponsor))
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(enabled = !langSubmitting, onClick = onDismiss) {
+                Text(stringResource(Res.string.cancel))
+            }
+        }
     )
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/subscribe/SubscribeViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/subscribe/SubscribeViewModel.kt
@@ -1,5 +1,6 @@
 package whl.trending.ai.ui.subscribe
 
+import whl.trending.ai.core.isValidEmail
 import whl.trending.ai.core.platform.isIosPlatform
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.local.globalSettingsManager
@@ -32,7 +33,7 @@ data class SubscribeUiState(
 }
 
 class SubscribeViewModel(
-    private val repository: TrendingRepository = TrendingRepository(),
+    private val repository: TrendingRepository = TrendingRepository.shared,
     private val settings: SettingsManager = globalSettingsManager,
 ) : ViewModel() {
 
@@ -48,14 +49,14 @@ class SubscribeViewModel(
     val events = _events.receiveAsFlow()
 
     fun updateEmail(value: String) {
-        val valid = value.isBlank() || EMAIL_REGEX.matches(value.trim())
+        val valid = value.isBlank() || isValidEmail(value)
         _uiState.update { it.copy(email = value, isEmailValid = valid) }
     }
 
     fun submit() {
         val state = _uiState.value
         val email = state.email.trim()
-        if (email.isEmpty() || !EMAIL_REGEX.matches(email) || state.isSubmitting) return
+        if (email.isEmpty() || !isValidEmail(email) || state.isSubmitting) return
 
         viewModelScope.launch {
             _uiState.update { it.copy(isSubmitting = true) }
@@ -80,7 +81,7 @@ class SubscribeViewModel(
     fun cancel() {
         val state = _uiState.value
         val email = (state.subscribedEmail ?: state.email).trim()
-        if (email.isEmpty() || !EMAIL_REGEX.matches(email) || state.isSubmitting) return
+        if (email.isEmpty() || !isValidEmail(email) || state.isSubmitting) return
 
         viewModelScope.launch {
             _uiState.update { it.copy(isSubmitting = true) }
@@ -102,8 +103,4 @@ class SubscribeViewModel(
 
     private fun currentSource(): String =
         if (isIosPlatform()) "app-ios" else "app-android"
-
-    companion object {
-        private val EMAIL_REGEX = Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$")
-    }
 }


### PR DESCRIPTION
## 背景

发布前 review 的 P3 清理项（11 条）一次收拢。除下述两处有意的行为变化外，均为无行为变化的去重/收敛。

## 改动清单

| 项 | 做法 |
|---|---|
| 邮箱正则 ×4 | 收敛到 shared core `isValidEmail()`（与服务端 subscribe.js 同口径） |
| waitlist lang 口径分叉 | 改用 `currentContentLang()`，与 SubscribeViewModel 对同一 subscribers 表同口径；删除与 ChatApi 逐字节重复的私有 resolveLang（聊天请求的 zh/en 口径是另一契约，保留在 ChatApi） |
| HttpClient 泛滥 | `TrendingRepository.shared` 进程级共享实例（仿 ChatApi.shared）；SettingsScreen / WaitlistDialog / Feedback / Subscribe 四处收敛 |
| upsell 埋点口径分裂 | source 词汇集中到 `ProSponsor`（chat_quota / model_locked / settings_language / settings_donate），shown / clicked 统一入口；口径变化记录进 docs/analytics-notes.md |
| warmUp 死代码 | HomeScreen 预热改调 `ChatModelsProvider.warmUp()`；删除零调用的 `resetForTest()` |
| GitHub 图标判定 ×2 | 抽 `githubLogoPainter()`（BrandIcons），顶栏与捐助弹窗共用 |
| 语言采集弹窗内联 | 抽为自包含 `LanguageCaptureDialog`：7 个提升状态变量回收，挂载即全新，宿主删掉手动重置块 |
| `"quota_device"` ×4 | 提为 `ChatError.CODE_QUOTA_DEVICE` |
| 死字符串 | 删除双语言 `chat_quota_user_exceeded` |

## 有意的行为变化（2 处）

1. **waitlist 的 lang**：非 zh/en 系统语言下从强制 `en` 变为真实 ISO 码（如 `ja`），与 newsletter 订阅一致——这本来就是 `currentContentLang()` 存在的目的。
2. **waitlist 提交按钮**：补 M3 Expressive `LoadingIndicator`，对齐 CLAUDE.md UI 规范与 Feedback/Subscribe 的提交态反馈。

另：settings 两个赞助入口自本 PR 起新增上报统一的 `pro_upsell_clicked`（原 `settings_summary_language_sponsor` / `settings_donate_github` 事件保留不动），漏斗对比注意口径起点，详见 docs/analytics-notes.md 。

## 验证

- `:androidApp:assembleDebug` / `:shared:compileKotlinIosSimulatorArm64` 编译通过
- chat / shared 单测全绿
- 残留检查：EMAIL_REGEX / UPSELL_SOURCE_KEY / quota_device 字面量 / resetForTest 全仓仅剩规范定义点

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

集中管理共享的邮件校验、网络请求、品牌样式和分析工具，同时简化 UI 状态管理、加强 Pro 升级追踪，并对部分 UX 和遥测行为进行小幅更新。

Enhancements:
- 在反馈、订阅、候补名单和语言采集流程中共享同一个邮件校验辅助工具，确保前端校验与后端保持一致。
- 引入进程级共享的 `TrendingRepository` 实例，避免创建过多的 `HttpClient` 实例，同时保持测试可注入性。
- 将设置中的“摘要语言”提示重构为自包含的 `LanguageCaptureDialog`，由其自行管理状态，并复用共享的反馈 / Pro 赞助流程。
- 通过可复用的 `githubLogoPainter` 组合函数统一 GitHub Logo 的主题样式，并在首页顶部栏与设置中的捐赠对话框中复用。
- 将 Pro 候补名单的语言推导逻辑与 `currentContentLang()` 对齐，使所有订阅用户与订阅流程保持一致的语言语义，并在候补名单提交过程中加入加载指示器。
- 通过 `ProSponsor` 路由 Pro 升级展示 / 点击事件及其来源词汇，并扩展赞助入口以上报统一的 `pro_upsell_clicked` 事件，并携带按来源区分的归因信息。
- 使用命名常量 `ChatError.CODE_QUOTA_DEVICE` 替代硬编码的 `quota_device` 字符串，用于重试逻辑和配额专用 UI 处理。
- 通过使用 `ChatModelsProvider.warmUp` 简化聊天模型预热逻辑，并移除未使用的、仅供测试的重置功能。
- 移除英文和中文资源中未使用的按等级区分的“配额超限”字符串。

Documentation:
- 在 `analytics-notes.md` 中记录统一的 Pro 升级漏斗来源词汇和事件语义，以确保各入口的分析解读保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize shared utilities for email validation, networking, branding, and analytics while simplifying UI state management and tightening Pro upsell tracking, with minor UX and telemetry behavior updates.

Enhancements:
- Share a single email validation helper across feedback, subscription, waitlist, and language capture flows to keep client-side checks consistent with the backend.
- Introduce a process-wide shared TrendingRepository instance to avoid proliferating HttpClient instances while keeping tests injectable.
- Refactor the settings summary-language prompt into a self-contained LanguageCaptureDialog that owns its own state and uses the shared feedback/Pro sponsor flow.
- Unify GitHub logo theming via a githubLogoPainter composable reused in the home top bar and settings donate dialog.
- Align Pro waitlist language derivation with currentContentLang() so all subscribers share the same lang semantics as the subscription flow, and add a loading indicator during waitlist submission.
- Route Pro upsell shown/clicked events and source vocabulary through ProSponsor, and extend sponsor entrypoints to report a unified pro_upsell_clicked event with source-specific attribution.
- Use a named ChatError.CODE_QUOTA_DEVICE constant instead of hardcoded quota_device strings for retry logic and dedicated quota UI handling.
- Simplify chat model warm-up by using ChatModelsProvider.warmUp and remove unused test-only reset functionality.
- Remove an unused per-tier quota-exceeded string in both English and Chinese resources.

Documentation:
- Document the unified Pro upsell funnel source vocabulary and event semantics in analytics-notes.md for consistent analytics interpretation across entrypoints.

</details>