### PR TITLE
feat(chat): 聊天支持拍照/相册发图（图片理解，仅登录用户）

### DIFF
--- a/androidLibrary/chat/build.gradle.kts
+++ b/androidLibrary/chat/build.gradle.kts
@@ -26,6 +26,10 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinxJson)
     implementation(libs.kotlinx.serialization.json)
 
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.exifinterface)
+    implementation(libs.coil.compose)
+
     implementation(libs.compose.runtime)
     implementation(libs.compose.foundation)
     implementation(libs.compose.material3)

--- a/androidLibrary/chat/src/main/AndroidManifest.xml
+++ b/androidLibrary/chat/src/main/AndroidManifest.xml
@@ -14,6 +14,17 @@
             android:label="Chat Demo"
             android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
             android:windowSoftInputMode="adjustResize" />
+
+        <!--
+            拍照（TakePicture）输出目标。用专属子类 ChatFileProvider（路径配置由构造器传入），
+            避免与宿主打包的其他库（如 kmp-webview）注册的 androidx FileProvider 在
+            manifest merger 里按类名撞车；authority 也带 .chat 命名空间双保险。
+        -->
+        <provider
+            android:name="whl.trending.chat.attach.ChatFileProvider"
+            android:authorities="${applicationId}.chat.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true" />
     </application>
 
 </manifest>

--- a/androidLibrary/chat/src/main/AndroidManifest.xml
+++ b/androidLibrary/chat/src/main/AndroidManifest.xml
@@ -16,15 +16,21 @@
             android:windowSoftInputMode="adjustResize" />
 
         <!--
-            拍照（TakePicture）输出目标。用专属子类 ChatFileProvider（路径配置由构造器传入），
-            避免与宿主打包的其他库（如 kmp-webview）注册的 androidx FileProvider 在
-            manifest merger 里按类名撞车；authority 也带 .chat 命名空间双保险。
+            拍照（TakePicture）输出目标。用专属子类 ChatFileProvider 避免与宿主打包的
+            其他库（如 kmp-webview）注册的 androidx FileProvider 在 manifest merger 里
+            按类名撞车；authority 也带 .chat 命名空间双保险。
+            meta-data 不能省：静态 FileProvider.getUriForFile() 只从 manifest meta-data
+            解析路径配置，不认子类构造器传入的资源，缺了会运行时崩溃。
         -->
         <provider
             android:name="whl.trending.chat.attach.ChatFileProvider"
             android:authorities="${applicationId}.chat.fileprovider"
             android:exported="false"
-            android:grantUriPermissions="true" />
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/chat_file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -52,22 +52,45 @@ class ChatViewModel(
         _uiState.update { it.copy(input = text) }
     }
 
+    /** 追加一张已压缩好的待发图片（本地缓存路径），超过单条上限时忽略。 */
+    fun addPendingImage(path: String) {
+        _uiState.update {
+            if (it.pendingImages.size >= MAX_IMAGES_PER_MESSAGE || path in it.pendingImages) it
+            else it.copy(pendingImages = it.pendingImages + path)
+        }
+    }
+
+    fun removePendingImage(path: String) {
+        _uiState.update { it.copy(pendingImages = it.pendingImages - path) }
+    }
+
     fun send() {
         val state = _uiState.value
         if (!state.canSend) return
         val text = state.input.trim()
-        _uiState.update { it.copy(input = "") }
-        sendText(text)
+        val images = state.pendingImages
+        _uiState.update { it.copy(input = "", pendingImages = emptyList()) }
+        sendMessage(text, images)
     }
 
     /** 发送一段指定文本（如快捷按钮的预设问题），不依赖输入框；发送中或空白则忽略。 */
-    fun sendText(text: String) {
-        if (_uiState.value.isSending || text.isBlank()) return
-        val userMessage = ChatMessage(nextId(), Role.USER, text)
+    fun sendText(text: String) = sendMessage(text, emptyList())
+
+    private fun sendMessage(text: String, images: List<String>) {
+        if (_uiState.value.isSending || (text.isBlank() && images.isEmpty())) return
+        if (images.isNotEmpty()) {
+            trackEvent("chat_send_with_images", mapOf("image_count" to images.size.toString()))
+        }
+        val userMessage = ChatMessage(nextId(), Role.USER, text, images = images)
         _uiState.update {
             it.copy(messages = it.messages + userMessage, isSending = true)
         }
         request()
+    }
+
+    companion object {
+        /** 单条消息图片数上限，与服务端及 [whl.trending.chat.engine.ChatWire] 对齐 */
+        const val MAX_IMAGES_PER_MESSAGE = 4
     }
 
     /** 对可重试的失败消息重试：移除该错误条，按当前历史重新请求。

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/attach/ChatFileProvider.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/attach/ChatFileProvider.kt
@@ -1,0 +1,12 @@
+package whl.trending.chat.attach
+
+import androidx.core.content.FileProvider
+import whl.trending.chat.R
+
+/**
+ * 聊天模块专属 FileProvider 子类。宿主可能还打包了其他注册
+ * `androidx.core.content.FileProvider` 的库（如 kmp-webview），manifest merger 按
+ * android:name 合并 provider，同类名必然冲突——子类化让类名唯一，路径配置直接由
+ * 构造器传入，无需 meta-data。
+ */
+internal class ChatFileProvider : FileProvider(R.xml.chat_file_paths)

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/attach/ChatFileProvider.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/attach/ChatFileProvider.kt
@@ -6,7 +6,10 @@ import whl.trending.chat.R
 /**
  * 聊天模块专属 FileProvider 子类。宿主可能还打包了其他注册
  * `androidx.core.content.FileProvider` 的库（如 kmp-webview），manifest merger 按
- * android:name 合并 provider，同类名必然冲突——子类化让类名唯一，路径配置直接由
- * 构造器传入，无需 meta-data。
+ * android:name 合并 provider，同类名必然冲突——子类化让类名唯一。
+ *
+ * 路径配置仍必须在 manifest 里以 meta-data 声明：静态 [FileProvider.getUriForFile]
+ * 只解析 meta-data，构造器资源只对 provider 实例方法生效，二者需指向同一份
+ * `chat_file_paths.xml`。
  */
 internal class ChatFileProvider : FileProvider(R.xml.chat_file_paths)

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/attach/ChatImages.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/attach/ChatImages.kt
@@ -1,0 +1,122 @@
+package whl.trending.chat.attach
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.net.Uri
+import androidx.core.content.FileProvider
+import androidx.exifinterface.media.ExifInterface
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * 聊天图片的采集与预处理。
+ *
+ * [ingest]：任意来源 Uri（相册 Photo Picker / 拍照 FileProvider）→ 采样解码（防大图 OOM）
+ * → 按 EXIF Orientation 旋正像素 → 长边缩至 ≤[MAX_EDGE] → JPEG q[JPEG_QUALITY] 重编码
+ * 写入私有缓存。重编码产物不含任何 EXIF（GPS/时间/设备随之剥除）；Orientation 是唯一
+ * 先消费再丢弃的字段。单张产物约 100–200KB。
+ */
+object ChatImages {
+
+    private const val MAX_EDGE = 1568
+    private const val JPEG_QUALITY = 80
+    private const val DIR = "chat_images"
+    private const val MAX_AGE_MS = 24 * 60 * 60 * 1000L
+
+    /** 与宿主 FileProvider 区隔的专属 authority 后缀（见模块 manifest） */
+    private const val AUTHORITY_SUFFIX = ".chat.fileprovider"
+
+    private var cleanedUp = false
+
+    /** 压缩 + EXIF 归一化后写入私有缓存，返回文件路径；失败返回 null。 */
+    suspend fun ingest(context: Context, uri: Uri): String? = withContext(Dispatchers.IO) {
+        cleanupOld(context)
+        runCatching {
+            val resolver = context.contentResolver
+
+            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
+                ?: return@runCatching null
+            var sampleSize = 1
+            while (maxOf(bounds.outWidth, bounds.outHeight) / (sampleSize * 2) >= MAX_EDGE) {
+                sampleSize *= 2
+            }
+
+            val opts = BitmapFactory.Options().apply { inSampleSize = sampleSize }
+            val decoded = resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, opts) }
+                ?: return@runCatching null
+
+            val orientation = runCatching {
+                resolver.openInputStream(uri)?.use {
+                    ExifInterface(it).getAttributeInt(
+                        ExifInterface.TAG_ORIENTATION,
+                        ExifInterface.ORIENTATION_NORMAL,
+                    )
+                }
+            }.getOrNull() ?: ExifInterface.ORIENTATION_NORMAL
+
+            val upright = applyOrientation(decoded, orientation)
+            val scaled = scaleDown(upright)
+
+            val out = File(imageDir(context), "${UUID.randomUUID()}.jpg")
+            FileOutputStream(out).use { scaled.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, it) }
+            if (scaled !== upright) upright.recycle()
+            scaled.recycle()
+            out.absolutePath
+        }.getOrNull()
+    }
+
+    /** 为系统相机 TakePicture 生成输出目标：私有缓存文件 + 专属 FileProvider Uri。 */
+    fun newCaptureTarget(context: Context): Pair<Uri, File> {
+        val file = File(imageDir(context), "capture_${UUID.randomUUID()}.jpg")
+        val uri = FileProvider.getUriForFile(context, context.packageName + AUTHORITY_SUFFIX, file)
+        return uri to file
+    }
+
+    private fun imageDir(context: Context): File =
+        File(context.cacheDir, DIR).apply { mkdirs() }
+
+    /** 清理超过 24h 的缓存图（会话是内存级的，进程重启后旧图必然不再被引用）。每进程执行一次。 */
+    private fun cleanupOld(context: Context) {
+        if (cleanedUp) return
+        cleanedUp = true
+        runCatching {
+            val cutoff = System.currentTimeMillis() - MAX_AGE_MS
+            imageDir(context).listFiles()?.forEach { if (it.lastModified() < cutoff) it.delete() }
+        }
+    }
+
+    private fun applyOrientation(bitmap: Bitmap, orientation: Int): Bitmap {
+        val matrix = Matrix()
+        when (orientation) {
+            ExifInterface.ORIENTATION_ROTATE_90 -> matrix.postRotate(90f)
+            ExifInterface.ORIENTATION_ROTATE_180 -> matrix.postRotate(180f)
+            ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)
+            ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.postScale(-1f, 1f)
+            ExifInterface.ORIENTATION_FLIP_VERTICAL -> matrix.postScale(1f, -1f)
+            ExifInterface.ORIENTATION_TRANSPOSE -> { matrix.postRotate(90f); matrix.postScale(-1f, 1f) }
+            ExifInterface.ORIENTATION_TRANSVERSE -> { matrix.postRotate(270f); matrix.postScale(-1f, 1f) }
+            else -> return bitmap
+        }
+        val rotated = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+        if (rotated !== bitmap) bitmap.recycle()
+        return rotated
+    }
+
+    private fun scaleDown(bitmap: Bitmap): Bitmap {
+        val edge = maxOf(bitmap.width, bitmap.height)
+        if (edge <= MAX_EDGE) return bitmap
+        val ratio = MAX_EDGE.toFloat() / edge
+        return Bitmap.createScaledBitmap(
+            bitmap,
+            (bitmap.width * ratio).toInt().coerceAtLeast(1),
+            (bitmap.height * ratio).toInt().coerceAtLeast(1),
+            true,
+        )
+    }
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/attach/ChatImages.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/attach/ChatImages.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.net.Uri
+import android.util.Log
 import androidx.core.content.FileProvider
 import androidx.exifinterface.media.ExifInterface
 import java.io.File
@@ -23,6 +24,7 @@ import kotlinx.coroutines.withContext
  */
 object ChatImages {
 
+    private const val TAG = "ChatImages"
     private const val MAX_EDGE = 1568
     private const val JPEG_QUALITY = 80
     private const val DIR = "chat_images"
@@ -39,9 +41,12 @@ object ChatImages {
         runCatching {
             val resolver = context.contentResolver
 
+            // 注意：inJustDecodeBounds 模式下 decodeStream 恒返回 null（只回填 bounds），
+            // 不能用它的返回值判空，须以 bounds 尺寸判断解码是否成功
             val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-            resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
-                ?: return@runCatching null
+            val boundsStream = resolver.openInputStream(uri) ?: return@runCatching null
+            boundsStream.use { BitmapFactory.decodeStream(it, null, bounds) }
+            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return@runCatching null
             var sampleSize = 1
             while (maxOf(bounds.outWidth, bounds.outHeight) / (sampleSize * 2) >= MAX_EDGE) {
                 sampleSize *= 2
@@ -68,7 +73,10 @@ object ChatImages {
             if (scaled !== upright) upright.recycle()
             scaled.recycle()
             out.absolutePath
-        }.getOrNull()
+        }
+            .onFailure { Log.w(TAG, "ingest failed: uri=$uri", it) }
+            .getOrNull()
+            .also { if (it == null) Log.w(TAG, "ingest returned null: uri=$uri") }
     }
 
     /** 为系统相机 TakePicture 生成输出目标：私有缓存文件 + 专属 FileProvider Uri。 */

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -19,6 +19,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import java.io.File
 import java.util.Locale
 import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.globalAuthManager
@@ -52,8 +54,9 @@ class ChatApi(
         val shared: ChatEngine by lazy { ChatApi() }
     }
 
+    /** content 两态：纯文本为 JSON string；末条带图 user 消息为 OpenAI 多模态 parts 数组 */
     @Serializable
-    private data class WireMessage(val role: String, val content: String)
+    private data class WireMessage(val role: String, val content: JsonElement)
 
     @Serializable
     private data class ChatRequest(
@@ -99,6 +102,8 @@ class ChatApi(
         try {
             // 发送时的登录自认知：与 429 的 tier=anonymous 对照可识别「token 缺失/被拒被静默降级」
             val sentAsLoggedIn = globalAuthManager.authState.value is AuthState.LoggedIn
+            val lang = resolveLang()
+            val imagePlaceholder = if (lang == "zh") "[图片]" else "[image]"
             val response: HttpResponse = client.post("$baseUrl/chat") {
                 header("X-Install-Id", globalSettingsManager.getOrCreateInstallId())
                 // 已登录则带 token 走登录档配额（每日 10 条）；token 无效时服务端静默降级匿名档
@@ -106,13 +111,20 @@ class ChatApi(
                 contentType(ContentType.Application.Json)
                 setBody(
                     ChatRequest(
-                        messages = history.map {
+                        messages = history.mapIndexed { index, m ->
                             WireMessage(
-                                role = if (it.role == Role.USER) "user" else "assistant",
-                                content = it.content,
+                                role = if (m.role == Role.USER) "user" else "assistant",
+                                content = ChatWire.buildContent(
+                                    message = m,
+                                    isLast = index == history.lastIndex,
+                                    imagePlaceholder = imagePlaceholder,
+                                    readImageBytes = { path ->
+                                        runCatching { File(path).readBytes() }.getOrNull()
+                                    },
+                                ),
                             )
                         },
-                        lang = resolveLang(),
+                        lang = lang,
                         context = context?.let {
                             WireContext(it.title, it.summary, it.sourceUrl)
                         },

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatWire.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatWire.kt
@@ -1,0 +1,75 @@
+package whl.trending.chat.engine
+
+import kotlin.io.encoding.Base64
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.Role
+
+/**
+ * OpenAI 兼容 wire 格式的 content 组装（纯函数，便于单测）。
+ *
+ * 规则（与服务端校验一一对应）：
+ * - 无图消息：content 是普通 JSON string，与历史行为完全一致
+ * - **仅末条 user 消息**内嵌图片：content 为 `[{type:text},{type:image_url,...}]` parts 数组，
+ *   图片读文件转 `data:image/jpeg;base64,` data-url
+ * - 历史里的带图消息降级为「文本 + 占位」纯文本，不重传 base64（防上下文体积膨胀，
+ *   也是服务端 images_in_history 校验的前提）
+ */
+internal object ChatWire {
+
+    /** 单条消息图片数上限，与服务端 MAX_IMAGES_PER_MSG 对齐 */
+    const val MAX_IMAGES_PER_MESSAGE = 4
+
+    fun buildContent(
+        message: ChatMessage,
+        isLast: Boolean,
+        imagePlaceholder: String,
+        readImageBytes: (String) -> ByteArray?,
+    ): JsonElement {
+        if (message.images.isEmpty()) return JsonPrimitive(message.content)
+
+        if (!isLast || message.role != Role.USER) {
+            val placeholders = imagePlaceholder.repeat(message.images.size)
+            val text = if (message.content.isBlank()) placeholders else "${message.content} $placeholders"
+            return JsonPrimitive(text)
+        }
+
+        return buildJsonArray {
+            if (message.content.isNotBlank()) {
+                add(
+                    buildJsonObject {
+                        put("type", "text")
+                        put("text", message.content)
+                    },
+                )
+            }
+            var encoded = 0
+            for (path in message.images.take(MAX_IMAGES_PER_MESSAGE)) {
+                val bytes = readImageBytes(path) ?: continue
+                add(
+                    buildJsonObject {
+                        put("type", "image_url")
+                        putJsonObject("image_url") {
+                            put("url", "data:image/jpeg;base64," + Base64.encode(bytes))
+                        }
+                    },
+                )
+                encoded++
+            }
+            // 图片全部读取失败且无文本：兜底一个占位文本部分，保证 content 合法非空
+            if (encoded == 0 && message.content.isBlank()) {
+                add(
+                    buildJsonObject {
+                        put("type", "text")
+                        put("text", imagePlaceholder)
+                    },
+                )
+            }
+        }
+    }
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatMessage.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatMessage.kt
@@ -7,11 +7,14 @@ enum class Role { USER, ASSISTANT }
  * 一条聊天消息。
  *
  * @param content 文本内容；assistant 为 Markdown 源串，渲染时按需解析
+ * @param images 用户随消息发送的图片（压缩后的本地缓存文件路径，仅 USER 消息使用）；
+ *   UI 直接按路径渲染，发送时由 transport 层读文件转 base64 内嵌
  * @param error 非空表示这条 assistant 消息是一次失败（按 [ChatError.category] 区分展示）
  */
 data class ChatMessage(
     val id: Long,
     val role: Role,
     val content: String,
+    val images: List<String> = emptyList(),
     val error: ChatError? = null,
 )

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatUiState.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatUiState.kt
@@ -3,14 +3,16 @@ package whl.trending.chat.model
 /**
  * 聊天页 UI 状态。
  *
- * @param messages   会话消息列表（内存级单会话）
- * @param input      输入框当前文本
- * @param isSending  是否正在等待助手回复（驱动「思考中」指示器与发送按钮禁用）
+ * @param messages      会话消息列表（内存级单会话）
+ * @param input         输入框当前文本
+ * @param pendingImages 待发送图片（压缩后的本地缓存文件路径，随下一条消息发出）
+ * @param isSending     是否正在等待助手回复（驱动「思考中」指示器与发送按钮禁用）
  */
 data class ChatUiState(
     val messages: List<ChatMessage> = emptyList(),
     val input: String = "",
+    val pendingImages: List<String> = emptyList(),
     val isSending: Boolean = false,
 ) {
-    val canSend: Boolean get() = input.isNotBlank() && !isSending
+    val canSend: Boolean get() = (input.isNotBlank() || pendingImages.isNotEmpty()) && !isSending
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatInputBar.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatInputBar.kt
@@ -1,64 +1,304 @@
 package whl.trending.chat.ui
 
+import android.net.Uri
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.PhotoCamera
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import java.io.File
+import kotlinx.coroutines.launch
+import whl.trending.ai.auth.AuthState
+import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.core.platform.trackEvent
+import whl.trending.chat.ChatViewModel
 import whl.trending.chat.R
+import whl.trending.chat.attach.ChatImages
 
-/** 底部输入区：输入框 + 发送按钮。发送中或空白时禁用发送。 */
+/**
+ * 底部输入区：图片入口（拍照/相册）+ 待发缩略图条 + 输入框 + 发送按钮。
+ *
+ * 图片理解仅对登录用户开放：未登录点「+」弹登录引导（服务端另有 403 真闸）。
+ * 选图走系统契约（Photo Picker / TakePicture），Android 13+ 全程零运行时权限。
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ChatInputBar(
     input: String,
     canSend: Boolean,
+    pendingImages: List<String>,
     onInputChange: (String) -> Unit,
     onSend: () -> Unit,
+    onAddImage: (String) -> Unit,
+    onRemoveImage: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val authState by globalAuthManager.authState.collectAsState()
+
+    var menuExpanded by remember { mutableStateOf(false) }
+    var showLoginDialog by remember { mutableStateOf(false) }
+    var processingCount by remember { mutableIntStateOf(0) }
+    var captureTarget by remember { mutableStateOf<Pair<Uri, File>?>(null) }
+
+    val failedText = stringResource(R.string.chat_image_processing_failed)
+    val remaining = ChatViewModel.MAX_IMAGES_PER_MESSAGE - pendingImages.size - processingCount
+
+    fun ingest(uri: Uri, source: String, deleteAfter: File? = null) {
+        processingCount++
+        scope.launch {
+            val path = ChatImages.ingest(context, uri)
+            deleteAfter?.delete()
+            processingCount--
+            if (path != null) {
+                trackEvent("chat_image_add", mapOf("source" to source))
+                onAddImage(path)
+            } else {
+                Toast.makeText(context, failedText, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    val albumLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickMultipleVisualMedia(ChatViewModel.MAX_IMAGES_PER_MESSAGE),
+    ) { uris ->
+        // 选择器允许选满上限，剩余名额不足时截断
+        uris.take(remaining.coerceAtLeast(0)).forEach { ingest(it, source = "album") }
+    }
+
+    val cameraLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.TakePicture(),
+    ) { success ->
+        val target = captureTarget
+        captureTarget = null
+        if (target != null) {
+            if (success) {
+                ingest(Uri.fromFile(target.second), source = "camera", deleteAfter = target.second)
+            } else {
+                target.second.delete()
+            }
+        }
+    }
+
+    if (showLoginDialog) {
+        AlertDialog(
+            onDismissRequest = { showLoginDialog = false },
+            title = { Text(stringResource(R.string.chat_image_login_title)) },
+            text = { Text(stringResource(R.string.chat_image_login_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showLoginDialog = false
+                    trackEvent("chat_image_login_click")
+                    globalAuthManager.signIn()
+                }) {
+                    Text(stringResource(R.string.chat_image_login_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showLoginDialog = false }) {
+                    Text(stringResource(R.string.chat_image_login_dismiss))
+                }
+            },
+        )
+    }
+
     Surface(tonalElevation = 3.dp, modifier = modifier.fillMaxWidth()) {
-        Row(
+        Column(
             // 避让手势导航条与键盘（union 取两者较大值，避免双重叠加）；
             // Surface 背景仍铺到屏幕底边，仅内容上移
             modifier = Modifier.fillMaxWidth()
                 .windowInsetsPadding(WindowInsets.navigationBars.union(WindowInsets.ime))
                 .padding(horizontal = 12.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
         ) {
-            OutlinedTextField(
-                value = input,
-                onValueChange = onInputChange,
-                modifier = Modifier.weight(1f),
-                placeholder = { Text(stringResource(R.string.chat_input_hint)) },
-                maxLines = 5,
-            )
-            IconButton(
-                onClick = onSend,
-                enabled = canSend,
-                modifier = Modifier.padding(start = 8.dp),
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.Send,
-                    contentDescription = stringResource(R.string.chat_send),
-                    tint = if (canSend) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
+            if (pendingImages.isNotEmpty() || processingCount > 0) {
+                PendingImageStrip(
+                    pendingImages = pendingImages,
+                    processingCount = processingCount,
+                    onRemoveImage = onRemoveImage,
+                    modifier = Modifier.padding(bottom = 8.dp),
                 )
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                // 登录能力不可用的构建（如无 auth 渠道）直接隐藏图片入口
+                if (globalAuthManager.isSupported) {
+                    Box {
+                        IconButton(
+                            onClick = {
+                                if (authState !is AuthState.LoggedIn) {
+                                    showLoginDialog = true
+                                } else {
+                                    menuExpanded = true
+                                }
+                            },
+                            enabled = remaining > 0,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Add,
+                                contentDescription = stringResource(R.string.chat_attach),
+                                tint = if (remaining > 0) {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                } else {
+                                    MaterialTheme.colorScheme.outline
+                                },
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = menuExpanded,
+                            onDismissRequest = { menuExpanded = false },
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.chat_attach_camera)) },
+                                leadingIcon = { Icon(Icons.Outlined.PhotoCamera, contentDescription = null) },
+                                onClick = {
+                                    menuExpanded = false
+                                    val target = ChatImages.newCaptureTarget(context)
+                                    captureTarget = target
+                                    // 极少数无相机应用的设备：launch 会抛 ActivityNotFoundException
+                                    runCatching { cameraLauncher.launch(target.first) }
+                                        .onFailure {
+                                            captureTarget = null
+                                            Toast.makeText(context, failedText, Toast.LENGTH_SHORT).show()
+                                        }
+                                },
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.chat_attach_album)) },
+                                leadingIcon = { Icon(Icons.Outlined.Image, contentDescription = null) },
+                                onClick = {
+                                    menuExpanded = false
+                                    albumLauncher.launch(
+                                        PickVisualMediaRequest(
+                                            ActivityResultContracts.PickVisualMedia.ImageOnly,
+                                        ),
+                                    )
+                                },
+                            )
+                        }
+                    }
+                }
+                OutlinedTextField(
+                    value = input,
+                    onValueChange = onInputChange,
+                    modifier = Modifier.weight(1f),
+                    placeholder = { Text(stringResource(R.string.chat_input_hint)) },
+                    maxLines = 5,
+                )
+                IconButton(
+                    onClick = onSend,
+                    enabled = canSend,
+                    modifier = Modifier.padding(start = 8.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.Send,
+                        contentDescription = stringResource(R.string.chat_send),
+                        tint = if (canSend) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** 待发图片缩略图条：可逐张移除；处理中的名额显示 LoadingIndicator 占位。 */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun PendingImageStrip(
+    pendingImages: List<String>,
+    processingCount: Int,
+    onRemoveImage: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(modifier = modifier.fillMaxWidth()) {
+        items(pendingImages, key = { it }) { path ->
+            Box(modifier = Modifier.padding(end = 8.dp)) {
+                AsyncImage(
+                    model = File(path),
+                    contentDescription = stringResource(R.string.chat_user_image),
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(72.dp)
+                        .clip(RoundedCornerShape(12.dp)),
+                )
+                Surface(
+                    color = MaterialTheme.colorScheme.scrim.copy(alpha = 0.6f),
+                    contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                    shape = CircleShape,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(2.dp),
+                ) {
+                    IconButton(
+                        onClick = { onRemoveImage(path) },
+                        modifier = Modifier.size(20.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = stringResource(R.string.chat_image_remove),
+                            modifier = Modifier.size(14.dp),
+                        )
+                    }
+                }
+            }
+        }
+        items(processingCount) {
+            Box(
+                modifier = Modifier
+                    .padding(end = 8.dp)
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(12.dp)),
+                contentAlignment = Alignment.Center,
+            ) {
+                LoadingIndicator(modifier = Modifier.size(24.dp))
             }
         }
     }
@@ -68,6 +308,14 @@ fun ChatInputBar(
 @Composable
 private fun ChatInputBarPreview() {
     MaterialTheme {
-        ChatInputBar(input = "你好", canSend = true, onInputChange = {}, onSend = {})
+        ChatInputBar(
+            input = "你好",
+            canSend = true,
+            pendingImages = emptyList(),
+            onInputChange = {},
+            onSend = {},
+            onAddImage = {},
+            onRemoveImage = {},
+        )
     }
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -119,8 +119,11 @@ fun ChatScreen(
                 ChatInputBar(
                     input = state.input,
                     canSend = state.canSend,
+                    pendingImages = state.pendingImages,
                     onInputChange = viewModel::updateInput,
                     onSend = viewModel::send,
+                    onAddImage = viewModel::addPendingImage,
+                    onRemoveImage = viewModel::removePendingImage,
                 )
             }
         },

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ImageViewerDialog.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ImageViewerDialog.kt
@@ -1,0 +1,107 @@
+package whl.trending.chat.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import coil3.compose.AsyncImage
+import java.io.File
+import whl.trending.chat.R
+
+private const val MIN_SCALE = 1f
+private const val MAX_SCALE = 5f
+private const val DOUBLE_TAP_SCALE = 2.5f
+
+/**
+ * 全屏图片查看器：捏合缩放 + 平移 + 双击放大/还原，单击或关闭按钮退出。
+ * Compose 手势自研，不引第三方 zoom 库。
+ */
+@Composable
+fun ImageViewerDialog(
+    path: String,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        var scale by remember { mutableFloatStateOf(MIN_SCALE) }
+        var offset by remember { mutableStateOf(Offset.Zero) }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+                .pointerInput(Unit) {
+                    detectTransformGestures { _, pan, zoom, _ ->
+                        scale = (scale * zoom).coerceIn(MIN_SCALE, MAX_SCALE)
+                        offset = if (scale > MIN_SCALE) offset + pan else Offset.Zero
+                    }
+                }
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onTap = { onDismiss() },
+                        onDoubleTap = {
+                            if (scale > MIN_SCALE) {
+                                scale = MIN_SCALE
+                                offset = Offset.Zero
+                            } else {
+                                scale = DOUBLE_TAP_SCALE
+                            }
+                        },
+                    )
+                },
+        ) {
+            AsyncImage(
+                model = File(path),
+                contentDescription = stringResource(R.string.chat_user_image),
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        scaleX = scale
+                        scaleY = scale
+                        translationX = offset.x
+                        translationY = offset.y
+                    },
+            )
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .statusBarsPadding()
+                    .padding(8.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(R.string.chat_image_viewer_close),
+                    tint = Color.White,
+                )
+            }
+        }
+    }
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
@@ -3,11 +3,13 @@ package whl.trending.chat.ui
 import android.content.ClipData
 import android.os.Build
 import android.widget.Toast
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -23,15 +25,23 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import java.io.File
 import kotlinx.coroutines.launch
 import whl.trending.ai.core.platform.shareText
 import whl.trending.chat.R
@@ -61,22 +71,73 @@ fun MessageItem(
 
 @Composable
 private fun UserMessage(message: ChatMessage, modifier: Modifier) {
-    Box(modifier = modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
-        Surface(
-            color = MaterialTheme.colorScheme.primaryContainer,
-            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-            shape = RoundedCornerShape(16.dp),
-            modifier = Modifier.widthIn(max = 300.dp),
-        ) {
-            SelectionContainer {
-                Text(
-                    text = message.content,
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
-                )
+    var viewerPath by remember { mutableStateOf<String?>(null) }
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.End,
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        if (message.images.isNotEmpty()) {
+            UserImages(images = message.images, onImageClick = { viewerPath = it })
+        }
+        if (message.content.isNotBlank()) {
+            Surface(
+                color = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                shape = RoundedCornerShape(16.dp),
+                modifier = Modifier.widthIn(max = 300.dp),
+            ) {
+                SelectionContainer {
+                    Text(
+                        text = message.content,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+                    )
+                }
             }
         }
     }
+    viewerPath?.let { path ->
+        ImageViewerDialog(path = path, onDismiss = { viewerPath = null })
+    }
+}
+
+/** 用户消息的图片区：单张放大展示，多张两列网格；点击进全屏查看器。 */
+@Composable
+private fun UserImages(images: List<String>, onImageClick: (String) -> Unit) {
+    if (images.size == 1) {
+        UserImageThumb(
+            path = images[0],
+            onClick = { onImageClick(images[0]) },
+            modifier = Modifier.widthIn(max = 220.dp).heightIn(min = 120.dp, max = 280.dp),
+        )
+        return
+    }
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp), horizontalAlignment = Alignment.End) {
+        images.chunked(2).forEach { row ->
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                row.forEach { path ->
+                    UserImageThumb(
+                        path = path,
+                        onClick = { onImageClick(path) },
+                        modifier = Modifier.size(140.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun UserImageThumb(path: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    AsyncImage(
+        model = File(path),
+        contentDescription = stringResource(R.string.chat_user_image),
+        contentScale = ContentScale.Crop,
+        modifier = modifier
+            .clip(RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick),
+    )
 }
 
 @Composable
@@ -148,6 +209,7 @@ private fun AssistantMessage(message: ChatMessage, onRetry: () -> Unit, modifier
 /** 选具体文案：优先服务端 [ChatError.code]，未知则回落到 [ChatError.category]。 */
 private fun errorMessageRes(error: ChatError): Int = when (error.code) {
     "auth_invalid" -> R.string.chat_error_auth_invalid
+    "images_require_login" -> R.string.chat_error_images_require_login
     "content_too_long" -> R.string.chat_error_content_too_long
     "quota_global" -> R.string.chat_error_quota_global
     ChatError.CODE_QUOTA_DEVICE -> R.string.chat_quota_exceeded

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -43,4 +43,16 @@
     <string name="chat_waitlist_error">提交失败，请稍后重试。</string>
     <string name="chat_beta_badge">Beta</string>
     <string name="chat_quota_notice">实验性功能，每日有限免费额度，用尽次日恢复。</string>
+    <string name="chat_attach">添加图片</string>
+    <string name="chat_attach_camera">拍照</string>
+    <string name="chat_attach_album">从相册选择</string>
+    <string name="chat_image_login_title">登录后可发送图片</string>
+    <string name="chat_image_login_message">图片理解功能对登录用户开放，使用 GitHub 登录即可发送照片和图片。</string>
+    <string name="chat_image_login_confirm">登录</string>
+    <string name="chat_image_login_dismiss">暂不</string>
+    <string name="chat_image_processing_failed">图片处理失败，请换一张试试。</string>
+    <string name="chat_image_remove">移除图片</string>
+    <string name="chat_user_image">图片</string>
+    <string name="chat_image_viewer_close">关闭</string>
+    <string name="chat_error_images_require_login">发送图片需要先登录。</string>
 </resources>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -43,4 +43,16 @@
     <string name="chat_waitlist_error">Submission failed. Please try again later.</string>
     <string name="chat_beta_badge">Beta</string>
     <string name="chat_quota_notice">Experimental feature. Limited free chats each day, resetting tomorrow.</string>
+    <string name="chat_attach">Add image</string>
+    <string name="chat_attach_camera">Take photo</string>
+    <string name="chat_attach_album">Choose from album</string>
+    <string name="chat_image_login_title">Sign in to send images</string>
+    <string name="chat_image_login_message">Image understanding is available to signed-in users. Sign in with GitHub to send photos and pictures.</string>
+    <string name="chat_image_login_confirm">Sign in</string>
+    <string name="chat_image_login_dismiss">Not now</string>
+    <string name="chat_image_processing_failed">Couldn\'t process the image. Please try another one.</string>
+    <string name="chat_image_remove">Remove image</string>
+    <string name="chat_user_image">Image</string>
+    <string name="chat_image_viewer_close">Close</string>
+    <string name="chat_error_images_require_login">Sign in to send images.</string>
 </resources>

--- a/androidLibrary/chat/src/main/res/xml/chat_file_paths.xml
+++ b/androidLibrary/chat/src/main/res/xml/chat_file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 聊天图片专用缓存目录：拍照输出与压缩产物都在这里，24h 自动清理 -->
+<paths>
+    <cache-path name="chat_images" path="chat_images/" />
+</paths>

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatWireTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatWireTest.kt
@@ -1,0 +1,120 @@
+package whl.trending.chat.engine
+
+import kotlin.io.encoding.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.Role
+
+class ChatWireTest {
+
+    private val bytes = byteArrayOf(1, 2, 3)
+    private val reader: (String) -> ByteArray? = { path -> if (path.startsWith("ok")) bytes else null }
+
+    private fun user(id: Long, text: String, images: List<String> = emptyList()) =
+        ChatMessage(id, Role.USER, text, images = images)
+
+    @Test
+    fun `纯文本消息 content 仍是 JSON string`() {
+        val element = ChatWire.buildContent(user(1, "hi"), isLast = true, imagePlaceholder = "[图片]", readImageBytes = reader)
+        assertEquals(JsonPrimitive("hi"), element)
+    }
+
+    @Test
+    fun `末条 user 带图转 parts 数组，文本在前图片在后`() {
+        val element = ChatWire.buildContent(
+            user(1, "这是什么", images = listOf("ok1.jpg", "ok2.jpg")),
+            isLast = true,
+            imagePlaceholder = "[图片]",
+            readImageBytes = reader,
+        )
+        val parts = element.jsonArray
+        assertEquals(3, parts.size)
+        assertEquals("text", parts[0].jsonObject["type"]!!.jsonPrimitive.content)
+        assertEquals("这是什么", parts[0].jsonObject["text"]!!.jsonPrimitive.content)
+        assertEquals("image_url", parts[1].jsonObject["type"]!!.jsonPrimitive.content)
+        assertEquals(
+            "data:image/jpeg;base64," + Base64.encode(bytes),
+            parts[1].jsonObject["image_url"]!!.jsonObject["url"]!!.jsonPrimitive.content,
+        )
+    }
+
+    @Test
+    fun `纯图无文本时 parts 里没有 text 部分`() {
+        val element = ChatWire.buildContent(
+            user(1, "", images = listOf("ok1.jpg")),
+            isLast = true,
+            imagePlaceholder = "[图片]",
+            readImageBytes = reader,
+        )
+        val parts = element.jsonArray
+        assertEquals(1, parts.size)
+        assertEquals("image_url", parts[0].jsonObject["type"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `历史带图消息降级为文本加占位，不重传 base64`() {
+        val element = ChatWire.buildContent(
+            user(1, "看这张", images = listOf("ok1.jpg", "ok2.jpg")),
+            isLast = false,
+            imagePlaceholder = "[图片]",
+            readImageBytes = reader,
+        )
+        assertEquals(JsonPrimitive("看这张 [图片][图片]"), element)
+    }
+
+    @Test
+    fun `历史纯图消息降级为占位文本`() {
+        val element = ChatWire.buildContent(
+            user(1, "", images = listOf("ok1.jpg")),
+            isLast = false,
+            imagePlaceholder = "[image]",
+            readImageBytes = reader,
+        )
+        assertEquals(JsonPrimitive("[image]"), element)
+    }
+
+    @Test
+    fun `图片文件读取失败则跳过该张`() {
+        val element = ChatWire.buildContent(
+            user(1, "hi", images = listOf("missing.jpg", "ok1.jpg")),
+            isLast = true,
+            imagePlaceholder = "[图片]",
+            readImageBytes = reader,
+        )
+        val parts = element.jsonArray
+        assertEquals(2, parts.size) // text + 1 张成功的图
+    }
+
+    @Test
+    fun `全部图片读取失败且无文本时兜底占位文本部分`() {
+        val element = ChatWire.buildContent(
+            user(1, "", images = listOf("missing.jpg")),
+            isLast = true,
+            imagePlaceholder = "[图片]",
+            readImageBytes = reader,
+        )
+        val parts = element.jsonArray
+        assertEquals(1, parts.size)
+        assertEquals("text", parts[0].jsonObject["type"]!!.jsonPrimitive.content)
+        assertEquals("[图片]", parts[0].jsonObject["text"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `超过 4 张只取前 4 张`() {
+        val element = ChatWire.buildContent(
+            user(1, "", images = List(6) { "ok$it.jpg" }),
+            isLast = true,
+            imagePlaceholder = "[图片]",
+            readImageBytes = reader,
+        )
+        assertTrue(element is JsonArray)
+        assertEquals(4, element.jsonArray.size)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ android-targetSdk = "36"
 androidx-activity = "1.13.0"
 androidx-appcompat = "1.7.1"
 androidx-browser = "1.10.0"
+androidx-core = "1.17.0"
+androidx-exifinterface = "1.4.1"
 
 # 💡 注意：此版本号由 Google (androidx.*) 与 JetBrains (org.jetbrains.androidx.*) 共用。
 # 由于两者的发布节奏并不完全同步，升级前需确认该版本在 Google Maven 与 JetBrains 仓库中均已发布。
@@ -38,6 +40,8 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "androidx-browser" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "androidx-exifinterface" }
 jetbrains-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "multiplatform-nav3-ui" }
 jetbrains-navigationevent-compose = { module = "org.jetbrains.androidx.navigationevent:navigationevent-compose", version.ref = "multiplatform-navigationevent" }
 compose-uiTooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "composeMultiplatform" }


### PR DESCRIPTION
## 概要

AI 助手聊天支持发图做图片理解：拍照 + 相册（Photo Picker），仅登录用户可用。选型对齐 AIChatProjects 反编译调研结论（Claude 系统契约路线 + base64 内嵌）。

## 改动

- **选图入口**：输入栏「+」→ 拍照（`TakePicture` + 专属 `ChatFileProvider`）/ 相册（`PickMultipleVisualMedia`，≤4 张）；Android 13+ 全程零运行时权限。未登录点击弹登录引导（服务端另有 403 真闸）
- **预处理**（`ChatImages`）：采样解码 + EXIF 方向归一化 + 长边 ≤1568px + JPEG q80 重编码，剥除全部 EXIF（含 GPS）；产物落私有缓存，24h 自动清理
- **wire 层**（`ChatWire`，纯函数）：末条 user 消息转 OpenAI 多模态 parts（base64 data-url），历史带图消息降级「[图片]」占位不重传；纯文本请求行为零变化
- **展示**：气泡内 Coil 3 缩略图（单张大图/多张两列网格）+ 自研捏合缩放全屏查看器
- FileProvider 用专属子类 + `.chat.fileprovider` authority，避免与 kmp-webview 的 provider 在 manifest merger 撞车
- 埋点：`chat_image_add`（source=camera|album）、`chat_send_with_images`（image_count）

## 测试

- `ChatWireTest` 8 用例全绿（parts 组装 / 历史降级 / 读文件失败兜底 / 上限截断）
- Pixel_9_2 模拟器实测：登录引导弹窗、拍照全链路、相册全链路、缩略图条增删；压缩产物 1176×1568、无 EXIF、临时文件已清理

## 依赖

发送带图需后端先合并部署 HarlonWang/github-ai-trending-api#14 并执行 D1 migration，否则服务端 400。

设计文档：TrendingProjects/docs/superpowers/specs/2026-07-09-chat-image-input-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

为聊天功能添加图片发送与查看支持，包括拍摄、从相册选择、预处理，以及多模态 API 接入，并仅对已登录用户开放。

New Features:
- 允许用户通过相机拍摄或图片选择器，在每条聊天消息中附加最多四张预处理过的图片，并在输入栏显示待发送缩略图条。
- 在聊天消息中支持按消息级别的图片元数据，并将用户图片以缩略图形式展示，提供全屏查看和双指缩放功能。
- 将图片附件集成到聊天传输层，通过将最新的用户消息编码为 OpenAI 风格的多模态内容，同时保持其他消息的纯文本行为。

Enhancements:
- 更新聊天 UI 状态和发送逻辑，使消息可以仅携带图片或同时携带文本和图片发送，并记录相应的追踪事件。
- 为图片附件流程添加本地化文案和错误消息，包括登录要求和处理失败提示。

Build:
- 添加对 core-ktx、ExifInterface 和 Coil Compose 的依赖，以支持图片 IO、EXIF 处理和缩略图渲染。

Deployment:
- 在 Android manifest 中注册聊天专用的 FileProvider 和 XML 路径配置，以安全处理相机输出，避免与其他 Provider 冲突。

Tests:
- 增加 ChatWire 单元测试，用于验证多模态内容组装、历史图片降级、文件读取失败以及图片数量上限等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add image sending and viewing support to chat, including capture, album selection, preprocessing, and multimodal API wiring, gated to signed-in users.

New Features:
- Allow users to attach up to four preprocessed images per chat message via camera capture or photo picker, with a pending thumbnail strip in the input bar.
- Support per-message image metadata in chat messages and render user images as thumbnails with a full-screen pinch-to-zoom viewer.
- Integrate image attachments into the chat transport layer by encoding the latest user message as OpenAI-style multimodal content while preserving text-only behavior for other messages.

Enhancements:
- Update chat UI state and sending logic so messages can be sent with images only or with combined text and images, with appropriate tracking events.
- Add localized strings and error messaging for image attachment flows, including login requirements and processing failures.

Build:
- Add dependencies for core-ktx, ExifInterface, and Coil Compose to support image IO, EXIF handling, and thumbnail rendering.

Deployment:
- Register a chat-specific FileProvider and XML path config in the Android manifest for safe camera output handling without clashing with other providers.

Tests:
- Introduce ChatWire unit tests that verify multimodal content assembly, history image downgrading, file read failures, and image count limits.

</details>