### PR TITLE
feat(chat): 一键详细解读 + 全链路流式渲染

### DIFF
--- a/androidLibrary/chat/build.gradle.kts
+++ b/androidLibrary/chat/build.gradle.kts
@@ -46,4 +46,5 @@ dependencies {
 
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlin.test.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -17,19 +17,23 @@ import whl.trending.chat.model.ChatError
 import whl.trending.chat.model.ChatErrorCategory
 import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.ChatUiState
+import whl.trending.chat.model.MessageKind
 import whl.trending.chat.model.Role
 
 /**
- * 聊天 ViewModel：内存级单会话。通过 [engine] 注入实现 Demo / 正式切换。
+ * 聊天 ViewModel：内存级单会话，流式渲染（发送先追加空 assistant 占位，delta 到达增量更新）。
+ * 通过 [engine] 注入实现 Demo / 正式切换。
  *
  * @param loadModels 模型目录拉取，注入点（便于测试替身）；默认走 [ChatModelsProvider] 的进程级缓存，
  *   避免每个会话都网络冷拉取导致选择器 chip 迟迟不出现（见冷首拉根因）。
+ * @param track 埋点注入点（便于测试替身），默认 [trackEvent]。
  */
 class ChatViewModel(
     private val engine: ChatEngine,
     private val context: ChatContext? = null,
     initialMessages: List<ChatMessage> = emptyList(),
     private val loadModels: suspend () -> List<ChatModelOption> = { ChatModelsProvider.get() },
+    private val track: (String, Map<String, String>) -> Unit = { name, props -> trackEvent(name, props) },
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ChatUiState(messages = initialMessages))
@@ -76,16 +80,28 @@ class ChatViewModel(
     /** 发送一段指定文本（如快捷按钮的预设问题），不依赖输入框；发送中或空白则忽略。 */
     fun sendText(text: String) = sendMessage(text, emptyList())
 
+    /**
+     * 「一键详细解读」：插入一条 user 消息（chip 文案），走 detail 管线流式生成解读。
+     * 可见性由 [DetailSummaryPolicy] 保证（GitHub 条目 + README 达标 + 尚无成功解读）。
+     */
+    fun sendDetailSummary(promptText: String) {
+        if (_uiState.value.isSending || context?.externalId == null) return
+        track("detail_summary_generate", mapOf("from" to "chat"))
+        val userMessage = ChatMessage(nextId(), Role.USER, promptText, kind = MessageKind.DETAIL_SUMMARY)
+        _uiState.update { it.copy(messages = it.messages + userMessage, isSending = true) }
+        launchRequest(MessageKind.DETAIL_SUMMARY)
+    }
+
     private fun sendMessage(text: String, images: List<String>) {
         if (_uiState.value.isSending || (text.isBlank() && images.isEmpty())) return
         if (images.isNotEmpty()) {
-            trackEvent("chat_send_with_images", mapOf("image_count" to images.size.toString()))
+            track("chat_send_with_images", mapOf("image_count" to images.size.toString()))
         }
         val userMessage = ChatMessage(nextId(), Role.USER, text, images = images)
         _uiState.update {
             it.copy(messages = it.messages + userMessage, isSending = true)
         }
-        request()
+        launchRequest(MessageKind.CHAT)
     }
 
     companion object {
@@ -93,31 +109,92 @@ class ChatViewModel(
         const val MAX_IMAGES_PER_MESSAGE = 4
     }
 
-    /** 对可重试的失败消息重试：移除该错误条，按当前历史重新请求。
-     *  quota_device 例外放行：匿名触顶后完成登录，配额键已切换，重发即可续聊。 */
+    /** 对可重试的失败消息重试：移除该错误条，按消息 [MessageKind] 路由回对应管线。
+     *  quota_device / login_required 例外放行：触顶或登录闸之后完成登录，重发即可继续。 */
     fun retry(message: ChatMessage) {
         val error = message.error ?: return
-        if (!error.category.retryable && error.code != ChatError.CODE_QUOTA_DEVICE) return
+        val passthrough = error.code == ChatError.CODE_QUOTA_DEVICE ||
+            error.code == ChatError.CODE_LOGIN_REQUIRED
+        if (!error.category.retryable && !passthrough) return
         _uiState.update {
             it.copy(messages = it.messages.filterNot { m -> m.id == message.id }, isSending = true)
         }
-        request()
+        launchRequest(message.kind)
     }
 
-    private fun request() = viewModelScope.launch {
-        val result = runCatching { engine.send(_uiState.value.messages, context) }
-        val assistant = result.fold(
-            onSuccess = { ChatMessage(nextId(), Role.ASSISTANT, it) },
+    /**
+     * 统一请求路径：先追加空 assistant 占位消息，delta 到达时增量更新其 content；
+     * 成功以全文定稿，失败清空已渲染部分（整条重试）并挂上分类错误。
+     */
+    private fun launchRequest(kind: MessageKind) = viewModelScope.launch {
+        val placeholderId = nextId()
+        _uiState.update {
+            it.copy(messages = it.messages + ChatMessage(placeholderId, Role.ASSISTANT, "", kind = kind))
+        }
+        val result = runCatching {
+            when (kind) {
+                MessageKind.CHAT -> {
+                    val history = _uiState.value.messages.filterNot { it.id == placeholderId }
+                    engine.send(history, context) { delta -> appendDelta(placeholderId, delta) }
+                }
+                MessageKind.DETAIL_SUMMARY -> {
+                    val detail = engine.sendDetailSummary(requireNotNull(context)) { delta ->
+                        appendDelta(placeholderId, delta)
+                    }
+                    if (detail.cached) track("detail_summary_cache_hit", mapOf("from" to "chat"))
+                    detail.content
+                }
+            }
+        }
+        result.fold(
+            onSuccess = { full ->
+                _uiState.update { st ->
+                    st.copy(
+                        messages = st.messages.map { m ->
+                            if (m.id == placeholderId) m.copy(content = full) else m
+                        },
+                        isSending = false,
+                    )
+                }
+            },
             onFailure = { e ->
                 val error = (e as? ChatException)?.error
                     ?: ChatError(ChatErrorCategory.UNKNOWN, detail = e.toString())
-                // 付费意愿漏斗第一级：个人配额触顶（在 VM 记一次，避免 UI 重组重复上报）
-                if (error.code == ChatError.CODE_QUOTA_DEVICE) {
-                    trackEvent("chat_quota_hit", mapOf("tier" to (error.tier ?: ChatError.TIER_ANONYMOUS)))
+                trackFailure(kind, error)
+                _uiState.update { st ->
+                    st.copy(
+                        // 已渲染部分丢弃，整条重试（中途断流语义）
+                        messages = st.messages.map { m ->
+                            if (m.id == placeholderId) m.copy(content = "", error = error) else m
+                        },
+                        isSending = false,
+                    )
                 }
-                ChatMessage(nextId(), Role.ASSISTANT, "", error = error)
             },
         )
-        _uiState.update { it.copy(messages = it.messages + assistant, isSending = false) }
+    }
+
+    private fun appendDelta(messageId: Long, delta: String) {
+        _uiState.update { st ->
+            st.copy(
+                messages = st.messages.map { m ->
+                    if (m.id == messageId) m.copy(content = m.content + delta) else m
+                },
+            )
+        }
+    }
+
+    private fun trackFailure(kind: MessageKind, error: ChatError) {
+        when {
+            // 付费意愿漏斗第一级：个人配额触顶（在 VM 记一次，避免 UI 重组重复上报）
+            error.code == ChatError.CODE_QUOTA_DEVICE -> {
+                val event = if (kind == MessageKind.DETAIL_SUMMARY) "detail_summary_quota_hit" else "chat_quota_hit"
+                track(event, mapOf("tier" to (error.tier ?: ChatError.TIER_ANONYMOUS)))
+            }
+            // 登录转化关键信号：匿名点了未缓存条目的解读
+            error.code == ChatError.CODE_LOGIN_REQUIRED && kind == MessageKind.DETAIL_SUMMARY -> {
+                track("detail_summary_login_required", mapOf("from" to "chat"))
+            }
+        }
     }
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/DetailSummaryPolicy.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/DetailSummaryPolicy.kt
@@ -1,0 +1,32 @@
+package whl.trending.chat
+
+import whl.trending.ai.chat.ChatContext
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.MessageKind
+import whl.trending.chat.model.Role
+
+/**
+ * 「一键详细解读」chip 的可见性策略（纯函数）。
+ *
+ * 显示条件（同时满足）：GitHub 条目入口、README 长度达标（null 不显示，宁缺勿滥）、
+ * 会话尚无成功的解读消息。满足即常驻（不同于介绍 chip 的「messages 为空才显示」），
+ * 生成成功一次后隐藏；失败消息不算成功，可重新触发。
+ */
+object DetailSummaryPolicy {
+
+    const val SOURCE_GITHUB = "github"
+
+    /** 短 README 阈值，与服务端 detail-summary 的 GITHUB_MIN_README_CHARS 同源约定 */
+    const val MIN_README_CHARS = 1500
+
+    fun chipVisible(context: ChatContext?, messages: List<ChatMessage>): Boolean {
+        if (context?.source != SOURCE_GITHUB || context.externalId.isNullOrBlank()) return false
+        if ((context.readmeLength ?: 0) < MIN_README_CHARS) return false
+        return messages.none {
+            it.kind == MessageKind.DETAIL_SUMMARY &&
+                it.role == Role.ASSISTANT &&
+                it.error == null &&
+                it.content.isNotBlank()
+        }
+    }
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -65,19 +65,21 @@ class ChatApi(
 
     /** content 两态：纯文本为 JSON string；末条带图 user 消息为 OpenAI 多模态 parts 数组 */
     @Serializable
-    private data class WireMessage(val role: String, val content: JsonElement)
+    internal data class WireMessage(val role: String, val content: JsonElement)
 
+    /** internal 供 wire 序列化测试直接构造；stream 故意**不带默认值**——
+     *  encodeDefaults=false 下「值等于默认值的属性会被省略」，曾让 "stream":true 静默消失 */
     @Serializable
-    private data class ChatRequest(
+    internal data class ChatRequest(
         val messages: List<WireMessage>,
         val lang: String,
         val context: WireContext? = null,
         val model: String? = null,
-        val stream: Boolean = true,
+        val stream: Boolean,
     )
 
     @Serializable
-    private data class WireContext(
+    internal data class WireContext(
         val title: String,
         val summary: String? = null,
         val sourceUrl: String? = null,
@@ -148,6 +150,7 @@ class ChatApi(
                         globalSettingsManager.currentSelectedChatModel(),
                         globalSettingsManager.currentIsPro(),
                     ),
+                    stream = true,
                 ),
             )
         }.content

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -1,22 +1,26 @@
 package whl.trending.chat.engine
 
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.timeout
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
-import io.ktor.client.request.post
+import io.ktor.client.request.preparePost
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsChannel
 import io.ktor.client.statement.bodyAsText
 import android.util.Log
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.readUTF8Line
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -30,17 +34,19 @@ import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.resolveEffectiveChatModel
 import whl.trending.ai.data.repository.ChatModelsProvider
 import whl.trending.chat.model.ChatError
+import whl.trending.chat.model.ChatErrorCategory
 import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.Role
 
 private const val TAG = "ChatApi"
 
 /**
- * 正式聊天引擎：POST 到 api.trendingai.cn，后端转 ChatGPT，返回整段 Markdown（非流式）。
+ * 正式聊天引擎：POST 到 api.trendingai.cn，后端转 ChatGPT，SSE 流式返回（`stream: true`）。
  *
  * - 透传 `X-Install-Id`（后端限流维度）
  * - 透传 `lang`（由 [AppLanguage] 解析，仅 zh 用中文，其余 en）
- * - 所有失败（HTTP 非 2xx / 传输异常）统一归类为 [ChatException]，由 [ChatErrors] 分类
+ * - chat 与 detail-summary 共用同一 SSE 解析路径（[ChatSse]），缓存命中一次性推完也走同一格式
+ * - 所有失败（HTTP 非 2xx / 传输异常 / 中途断流）统一归类为 [ChatException]，由 [ChatErrors] 分类
  */
 class ChatApi(
     private val baseUrl: String = "https://api.trendingai.cn/api",
@@ -52,6 +58,9 @@ class ChatApi(
          * 各会话线（keyed ChatViewModel）共用同一 engine，避免反复新建且从不关闭的泄漏。
          */
         val shared: ChatEngine by lazy { ChatApi() }
+
+        /** 流式请求总时长上限：生成 2500~4000 字解读可能远超普通请求，放到 5 分钟 */
+        private const val STREAM_REQUEST_TIMEOUT_MS = 300_000L
     }
 
     /** content 两态：纯文本为 JSON string；末条带图 user 消息为 OpenAI 多模态 parts 数组 */
@@ -64,6 +73,7 @@ class ChatApi(
         val lang: String,
         val context: WireContext? = null,
         val model: String? = null,
+        val stream: Boolean = true,
     )
 
     @Serializable
@@ -71,6 +81,13 @@ class ChatApi(
         val title: String,
         val summary: String? = null,
         val sourceUrl: String? = null,
+    )
+
+    @Serializable
+    private data class DetailSummaryRequest(
+        val source: String,
+        @SerialName("external_id") val externalId: String,
+        val lang: String,
     )
 
     @Serializable
@@ -90,86 +107,147 @@ class ChatApi(
             json(json)
         }
         install(HttpTimeout) {
-            // 非流式等待较久，放宽超时
             requestTimeoutMillis = 60_000
             connectTimeoutMillis = 15_000
-            // OkHttp 引擎默认 readTimeout=10s，会在等响应头阶段掐断慢的非流式回复，必须显式放宽
+            // OkHttp 引擎默认 readTimeout=10s；流式场景它约束的是「相邻数据块间隔」，放宽到 60s
             socketTimeoutMillis = 60_000
         }
     }
 
-    override suspend fun send(history: List<ChatMessage>, context: ChatContext?): String {
+    override suspend fun send(
+        history: List<ChatMessage>,
+        context: ChatContext?,
+        onDelta: (String) -> Unit,
+    ): String {
+        val lang = resolveLang()
+        val imagePlaceholder = if (lang == "zh") "[图片]" else "[image]"
+        return executeStreaming(path = "chat", onDelta = onDelta) {
+            setBody(
+                ChatRequest(
+                    messages = history.mapIndexed { index, m ->
+                        WireMessage(
+                            role = if (m.role == Role.USER) "user" else "assistant",
+                            content = ChatWire.buildContent(
+                                message = m,
+                                isLast = index == history.lastIndex,
+                                imagePlaceholder = imagePlaceholder,
+                                readImageBytes = { path ->
+                                    runCatching { File(path).readBytes() }.getOrNull()
+                                },
+                            ),
+                        )
+                    },
+                    lang = lang,
+                    context = context?.let {
+                        WireContext(it.title, it.summary, it.sourceUrl)
+                    },
+                    // 发送前按目录缓存解析实际生效模型（与选择器同一套判定），避免选择器未挂载时
+                    // 把过期的 Pro 专属选择原样发出；目录未拉到则透传，服务端仍按 tier 强制兜底
+                    model = resolveEffectiveChatModel(
+                        ChatModelsProvider.cachedOrEmpty(),
+                        globalSettingsManager.currentSelectedChatModel(),
+                        globalSettingsManager.currentIsPro(),
+                    ),
+                ),
+            )
+        }.content
+    }
+
+    override suspend fun sendDetailSummary(
+        context: ChatContext,
+        onDelta: (String) -> Unit,
+    ): DetailSummaryResult {
+        val source = requireNotNull(context.source) { "detail summary requires context.source" }
+        val externalId = requireNotNull(context.externalId) { "detail summary requires context.externalId" }
+        val lang = resolveLang()
+        return executeStreaming(path = "detail-summary", onDelta = onDelta) {
+            setBody(DetailSummaryRequest(source = source, externalId = externalId, lang = lang))
+        }
+    }
+
+    /**
+     * 共用的流式执行路径：POST → 非 2xx 走 JSON 错误分类；2xx SSE 逐行解析 delta/done；
+     * 2xx 非 SSE（服务端降级非流式）整段作为一个 delta 兜底。
+     * 流在 done 之前结束视为中途断流 → SERVER 可重试，已渲染部分由调用方丢弃。
+     */
+    private suspend fun executeStreaming(
+        path: String,
+        onDelta: (String) -> Unit,
+        configure: HttpRequestBuilder.() -> Unit,
+    ): DetailSummaryResult {
         try {
             // 发送时的登录自认知：与 429 的 tier=anonymous 对照可识别「token 缺失/被拒被静默降级」
             val sentAsLoggedIn = globalAuthManager.authState.value is AuthState.LoggedIn
-            val lang = resolveLang()
-            val imagePlaceholder = if (lang == "zh") "[图片]" else "[image]"
-            val response: HttpResponse = client.post("$baseUrl/chat") {
+            return client.preparePost("$baseUrl/$path") {
                 header("X-Install-Id", globalSettingsManager.getOrCreateInstallId())
-                // 已登录则带 token 走登录档配额（每日 10 条）；token 无效时服务端静默降级匿名档
+                // 已登录则带 token 走登录档配额；detail 生成仅登录档开放（服务端真闸）
                 globalAuthManager.getAccessToken()?.let { header("Authorization", "Bearer $it") }
                 contentType(ContentType.Application.Json)
-                setBody(
-                    ChatRequest(
-                        messages = history.mapIndexed { index, m ->
-                            WireMessage(
-                                role = if (m.role == Role.USER) "user" else "assistant",
-                                content = ChatWire.buildContent(
-                                    message = m,
-                                    isLast = index == history.lastIndex,
-                                    imagePlaceholder = imagePlaceholder,
-                                    readImageBytes = { path ->
-                                        runCatching { File(path).readBytes() }.getOrNull()
-                                    },
-                                ),
-                            )
-                        },
-                        lang = lang,
-                        context = context?.let {
-                            WireContext(it.title, it.summary, it.sourceUrl)
-                        },
-                        // 发送前按目录缓存解析实际生效模型（与选择器同一套判定），避免选择器未挂载时
-                        // 把过期的 Pro 专属选择原样发出；目录未拉到则透传，服务端仍按 tier 强制兜底
-                        model = resolveEffectiveChatModel(
-                            ChatModelsProvider.cachedOrEmpty(),
-                            globalSettingsManager.currentSelectedChatModel(),
-                            globalSettingsManager.currentIsPro(),
-                        ),
+                timeout { requestTimeoutMillis = STREAM_REQUEST_TIMEOUT_MS }
+                configure()
+            }.execute { response ->
+                if (response.status != HttpStatusCode.OK) {
+                    throw toChatException(response, sentAsLoggedIn)
+                }
+                if (response.contentType()?.match(ContentType.Text.EventStream) != true) {
+                    // 服务端降级为非流式 JSON（spec 的 SSE 兜底路径）
+                    val content = json.decodeFromString<ChatResponse>(response.bodyAsText()).content
+                    onDelta(content)
+                    return@execute DetailSummaryResult(content, cached = false)
+                }
+                val channel = response.bodyAsChannel()
+                val full = StringBuilder()
+                var done: ChatSse.Event.Done? = null
+                while (done == null) {
+                    val line = channel.readUTF8Line() ?: break
+                    when (val event = ChatSse.parseLine(line)) {
+                        is ChatSse.Event.Delta -> {
+                            full.append(event.text)
+                            onDelta(event.text)
+                        }
+                        is ChatSse.Event.Done -> done = event
+                        null -> Unit
+                    }
+                }
+                val finished = done ?: throw ChatException(
+                    ChatError(
+                        ChatErrorCategory.SERVER,
+                        code = "stream_interrupted",
+                        detail = "stream ended before done event",
                     ),
                 )
+                DetailSummaryResult(full.toString(), finished.cached)
             }
-
-            if (response.status == HttpStatusCode.OK) {
-                return response.body<ChatResponse>().content
-            }
-
-            // 非 2xx：取服务端 error 文案 + 机器码，按状态码分类
-            val raw = runCatching { response.bodyAsText() }.getOrNull()
-            val parsed = raw?.let { runCatching { json.decodeFromString<ErrorResponse>(it) }.getOrNull() }
-            val bodyError = parsed?.error ?: raw
-            throw ChatException(
-                ChatErrors.markAuthDegraded(
-                    ChatErrors.forStatus(response.status.value, parsed?.code, bodyError, parsed?.tier),
-                    sentAsLoggedIn,
-                ),
-            )
         } catch (e: ChatException) {
-            logFailure(e.error)
+            logFailure(path, e.error)
             throw e
         } catch (e: CancellationException) {
             throw e // 不吞协程取消
         } catch (e: Throwable) {
-            // 传输异常（超时/断网等）
+            // 传输异常（超时/断网/流中断等）
             val error = ChatErrors.forThrowable(e)
-            logFailure(error)
+            logFailure(path, error)
             throw ChatException(error)
         }
     }
 
-    private fun logFailure(error: ChatError) {
+    /** 非 2xx：取服务端 error 文案 + 机器码，按状态码分类 */
+    private suspend fun toChatException(response: HttpResponse, sentAsLoggedIn: Boolean): ChatException {
+        val raw = runCatching { response.bodyAsText() }.getOrNull()
+        val parsed = raw?.let { runCatching { json.decodeFromString<ErrorResponse>(it) }.getOrNull() }
+        val bodyError = parsed?.error ?: raw
+        return ChatException(
+            ChatErrors.markAuthDegraded(
+                ChatErrors.forStatus(response.status.value, parsed?.code, bodyError, parsed?.tier),
+                sentAsLoggedIn,
+            ),
+        )
+    }
+
+    private fun logFailure(path: String, error: ChatError) {
         Log.w(
             TAG,
-            "send failed: category=${error.category} code=${error.code} " +
+            "$path failed: category=${error.category} code=${error.code} " +
                 "status=${error.httpStatus} detail=${error.detail}",
         )
     }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatEngine.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatEngine.kt
@@ -3,17 +3,39 @@ package whl.trending.chat.engine
 import whl.trending.ai.chat.ChatContext
 import whl.trending.chat.model.ChatMessage
 
+/** 一次详细解读请求的结果：全文 + 是否缓存命中（驱动 detail_summary_cache_hit 埋点）。 */
+data class DetailSummaryResult(val content: String, val cached: Boolean)
+
 /**
  * 聊天引擎抽象。Demo 注入 [whl.trending.chat.sample.FakeChatEngine]，
- * 正式注入 [ChatApi]，UI 层零改动即可切换。
+ * 正式注入 [ChatApi]，UI 层零改动即可切换。两个方法均为流式：
+ * [onDelta] 随增量到达被调用（调用线程不保证），返回值是最终全文。
  */
 interface ChatEngine {
     /**
-     * 发送一轮对话，返回助手回复（Markdown 源串）。
+     * 发送一轮对话，流式返回助手回复（Markdown 源串）。
      *
-     * @param history 截至当前的完整消息历史（含本轮用户消息）
+     * @param history 截至当前的完整消息历史（含本轮用户消息，不含流式占位）
      * @param context 可选初始上下文
-     * @throws ChatException 任何失败（HTTP 非 2xx / 传输异常），携带分类后的 [whl.trending.chat.model.ChatError]
+     * @param onDelta 增量回调，按到达顺序携带片段文本
+     * @throws ChatException 任何失败（HTTP 非 2xx / 传输异常 / 中途断流），携带分类后的
+     *   [whl.trending.chat.model.ChatError]；中途断流按可重试处理，已渲染部分由调用方丢弃
      */
-    suspend fun send(history: List<ChatMessage>, context: ChatContext?): String
+    suspend fun send(
+        history: List<ChatMessage>,
+        context: ChatContext?,
+        onDelta: (String) -> Unit = {},
+    ): String
+
+    /**
+     * 请求「一键详细解读」（`POST /api/detail-summary`），流式返回解读全文。
+     * 缓存命中时服务端以同一 SSE 格式一次性推完，[DetailSummaryResult.cached] 为 true。
+     *
+     * @param context 必须携带 source/externalId（[whl.trending.chat.DetailSummaryPolicy] 已保证）
+     * @throws ChatException 失败分类同 [send]；403 `login_required` 为登录闸（匿名生成不可用）
+     */
+    suspend fun sendDetailSummary(
+        context: ChatContext,
+        onDelta: (String) -> Unit = {},
+    ): DetailSummaryResult
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatSse.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatSse.kt
@@ -1,0 +1,35 @@
+package whl.trending.chat.engine
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * SSE 行解析（纯函数，便于单测）。事件协议与 Worker 端 `lib/sse.js` 一一对应：
+ * `data: {"delta":"..."}` 增量、`data: {"done":true}` 收尾（可带 `cached` 元信息）。
+ * 无法识别的行一律返回 null（容忍 keep-alive 注释与脏行）。
+ */
+internal object ChatSse {
+
+    sealed interface Event {
+        data class Delta(val text: String) : Event
+        data class Done(val cached: Boolean) : Event
+    }
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun parseLine(line: String): Event? {
+        val trimmed = line.trim()
+        if (!trimmed.startsWith("data:")) return null
+        val payload = trimmed.removePrefix("data:").trim()
+        if (payload.isEmpty()) return null
+        val obj = runCatching { json.parseToJsonElement(payload).jsonObject }.getOrNull() ?: return null
+        (obj["delta"] as? JsonPrimitive)?.contentOrNull?.let { return Event.Delta(it) }
+        if ((obj["done"] as? JsonPrimitive)?.booleanOrNull == true) {
+            return Event.Done(cached = (obj["cached"] as? JsonPrimitive)?.booleanOrNull == true)
+        }
+        return null
+    }
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatError.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatError.kt
@@ -40,5 +40,9 @@ data class ChatError(
 
         /** 个人配额触顶的机器码（服务端 chat.js quotaError）；重试放行与专属卡片选择都以它为判据 */
         const val CODE_QUOTA_DEVICE = "quota_device"
+
+        /** 详细解读登录闸的机器码（服务端 detail-summary，403）：匿名点未缓存条目 → 登录卡转化，
+         *  登录成功后与 quota_device 同样享受 retry 放行例外 */
+        const val CODE_LOGIN_REQUIRED = "login_required"
     }
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatMessage.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatMessage.kt
@@ -4,12 +4,20 @@ package whl.trending.chat.model
 enum class Role { USER, ASSISTANT }
 
 /**
+ * 消息由哪条管线生成：驱动 chip 可见性与 retry 路由（解读失败重试回 detail 管线），渲染无差别。
+ * 若未来新增 kind 需要消息级再生成参数或差异化渲染，届时再升级为 sealed interface——
+ * 会话仅内存存储，重构无兼容成本。
+ */
+enum class MessageKind { CHAT, DETAIL_SUMMARY }
+
+/**
  * 一条聊天消息。
  *
  * @param content 文本内容；assistant 为 Markdown 源串，渲染时按需解析
  * @param images 用户随消息发送的图片（压缩后的本地缓存文件路径，仅 USER 消息使用）；
  *   UI 直接按路径渲染，发送时由 transport 层读文件转 base64 内嵌
  * @param error 非空表示这条 assistant 消息是一次失败（按 [ChatError.category] 区分展示）
+ * @param kind 生成管线标记，默认普通对话
  */
 data class ChatMessage(
     val id: Long,
@@ -17,4 +25,5 @@ data class ChatMessage(
     val content: String,
     val images: List<String> = emptyList(),
     val error: ChatError? = null,
+    val kind: MessageKind = MessageKind.CHAT,
 )

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/sample/FakeChatEngine.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/sample/FakeChatEngine.kt
@@ -3,14 +3,15 @@ package whl.trending.chat.sample
 import kotlinx.coroutines.delay
 import whl.trending.ai.chat.ChatContext
 import whl.trending.chat.engine.ChatEngine
+import whl.trending.chat.engine.DetailSummaryResult
 import whl.trending.chat.model.ChatMessage
 
 /**
- * 离线假引擎：不接 API，发送后延迟一段返回预置 Markdown，
- * 用于跑通「输入 → 发送 → 思考中 → 渲染」完整交互链路。
+ * 离线假引擎：不接 API，模拟逐字流式输出预置 Markdown，
+ * 用于跑通「输入 → 发送 → 流式渲染」完整交互链路。
  */
 class FakeChatEngine(
-    private val delayMillis: Long = 1200L,
+    private val chunkDelayMillis: Long = 30L,
 ) : ChatEngine {
 
     private val replies = listOf(
@@ -20,10 +21,30 @@ class FakeChatEngine(
     )
     private var index = 0
 
-    override suspend fun send(history: List<ChatMessage>, context: ChatContext?): String {
-        delay(delayMillis)
+    override suspend fun send(
+        history: List<ChatMessage>,
+        context: ChatContext?,
+        onDelta: (String) -> Unit,
+    ): String {
         val reply = replies[index % replies.size]
         index++
+        return streamOut(reply, onDelta)
+    }
+
+    override suspend fun sendDetailSummary(
+        context: ChatContext,
+        onDelta: (String) -> Unit,
+    ): DetailSummaryResult {
+        val reply = "### 这是什么\n\n${context.title} 的模拟详细解读。\n\n" + SampleData.richMarkdown
+        return DetailSummaryResult(streamOut(reply, onDelta), cached = false)
+    }
+
+    /** 按小块模拟逐字输出 */
+    private suspend fun streamOut(reply: String, onDelta: (String) -> Unit): String {
+        reply.chunked(24).forEach { chunk ->
+            delay(chunkDelayMillis)
+            onDelta(chunk)
+        }
         return reply
     }
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import whl.trending.ai.chat.ChatContext
 import whl.trending.chat.ChatViewModel
+import whl.trending.chat.DetailSummaryPolicy
 import whl.trending.chat.R
 import whl.trending.chat.engine.ChatApi
 import whl.trending.chat.engine.ChatEngine
@@ -90,6 +91,18 @@ fun ChatScreen(
         },
         bottomBar = {
             Column {
+                // 「一键详细解读」chip：GitHub 条目 + README 达标 + 尚无成功解读 → 常驻显示
+                // （不同于介绍 chip 的「messages 为空才显示」）；生成中置灰，成功一次后隐藏。
+                if (DetailSummaryPolicy.chipVisible(initialContext, state.messages)) {
+                    val detailPrompt = stringResource(R.string.chat_action_detail_summary)
+                    Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp)) {
+                        AssistChip(
+                            onClick = { viewModel.sendDetailSummary(detailPrompt) },
+                            enabled = !state.isSending,
+                            label = { Text(detailPrompt) },
+                        )
+                    }
+                }
                 // 尚无对话时在输入框上方显示入口对应的快捷问（label 资源 to prompt 资源）：
                 // 通用助手入口问能力，README 入口问项目介绍。messages 非空即隐藏，
                 // 天然覆盖"发送后隐藏"与"恢复历史会话不再显示"。

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
@@ -188,9 +188,13 @@ private fun AssistantMessage(message: ChatMessage, onRetry: () -> Unit, modifier
                     )
                 }
             }
-        } else if (error.code == ChatError.CODE_QUOTA_DEVICE) {
-            // 个人配额触顶走专属卡片（登录 CTA / waitlist），全局熔断仍走普通错误文案
-            QuotaLimitCard(error = error, onRetry = onRetry)
+        } else if (error.code == ChatError.CODE_QUOTA_DEVICE || error.code == ChatError.CODE_LOGIN_REQUIRED) {
+            // 个人配额触顶 / 解读登录闸走专属卡片（登录 CTA / waitlist），全局熔断仍走普通错误文案
+            QuotaLimitCard(
+                error = error,
+                onRetry = onRetry,
+                isDetail = message.kind == whl.trending.chat.model.MessageKind.DETAIL_SUMMARY,
+            )
         } else {
             Text(
                 text = stringResource(errorMessageRes(error)),
@@ -208,6 +212,7 @@ private fun AssistantMessage(message: ChatMessage, onRetry: () -> Unit, modifier
 
 /** 选具体文案：优先服务端 [ChatError.code]，未知则回落到 [ChatError.category]。 */
 private fun errorMessageRes(error: ChatError): Int = when (error.code) {
+    "readme_too_short" -> R.string.chat_error_readme_too_short
     "auth_invalid" -> R.string.chat_error_auth_invalid
     "images_require_login" -> R.string.chat_error_images_require_login
     "content_too_long" -> R.string.chat_error_content_too_long

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageList.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageList.kt
@@ -8,15 +8,18 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.Role
 
-/** 消息列表：LazyColumn，message.id 作稳定 key；新消息 / 思考中 / 流式增量时自动滚到底。 */
+/**
+ * 消息列表：reverseLayout 的 LazyColumn（经典聊天结构），index 0 = 最新消息，屏幕底部。
+ *
+ * 流式跟随不用任何程序滚动：贴底（锚点 index 0 / offset 0）时消息内容增长由布局锚点
+ * 语义自动保持贴底；用户上滑即离开锚点、跟随自然停止——不存在程序滚动与手势抢夺
+ * （此前正向列表 + 每 delta scrollToItem 的方案，会在末项高过一屏后失效并持续杀掉用户 fling）。
+ */
 @Composable
 fun MessageList(
     messages: List<ChatMessage>,
@@ -26,23 +29,9 @@ fun MessageList(
 ) {
     val listState = rememberLazyListState()
 
-    // 新消息 / typing 项出现时总是滚到底（发送、回复到达等离散事件）
+    // 仅离散事件（发送/回复到达/typing 项增删）时滚回底部；流式增量期间 size 不变、不触发
     LaunchedEffect(messages.size, isSending) {
-        val target = messages.size // 含末尾 typing 项时仍滚到底
-        if (target > 0) listState.animateScrollToItem(target)
-    }
-
-    // 流式渲染中内容在末条消息里增长、size 不变：仅当末项仍可见（用户没上滑离开底部）时跟随滚动，
-    // 避免长解读生成期间把上滑回看的用户反复拽回底部
-    val lastContentLength = messages.lastOrNull()?.content?.length ?: 0
-    val followStream by remember {
-        derivedStateOf {
-            val info = listState.layoutInfo
-            (info.visibleItemsInfo.lastOrNull()?.index ?: -1) >= info.totalItemsCount - 1
-        }
-    }
-    LaunchedEffect(lastContentLength) {
-        if (followStream && messages.isNotEmpty()) listState.scrollToItem(messages.size)
+        if (messages.isNotEmpty()) listState.animateScrollToItem(0)
     }
 
     // 流式占位一旦开始出字（或出错）就收起 typing 指示器，避免「正文下面还转圈」
@@ -52,15 +41,17 @@ fun MessageList(
 
     LazyColumn(
         state = listState,
+        reverseLayout = true,
         modifier = modifier.fillMaxSize(),
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        items(messages, key = { it.id }) { message ->
-            MessageItem(message = message, onRetry = { onRetry(message) })
-        }
+        // reverseLayout 下内容按「屏幕自下而上」顺序声明：typing 最贴底，随后是最新→最旧消息
         if (showTyping) {
             item(key = "typing") { TypingIndicator() }
+        }
+        items(messages.asReversed(), key = { it.id }) { message ->
+            MessageItem(message = message, onRetry = { onRetry(message) })
         }
     }
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageList.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageList.kt
@@ -11,8 +11,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.Role
 
-/** 消息列表：LazyColumn，message.id 作稳定 key；新消息 / 思考中时自动滚到底。 */
+/** 消息列表：LazyColumn，message.id 作稳定 key；新消息 / 思考中 / 流式增量时自动滚到底。 */
 @Composable
 fun MessageList(
     messages: List<ChatMessage>,
@@ -22,10 +23,17 @@ fun MessageList(
 ) {
     val listState = rememberLazyListState()
 
-    LaunchedEffect(messages.size, isSending) {
+    // 流式渲染中内容在末条 assistant 消息里增长，size 不变——以末条内容长度作额外 key 跟随滚动
+    val lastContentLength = messages.lastOrNull()?.content?.length ?: 0
+    LaunchedEffect(messages.size, isSending, lastContentLength) {
         val target = messages.size // 含末尾 typing 项时仍滚到底
-        if (target > 0) listState.animateScrollToItem(target)
+        if (target > 0) listState.scrollToItem(target)
     }
+
+    // 流式占位一旦开始出字（或出错）就收起 typing 指示器，避免「正文下面还转圈」
+    val last = messages.lastOrNull()
+    val showTyping = isSending &&
+        (last == null || last.role == Role.USER || (last.content.isBlank() && last.error == null))
 
     LazyColumn(
         state = listState,
@@ -36,7 +44,7 @@ fun MessageList(
         items(messages, key = { it.id }) { message ->
             MessageItem(message = message, onRetry = { onRetry(message) })
         }
-        if (isSending) {
+        if (showTyping) {
             item(key = "typing") { TypingIndicator() }
         }
     }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageList.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageList.kt
@@ -8,6 +8,9 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import whl.trending.chat.model.ChatMessage
@@ -23,11 +26,23 @@ fun MessageList(
 ) {
     val listState = rememberLazyListState()
 
-    // 流式渲染中内容在末条 assistant 消息里增长，size 不变——以末条内容长度作额外 key 跟随滚动
-    val lastContentLength = messages.lastOrNull()?.content?.length ?: 0
-    LaunchedEffect(messages.size, isSending, lastContentLength) {
+    // 新消息 / typing 项出现时总是滚到底（发送、回复到达等离散事件）
+    LaunchedEffect(messages.size, isSending) {
         val target = messages.size // 含末尾 typing 项时仍滚到底
-        if (target > 0) listState.scrollToItem(target)
+        if (target > 0) listState.animateScrollToItem(target)
+    }
+
+    // 流式渲染中内容在末条消息里增长、size 不变：仅当末项仍可见（用户没上滑离开底部）时跟随滚动，
+    // 避免长解读生成期间把上滑回看的用户反复拽回底部
+    val lastContentLength = messages.lastOrNull()?.content?.length ?: 0
+    val followStream by remember {
+        derivedStateOf {
+            val info = listState.layoutInfo
+            (info.visibleItemsInfo.lastOrNull()?.index ?: -1) >= info.totalItemsCount - 1
+        }
+    }
+    LaunchedEffect(lastContentLength) {
+        if (followStream && messages.isNotEmpty()) listState.scrollToItem(messages.size)
     }
 
     // 流式占位一旦开始出字（或出错）就收起 typing 指示器，避免「正文下面还转圈」

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
@@ -73,20 +73,31 @@ internal fun QuotaLimitCard(
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         when {
             isLoginGate -> {
-                if (authState == AuthState.LoggedIn) {
-                    // 登录完成：与触顶卡的放行例外同构，点重试续上生成
-                    QuotaText(R.string.chat_detail_login_unlocked)
-                    TextButton(onClick = onRetry) {
-                        Text(stringResource(R.string.chat_retry))
+                when {
+                    // 发请求时自认已登录、却被按匿名档处理（Logto 故障降级）：如实提示登录态未生效，
+                    // 不给「已登录、重试即可」的死循环误导——authDegraded 就是为此而生，此分支必须消费它
+                    error.authDegraded -> {
+                        QuotaText(R.string.chat_quota_auth_degraded)
+                        TextButton(onClick = onRetry) {
+                            Text(stringResource(R.string.chat_retry))
+                        }
                     }
-                } else {
-                    QuotaText(R.string.chat_detail_login_message)
-                    if (globalAuthManager.isSupported) {
-                        Button(onClick = {
-                            trackEvent("detail_summary_login_click")
-                            globalAuthManager.signIn()
-                        }) {
-                            Text(stringResource(R.string.chat_quota_login_cta))
+                    // 登录完成：与触顶卡的放行例外同构，点重试续上生成
+                    authState == AuthState.LoggedIn -> {
+                        QuotaText(R.string.chat_detail_login_unlocked)
+                        TextButton(onClick = onRetry) {
+                            Text(stringResource(R.string.chat_retry))
+                        }
+                    }
+                    else -> {
+                        QuotaText(R.string.chat_detail_login_message)
+                        if (globalAuthManager.isSupported) {
+                            Button(onClick = {
+                                trackEvent("detail_summary_login_click")
+                                globalAuthManager.signIn()
+                            }) {
+                                Text(stringResource(R.string.chat_quota_login_cta))
+                            }
                         }
                     }
                 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/QuotaLimitCard.kt
@@ -42,21 +42,28 @@ import whl.trending.chat.R
 import whl.trending.chat.model.ChatError
 
 /**
- * 个人配额触顶卡片（`quota_device`），按档位分形态：
+ * 个人配额触顶卡片（`quota_device`）与详细解读登录闸卡片（`login_required`），按档位分形态：
  * - 匿名触顶：登录 CTA（转化点）+ waitlist 次按钮
  * - 匿名触顶后完成登录：提示已解锁，给重试按钮直接续聊
  * - 登录触顶：waitlist CTA（付费意愿温度计）
+ * - 解读登录闸（匿名点未缓存条目）：复用匿名触顶卡形态，文案换「生成解读需登录」口径；
+ *   登录成功后与触顶卡同样给重试按钮续上生成
  *
  * 全局熔断（`quota_global`）不走本卡片，仍是普通错误文案——语义上与个人额度承诺切开。
+ *
+ * @param isDetail 由解读消息触发（驱动 waitlist 埋点前缀 detail_summary_*）
  */
 @Composable
 internal fun QuotaLimitCard(
     error: ChatError,
     onRetry: () -> Unit,
+    isDetail: Boolean = false,
 ) {
     val authState by globalAuthManager.authState.collectAsState()
     val isProTier = error.tier == ChatError.TIER_PRO
     val isUserTier = error.tier == ChatError.TIER_USER
+    val isLoginGate = error.code == ChatError.CODE_LOGIN_REQUIRED
+    val waitlistEvent = if (isDetail) "detail_summary_waitlist_click" else "chat_quota_waitlist_click"
     var showWaitlistDialog by remember { mutableStateOf(false) }
 
     if (showWaitlistDialog) {
@@ -65,6 +72,25 @@ internal fun QuotaLimitCard(
 
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         when {
+            isLoginGate -> {
+                if (authState == AuthState.LoggedIn) {
+                    // 登录完成：与触顶卡的放行例外同构，点重试续上生成
+                    QuotaText(R.string.chat_detail_login_unlocked)
+                    TextButton(onClick = onRetry) {
+                        Text(stringResource(R.string.chat_retry))
+                    }
+                } else {
+                    QuotaText(R.string.chat_detail_login_message)
+                    if (globalAuthManager.isSupported) {
+                        Button(onClick = {
+                            trackEvent("detail_summary_login_click")
+                            globalAuthManager.signIn()
+                        }) {
+                            Text(stringResource(R.string.chat_quota_login_cta))
+                        }
+                    }
+                }
+            }
             isProTier -> {
                 // Pro 触顶（极罕见）：不透数字的软着陆，无 CTA（已是 Pro，明日恢复）
                 QuotaText(R.string.chat_quota_pro_exceeded)
@@ -82,7 +108,7 @@ internal fun QuotaLimitCard(
                 }
                 // 次按钮：付不了国际卡的人 → waitlist（捕获支付摩擦样本）
                 TextButton(onClick = {
-                    trackEvent("chat_quota_waitlist_click", mapOf("tier" to ChatError.TIER_USER))
+                    trackEvent(waitlistEvent, mapOf("tier" to ChatError.TIER_USER))
                     showWaitlistDialog = true
                 }) {
                     Text(stringResource(R.string.chat_quota_waitlist_cta))
@@ -114,7 +140,7 @@ internal fun QuotaLimitCard(
                     }
                 }
                 TextButton(onClick = {
-                    trackEvent("chat_quota_waitlist_click", mapOf("tier" to ChatError.TIER_ANONYMOUS))
+                    trackEvent(waitlistEvent, mapOf("tier" to ChatError.TIER_ANONYMOUS))
                     showWaitlistDialog = true
                 }) {
                     Text(stringResource(R.string.chat_quota_waitlist_cta))

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -56,7 +56,7 @@
     <string name="chat_image_viewer_close">关闭</string>
     <string name="chat_error_images_require_login">发送图片需要先登录。</string>
     <string name="chat_action_detail_summary">一键详细解读</string>
-    <string name="chat_detail_login_message">生成详细解读需要登录；阅读已生成的解读始终免费。</string>
+    <string name="chat_detail_login_message">生成详细解读需要登录。</string>
     <string name="chat_detail_login_unlocked">已登录，点击重试继续生成。</string>
     <string name="chat_error_readme_too_short">这个项目的 README 太短，暂不支持详细解读。</string>
 </resources>

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -55,4 +55,8 @@
     <string name="chat_user_image">图片</string>
     <string name="chat_image_viewer_close">关闭</string>
     <string name="chat_error_images_require_login">发送图片需要先登录。</string>
+    <string name="chat_action_detail_summary">一键详细解读</string>
+    <string name="chat_detail_login_message">生成详细解读需要登录；阅读已生成的解读始终免费。</string>
+    <string name="chat_detail_login_unlocked">已登录，点击重试继续生成。</string>
+    <string name="chat_error_readme_too_short">这个项目的 README 太短，暂不支持详细解读。</string>
 </resources>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -55,4 +55,8 @@
     <string name="chat_user_image">Image</string>
     <string name="chat_image_viewer_close">Close</string>
     <string name="chat_error_images_require_login">Sign in to send images.</string>
+    <string name="chat_action_detail_summary">In-depth overview</string>
+    <string name="chat_detail_login_message">Generating an in-depth overview requires signing in. Reading already-generated overviews stays free.</string>
+    <string name="chat_detail_login_unlocked">Signed in — tap retry to continue generating.</string>
+    <string name="chat_error_readme_too_short">This project\'s README is too short for an in-depth overview.</string>
 </resources>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -56,7 +56,7 @@
     <string name="chat_image_viewer_close">Close</string>
     <string name="chat_error_images_require_login">Sign in to send images.</string>
     <string name="chat_action_detail_summary">In-depth overview</string>
-    <string name="chat_detail_login_message">Generating an in-depth overview requires signing in. Reading already-generated overviews stays free.</string>
+    <string name="chat_detail_login_message">Sign in to generate an in-depth overview.</string>
     <string name="chat_detail_login_unlocked">Signed in — tap retry to continue generating.</string>
     <string name="chat_error_readme_too_short">This project\'s README is too short for an in-depth overview.</string>
 </resources>

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelStreamingTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelStreamingTest.kt
@@ -1,0 +1,172 @@
+package whl.trending.chat
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import whl.trending.ai.chat.ChatContext
+import whl.trending.chat.engine.ChatEngine
+import whl.trending.chat.engine.ChatException
+import whl.trending.chat.engine.DetailSummaryResult
+import whl.trending.chat.model.ChatError
+import whl.trending.chat.model.ChatErrorCategory
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.MessageKind
+import whl.trending.chat.model.Role
+
+/** ChatViewModel 流式渲染与 detail 管线路由。 */
+class ChatViewModelStreamingTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @AfterTest
+    fun tearDown() = Dispatchers.resetMain()
+
+    private val context = ChatContext(
+        title = "octo/demo",
+        sourceUrl = "https://github.com/octo/demo",
+        source = "github",
+        externalId = "octo/demo",
+        readmeLength = 5000,
+    )
+
+    /** 可编程假引擎：记录调用、按脚本流式吐块或抛错 */
+    private class ScriptedEngine(
+        var chatChunks: List<String> = listOf("你", "好"),
+        var detailChunks: List<String> = listOf("解", "读"),
+        var detailCached: Boolean = false,
+        var failWith: ChatError? = null,
+    ) : ChatEngine {
+        var chatCalls = 0
+        var detailCalls = 0
+
+        override suspend fun send(
+            history: List<ChatMessage>,
+            context: ChatContext?,
+            onDelta: (String) -> Unit,
+        ): String {
+            chatCalls++
+            failWith?.let { throw ChatException(it) }
+            chatChunks.forEach(onDelta)
+            return chatChunks.joinToString("")
+        }
+
+        override suspend fun sendDetailSummary(
+            context: ChatContext,
+            onDelta: (String) -> Unit,
+        ): DetailSummaryResult {
+            detailCalls++
+            failWith?.let { throw ChatException(it) }
+            detailChunks.forEach(onDelta)
+            return DetailSummaryResult(detailChunks.joinToString(""), detailCached)
+        }
+    }
+
+    private fun vm(engine: ChatEngine, track: (String, Map<String, String>) -> Unit = { _, _ -> }) =
+        ChatViewModel(engine, context, loadModels = { emptyList() }, track = track)
+
+    @Test
+    fun `发送后流式定稿：assistant 消息内容为全文，isSending 复位`() = runTest(dispatcher) {
+        val viewModel = vm(ScriptedEngine())
+        viewModel.sendText("hi")
+        advanceUntilIdle()
+        val state = viewModel.uiState.value
+        assertEquals(2, state.messages.size)
+        assertEquals("你好", state.messages.last().content)
+        assertNull(state.messages.last().error)
+        assertTrue(!state.isSending)
+    }
+
+    @Test
+    fun `解读发送：插入 chip 文案 user 消息 + DETAIL_SUMMARY assistant 消息`() = runTest(dispatcher) {
+        val engine = ScriptedEngine()
+        val viewModel = vm(engine)
+        viewModel.sendDetailSummary("一键详细解读")
+        advanceUntilIdle()
+        val messages = viewModel.uiState.value.messages
+        assertEquals(2, messages.size)
+        assertEquals(Role.USER, messages[0].role)
+        assertEquals("一键详细解读", messages[0].content)
+        assertEquals(MessageKind.DETAIL_SUMMARY, messages[1].kind)
+        assertEquals("解读", messages[1].content)
+        assertEquals(1, engine.detailCalls)
+        assertEquals(0, engine.chatCalls)
+    }
+
+    @Test
+    fun `失败时已渲染部分丢弃：content 清空、挂错误、kind 保留`() = runTest(dispatcher) {
+        val engine = ScriptedEngine(failWith = ChatError(ChatErrorCategory.SERVER, code = "stream_interrupted"))
+        val viewModel = vm(engine)
+        viewModel.sendDetailSummary("一键详细解读")
+        advanceUntilIdle()
+        val failed = viewModel.uiState.value.messages.last()
+        assertEquals("", failed.content)
+        assertNotNull(failed.error)
+        assertEquals(MessageKind.DETAIL_SUMMARY, failed.kind)
+    }
+
+    @Test
+    fun `retry 按 kind 路由：解读失败重试走 detail 管线而非 chat`() = runTest(dispatcher) {
+        val engine = ScriptedEngine(failWith = ChatError(ChatErrorCategory.SERVER, code = "stream_interrupted"))
+        val viewModel = vm(engine)
+        viewModel.sendDetailSummary("一键详细解读")
+        advanceUntilIdle()
+        engine.failWith = null // 网络恢复
+        viewModel.retry(viewModel.uiState.value.messages.last())
+        advanceUntilIdle()
+        assertEquals(2, engine.detailCalls)
+        assertEquals(0, engine.chatCalls)
+        assertEquals("解读", viewModel.uiState.value.messages.last().content)
+    }
+
+    @Test
+    fun `login_required 不可重试类别但享受放行例外（登录后 retry 续上）`() = runTest(dispatcher) {
+        val engine = ScriptedEngine(
+            failWith = ChatError(
+                ChatErrorCategory.BAD_REQUEST, // 403 归类不可重试
+                code = ChatError.CODE_LOGIN_REQUIRED,
+                tier = ChatError.TIER_ANONYMOUS,
+            ),
+        )
+        val viewModel = vm(engine)
+        viewModel.sendDetailSummary("一键详细解读")
+        advanceUntilIdle()
+        engine.failWith = null // 模拟登录完成
+        viewModel.retry(viewModel.uiState.value.messages.last())
+        advanceUntilIdle()
+        assertEquals("解读", viewModel.uiState.value.messages.last().content)
+        assertEquals(2, engine.detailCalls)
+    }
+
+    @Test
+    fun `埋点：generate、cache_hit、login_required`() = runTest(dispatcher) {
+        val events = mutableListOf<String>()
+        val engine = ScriptedEngine(detailCached = true)
+        val viewModel = vm(engine) { name, _ -> events.add(name) }
+        viewModel.sendDetailSummary("一键详细解读")
+        advanceUntilIdle()
+        assertTrue("detail_summary_generate" in events)
+        assertTrue("detail_summary_cache_hit" in events)
+
+        val gated = ScriptedEngine(
+            failWith = ChatError(ChatErrorCategory.BAD_REQUEST, code = ChatError.CODE_LOGIN_REQUIRED),
+        )
+        val events2 = mutableListOf<String>()
+        val vm2 = vm(gated) { name, _ -> events2.add(name) }
+        vm2.sendDetailSummary("一键详细解读")
+        advanceUntilIdle()
+        assertTrue("detail_summary_login_required" in events2)
+    }
+}

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/DetailSummaryPolicyTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/DetailSummaryPolicyTest.kt
@@ -1,0 +1,79 @@
+package whl.trending.chat
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import whl.trending.ai.chat.ChatContext
+import whl.trending.chat.model.ChatError
+import whl.trending.chat.model.ChatErrorCategory
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.MessageKind
+import whl.trending.chat.model.Role
+
+/** 「一键详细解读」chip 可见性策略（纯函数）。 */
+class DetailSummaryPolicyTest {
+
+    private val githubContext = ChatContext(
+        title = "octo/demo",
+        sourceUrl = "https://github.com/octo/demo",
+        source = "github",
+        externalId = "octo/demo",
+        readmeLength = 5000,
+    )
+
+    @Test
+    fun `GitHub 条目且 README 达标 → 显示`() {
+        assertTrue(DetailSummaryPolicy.chipVisible(githubContext, emptyList()))
+    }
+
+    @Test
+    fun `通用助手入口（context 为空）→ 不显示`() {
+        assertFalse(DetailSummaryPolicy.chipVisible(null, emptyList()))
+    }
+
+    @Test
+    fun `非 GitHub 源 → 不显示`() {
+        assertFalse(DetailSummaryPolicy.chipVisible(githubContext.copy(source = "hackernews"), emptyList()))
+        assertFalse(DetailSummaryPolicy.chipVisible(githubContext.copy(source = null), emptyList()))
+    }
+
+    @Test
+    fun `readmeLength 为 null（未加载完）→ 不显示，宁缺勿滥`() {
+        assertFalse(DetailSummaryPolicy.chipVisible(githubContext.copy(readmeLength = null), emptyList()))
+    }
+
+    @Test
+    fun `readmeLength 低于阈值 → 不显示`() {
+        assertFalse(
+            DetailSummaryPolicy.chipVisible(
+                githubContext.copy(readmeLength = DetailSummaryPolicy.MIN_README_CHARS - 1),
+                emptyList(),
+            ),
+        )
+    }
+
+    @Test
+    fun `已有成功解读消息 → 隐藏`() {
+        val success = ChatMessage(2, Role.ASSISTANT, "解读全文", kind = MessageKind.DETAIL_SUMMARY)
+        assertFalse(DetailSummaryPolicy.chipVisible(githubContext, listOf(success)))
+    }
+
+    @Test
+    fun `解读失败消息不算成功 → 仍显示（可重新触发）`() {
+        val failed = ChatMessage(
+            2, Role.ASSISTANT, "",
+            error = ChatError(ChatErrorCategory.SERVER),
+            kind = MessageKind.DETAIL_SUMMARY,
+        )
+        assertTrue(DetailSummaryPolicy.chipVisible(githubContext, listOf(failed)))
+    }
+
+    @Test
+    fun `已有普通对话轮次 → 常驻显示（不同于介绍 chip 的 messages 为空规则）`() {
+        val chat = listOf(
+            ChatMessage(1, Role.USER, "hi"),
+            ChatMessage(2, Role.ASSISTANT, "hello"),
+        )
+        assertTrue(DetailSummaryPolicy.chipVisible(githubContext, chat))
+    }
+}

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatApiWireTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatApiWireTest.kt
@@ -1,0 +1,24 @@
+package whl.trending.chat.engine
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * 请求方向的 wire 序列化断言。
+ *
+ * 回归背景：kotlinx.serialization 默认 encodeDefaults=false，带默认值的属性在值等于默认值时
+ * 会被整个省略——`stream: Boolean = true` 曾因此从请求体里消失，服务端 `body.stream === true`
+ * 严格判断收不到字段就走旧 JSON 路径，chat 流式静默失效。此测试保证 stream 字段必定出现在线上。
+ */
+class ChatApiWireTest {
+
+    @Test
+    fun `chat 请求体必须序列化出 stream true`() {
+        val body = Json { ignoreUnknownKeys = true }.encodeToString(
+            ChatApi.ChatRequest(messages = emptyList(), lang = "zh", stream = true),
+        )
+        assertContains(body, "\"stream\":true")
+    }
+}

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatSseTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatSseTest.kt
@@ -1,0 +1,46 @@
+package whl.trending.chat.engine
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/** SSE 行解析纯函数：与 Worker 端 lib/sse.js 的事件协议一一对应。 */
+class ChatSseTest {
+
+    @Test
+    fun `delta 事件解析出文本`() {
+        val event = ChatSse.parseLine("""data: {"delta":"你好"}""")
+        assertEquals(ChatSse.Event.Delta("你好"), event)
+    }
+
+    @Test
+    fun `done 事件解析为结束信号`() {
+        val event = ChatSse.parseLine("""data: {"done":true}""")
+        assertEquals(ChatSse.Event.Done(cached = false), event)
+    }
+
+    @Test
+    fun `done 事件携带 cached 元信息（缓存命中一次性推完）`() {
+        val event = ChatSse.parseLine("""data: {"done":true,"cached":true}""")
+        assertEquals(ChatSse.Event.Done(cached = true), event)
+    }
+
+    @Test
+    fun `非 data 前缀行忽略`() {
+        assertNull(ChatSse.parseLine(""))
+        assertNull(ChatSse.parseLine(": keep-alive"))
+        assertNull(ChatSse.parseLine("event: message"))
+    }
+
+    @Test
+    fun `脏行与非法 JSON 忽略不抛`() {
+        assertNull(ChatSse.parseLine("data: not-json"))
+        assertNull(ChatSse.parseLine("data: {\"unknown\":1}"))
+    }
+
+    @Test
+    fun `delta 内容含特殊字符与换行`() {
+        val event = ChatSse.parseLine("""data: {"delta":"a\nb \"c\""}""")
+        assertEquals(ChatSse.Event.Delta("a\nb \"c\""), event)
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/chat/ChatIntegration.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/chat/ChatIntegration.kt
@@ -5,11 +5,18 @@ import androidx.compose.runtime.Composable
 /**
  * 进入聊天时可携带的初始上下文（项目 / HN / PH 条目）。
  * 通用 AI 助手入口传 null。
+ *
+ * @param source 条目所属数据源（`github` 等，与服务端 contents 表口径一致），驱动「一键详细解读」入口
+ * @param externalId 条目在数据源内的 ID（GitHub 为 `owner/repo`），detail-summary API 入参
+ * @param readmeLength README 正文长度估计（ReadmeScreen 进 chat 时填充；未加载完为 null → chip 不显示）
  */
 data class ChatContext(
     val title: String,
     val summary: String? = null,
     val sourceUrl: String? = null,
+    val source: String? = null,
+    val externalId: String? = null,
+    val readmeLength: Int? = null,
 )
 
 /**

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
@@ -190,7 +190,15 @@ fun ReadmeScreen(
                                 // 带上 README 摘录作为依据，让 AI 能介绍冷门项目；
                                 // README 未加载完则为 null，退化为仅 title + url
                                 summary = summary,
-                                sourceUrl = repoUrl
+                                sourceUrl = repoUrl,
+                                // 「一键详细解读」入参：与服务端 contents 表 (source, external_id) 对齐
+                                source = "github",
+                                externalId = "$owner/$repo",
+                                // README 正文长度估计（HTML 去标签）；未加载完为 null → 解读 chip 不显示
+                                readmeLength = uiState.html
+                                    .takeIf { it.isNotBlank() }
+                                    ?.replace(Regex("<[^>]+>"), "")
+                                    ?.length,
                             )
                         )
                     }


### PR DESCRIPTION
## 概要

实现「榜单条目一键详细解读」的客户端侧（Android，spec 见 docs 仓库 `2026-07-09-detail-summary-chat-entry-design.md`；Worker 侧 PR：github-ai-trending-api#15）。

- **数据模型**：`ChatMessage` 加 `kind`（CHAT/DETAIL_SUMMARY，默认 CHAT）驱动 chip 可见性与 retry 路由，渲染无差别；`ChatContext` 加 `source/externalId/readmeLength`（ReadmeScreen 进 chat 时填充，与 API 入参对齐、不带 GitHub 专属字段）。
- **流式引擎**：`ChatEngine` 改增量回调；`ChatApi` 发 `stream:true` 走 SSE（Ktor `bodyAsChannel` 逐行解析，`ChatSse` 纯函数与 Worker 协议一一对应），chat 与 detail 共用同一解析路径；2xx 非 SSE 响应整段兜底（服务端未部署流式时仍可用）；断流归类可重试。
- **ViewModel**：发送先追加空 assistant 占位，delta 增量更新 content；失败清空已渲染部分整条重试；retry 按 `kind` 路由回对应管线；`quota_device`/`login_required` 享受登录后放行例外。
- **交互**：「一键详细解读」chip 常驻显示策略（GitHub 条目 + README≥1500 + 尚无成功解读，`DetailSummaryPolicy` 纯函数）；匿名点未缓存条目 → 登录卡（复用 `QuotaLimitCard` 形态，登录后 retry 续上）；`readme_too_short` 渲染为不可重试提示；流式出字后收起 typing 指示器。
- **埋点**：`detail_summary_generate` / `cache_hit` / `login_required` / `quota_hit`(tier) / `waitlist_click`，统一 `from=chat`。
- **文案**：zh/en 双语（chip「一键详细解读 / In-depth overview」）。

## 测试

- 单测 44 全绿（新增 `ChatSseTest` / `DetailSummaryPolicyTest` / `ChatViewModelStreamingTest`，TDD）
- `assembleDebug` 通过
- 模拟器 e2e 待 Worker PR 部署后执行（新客户端对旧 Worker 向后兼容：`stream:true` 被忽略时走 JSON 兜底路径）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在聊天体验中添加流式聊天支持以及“一键式深入仓库概览”入口，包括基于 SSE 的引擎改动、新的 detail-summary 流程，以及 UI/分析 的集成。

新功能：
- 引入 detail-summary 聊天模式，可在聊天中为符合条件的 GitHub 条目生成深入的概览。
- 为具有足够长 README 且尚无成功概览的 GitHub 仓库，在聊天中展示持久的“In-depth overview（深入概览）”标签（chip）。
- 支持助手消息在聊天中的流式渲染，在生成期间增量更新内容。

功能改进：
- 扩展聊天引擎，对普通聊天和 detail-summary 请求均使用基于 SSE 的流式响应，并共享解析路径。
- 更新聊天消息和上下文模型，以携带与后端 detail-summary API 要求对齐的 pipeline 类型和来源元数据。
- 调整输入中指示（typing indicator）行为和自动滚动逻辑，以更好地反映助手流式输出。
- 优化重试行为，将失败路由回对应的 pipeline，并将中断的流视为可重试错误。
- 增强配额/登录门控 UI，以同时处理 detail-summary 的登录要求，并复用配额卡片（quota card）配合调整后的文案。

文档：
- 为 detail-summary 标签（chip）、登录门控消息以及 README-too-short 错误新增双语 UI 文案，涵盖中文（zh）和英文（en）。

测试：
- 添加针对 SSE 行解析、detail-summary 标签可见性策略以及 ChatViewModel 流式行为和路由的单元测试。
- 扩展测试依赖，引入 `kotlinx-coroutines-test`，以实现对流式流程的可控（确定性）测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add streaming chat support and a one-tap in-depth repo overview entry in the chat experience, including SSE-based engine changes, new detail-summary pipeline, and UI/analytics integration.

New Features:
- Introduce a detail-summary chat mode that generates in-depth overviews for eligible GitHub entries from within the chat.
- Expose a persistent "In-depth overview" chip in chat for GitHub repos with sufficiently long READMEs and no successful prior overview.
- Support streaming rendering of assistant messages in chat, updating content incrementally during generation.

Enhancements:
- Extend the chat engine to use SSE-based streaming responses for both normal chats and detail-summary requests with a shared parsing path.
- Update chat message and context models to carry pipeline kind and source metadata aligned with backend detail-summary API requirements.
- Adjust typing indicator behavior and auto-scroll logic to better reflect streaming assistant output.
- Refine retry behavior to route failures back to the appropriate pipeline and to treat interrupted streams as retriable errors.
- Enhance quota/login gating UI to also handle detail-summary login requirements, reusing the quota card with adjusted copy.

Documentation:
- Add bilingual UI strings for the detail-summary chip, login gating messages, and README-too-short error in both zh and en.

Tests:
- Add unit tests for SSE line parsing, detail-summary chip visibility policy, and ChatViewModel streaming behavior and routing.
- Extend test dependencies to include kotlinx-coroutines-test for deterministic testing of streaming flows.

</details>