### PR TITLE
feat(auth): 登录成功/失败埋点补登录耗时 duration_ms

### DIFF
--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -1,6 +1,7 @@
 package whl.trending.ai.auth
 
 import android.app.Activity
+import android.os.SystemClock
 import io.logto.sdk.android.LogtoClient
 import io.logto.sdk.android.exception.LogtoException
 import io.logto.sdk.android.type.LogtoConfig
@@ -51,15 +52,21 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
     override fun signIn() {
         val activity = activityRef.get() ?: return
         _authState.value = AuthState.LoggingIn
+        // 登录耗时起点：单调时钟，不受系统时间/时区调整影响；用局部变量随闭包捕获，
+        // 配置变更重建 Activity 后回调即便落在旧实例也仍读到本次登录的起点（见 SignInFailureBus）。
+        val signInStartedAt = SystemClock.elapsedRealtime()
         logtoClient.signIn(activity, REDIRECT_URI) { logtoException ->
+            // 从登录进入到本次回调的耗时：成功=登录总时长，失败=到失败的时长（取消即用户在授权页停留时长）。
+            // 需结合事件/reason 解读：config/no_browser 等快失败耗时接近 0 属正常。
+            val durationMs = SystemClock.elapsedRealtime() - signInStartedAt
             if (logtoException == null && logtoClient.isAuthenticated) {
                 _authState.value = AuthState.LoggedIn
-                trackEvent("sign_in_success")
+                trackEvent("sign_in_success", mapOf("duration_ms" to durationMs))
             } else {
                 _authState.value = AuthState.LoggedOut
                 if (logtoException != null) {
                     val (reason, props) = analyzeSignInFailure(logtoException)
-                    trackEvent("sign_in_failed", props)
+                    trackEvent("sign_in_failed", props + ("duration_ms" to durationMs))
                     // 走进程级总线而非实例字段：配置变更重建 Activity 后回调可能落在旧实例上（见 SignInFailureBus）
                     SignInFailureBus.emit(reason)
                 }


### PR DESCRIPTION
## 背景

用户登录 `USER_CANCELED` 场景希望能度量「从登录进入到用户放弃」的耗时。评估后决定统一给登录成功/失败埋点都带上耗时维度，而非单独新增事件。

## 改动

`LogtoAuthManager.signIn()` 回调开头统一算一次 `durationMs`（`SystemClock.elapsedRealtime()` 单调时钟，不受系统时间/时区调整影响；起点随闭包捕获，配置变更重建 Activity 后回调即便落在旧实例也不丢），两条既有埋点各带上：

- **`sign_in_success`** → `duration_ms`：登录总时长（进入登录到成功）。
- **`sign_in_failed`** → 原有 props（`reason` / `logto_type` / `cause`）+ `duration_ms`：到失败的时长；`reason=user_canceled` 即用户在授权页停留多久后放弃。

不新增事件、不改事件数，两个事件仍自动附带 `install_id` / `channel`。

## 分析口径说明

`duration_ms` 需结合事件与 `reason` 一起解读：`config` / `no_browser` 等快失败场景耗时接近 0 属正常。

## 验证

`:androidApp:compileGithubDebugKotlin` 编译通过。纯埋点属性补充，无行为/UI 变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

新功能：
- 使用单调时钟记录登录会话持续时间，并在登录成功和失败事件中以 `duration_ms` 附加该持续时间。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Record login session duration using a monotonic clock and attach it to sign-in success and failure events as duration_ms.

</details>