### PR TITLE
feat(auth): 登录入口前置价值说明弹窗，降低授权流程放弃率

### DIFF
--- a/docs/superpowers/specs/2026-07-11-sign-in-value-prop-design.md
+++ b/docs/superpowers/specs/2026-07-11-sign-in-value-prop-design.md
@@ -1,0 +1,79 @@
+# 登录入口前置价值说明（Sign-in Value Proposition）设计
+
+日期：2026-07-11
+分支：feat/sign-in-value-prop
+
+## 背景与问题
+
+埋点数据显示：约 117 台设备尝试登录，仅 22 台成功（约 19%）；0.19.0 版本 `sign_in_failed` 的
+reason 全部为 `user_canceled`——用户是在 Logto 网页授权流程中主动放弃，并非技术故障。
+`repo_star` 渗透率仅 1.2%，基本被该漏斗锁死。
+
+根因假设：用户不知道登录能得到什么（GitHub star、chat 配额），也不知道点击后会跳转浏览器走
+GitHub 授权，遇到陌生网页流程即放弃。
+
+## 现状盘点（登录入口）
+
+| 入口 | 现状 | 是否已有价值说明 |
+| --- | --- | --- |
+| A. 首页 topbar 头像（`HomeScreen.kt`） | 未登录点击**直接** `signIn()` 拉起网页授权 | ❌ 零说明 |
+| B/C. Trending / Readme star Snackbar | 「登录后即可 Star 该仓库」+ 登录 action | ✅ 场景化说明 |
+| D. Chat 配额卡（`QuotaLimitCard.kt`） | 「登录解锁每日 10 条」CTA | ✅ |
+| E. Chat 发图弹窗（`ChatInputBar.kt`） | 专门的说明 AlertDialog | ✅ |
+
+漏斗锁死点在入口 A：它是最显眼的通用入口，却零铺垫直接把用户抛进 Logto 网页。
+
+## 方案（已选）
+
+**在入口 A 前置一个「登录价值说明」AlertDialog**；B–E 保持现状（已有场景化说明，避免双重弹窗）。
+
+考虑过的替代方案：
+1. 在 `AuthManager.signIn()` 内全局拦截加弹窗 —— 会给 B–E 造成双重说明/双重弹窗，放弃。
+2. 用 `ModalBottomSheet` 做更丰富的登录页 —— 项目内说明类 UI 惯例是 `AlertDialog`
+   （`SignInHintHost`、发图登录弹窗、登出确认等），且改动更重，YAGNI，放弃。
+
+### 组件
+
+新建 `shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SignInValueDialog.kt`：
+
+- Material3 `AlertDialog`（沿用项目惯例，TextButton 按钮）。
+- 内容：标题 + 3 条价值点（图标 + 文案）+ 底部小字流程预期说明：
+  - ⭐ 一键 Star 喜欢的仓库（对应 star 能力）
+  - 💬 更多 AI 对话额度与深度解读（不体现具体次数，避免额度策略调整后文案过期）
+  - 👤 查看你的 GitHub 主页与关注动态（Profile 页能力）
+  - 小字：将跳转浏览器完成 GitHub 授权 —— 设定预期，直接针对「网页流程中途放弃」
+- **不提收藏同步**（未上线，不承诺）。
+- 参数：`source: String`（埋点来源，便于未来复用）、`onConfirm`、`onDismiss`。
+
+### 接线（HomeScreen）
+
+未登录点击头像：`signIn()` → `showSignInValueDialog = true`；
+弹窗确认 → 关闭弹窗 + `authManager.signIn()`；取消/外点 → 关闭。
+`LoggingIn` 状态下按钮已禁用，无重入问题。
+
+### 埋点
+
+沿用 `trackEvent`（`Platform.kt`），事件命名对齐现有 snake_case 风格，均带 `source` 属性
+（当前唯一取值 `home_avatar`）：
+
+- `sign_in_value_shown` —— 弹窗曝光
+- `sign_in_value_confirm` —— 点「登录」（后续接既有 `sign_in_success`/`sign_in_failed` 形成完整漏斗）
+- `sign_in_value_dismiss` —— 点「暂不」或外点/返回关闭
+
+### 字符串
+
+`shared/composeResources/values{,-zh}/strings.xml` 新增：
+`sign_in_value_title` / `sign_in_value_star` / `sign_in_value_chat` / `sign_in_value_profile` /
+`sign_in_value_footer` / `sign_in_value_dismiss`；确认按钮复用现有 `sign_in`。
+
+## 测试与验证
+
+- 弹窗为纯 UI 组件（无 ViewModel 逻辑），按项目现状不新增 commonTest；
+- 运行时验证：构建 → 安装 Pixel_9_2 模拟器 → 未登录点头像 → 截图确认弹窗内容（中英双语）、
+  「暂不」关闭、「登录」拉起 Logto 授权页。
+
+## 成功标准
+
+- 未登录点击首页头像先看到价值说明，确认后才进入网页授权；
+- `sign_in_value_*` 漏斗可量化弹窗到授权完成的转化；
+- 上线后观察 `sign_in_failed(user_canceled)` 占比与 `repo_star` 渗透变化。

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -145,6 +145,12 @@
     <string name="sign_in">登录</string>
     <string name="sign_out">退出登录</string>
     <string name="sign_out_confirm">确定要退出登录吗？</string>
+    <string name="sign_in_value_title">登录解锁更多功能</string>
+    <string name="sign_in_value_star">一键 Star 喜欢的仓库</string>
+    <string name="sign_in_value_chat">更多 AI 对话额度与深度解读</string>
+    <string name="sign_in_value_profile">查看你的 GitHub 主页与关注动态</string>
+    <string name="sign_in_value_footer">将跳转浏览器完成 GitHub 授权，只需片刻。</string>
+    <string name="sign_in_value_dismiss">暂不</string>
     <string name="sign_in_hint_title">登录未完成</string>
     <string name="sign_in_hint_connectivity">GitHub 登录需要能正常访问 github.com，请检查网络后重试。</string>
     <string name="sign_in_hint_dismiss">知道了</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -145,6 +145,12 @@
     <string name="sign_in">Sign in</string>
     <string name="sign_out">Sign out</string>
     <string name="sign_out_confirm">Are you sure you want to sign out?</string>
+    <string name="sign_in_value_title">Sign in to unlock more</string>
+    <string name="sign_in_value_star">Star repos you like with one tap</string>
+    <string name="sign_in_value_chat">More AI chats a day, plus in-depth overviews</string>
+    <string name="sign_in_value_profile">Your GitHub profile and network activity</string>
+    <string name="sign_in_value_footer">You&apos;ll be taken to your browser to sign in with GitHub — it only takes a moment.</string>
+    <string name="sign_in_value_dismiss">Not now</string>
     <string name="sign_in_hint_title">Sign-in not completed</string>
     <string name="sign_in_hint_connectivity">GitHub sign-in needs to reach github.com. Please check your connection and try again.</string>
     <string name="sign_in_hint_dismiss">Got it</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SignInValueDialog.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SignInValueDialog.kt
@@ -1,0 +1,103 @@
+package whl.trending.ai.ui.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.sign_in
+import trendingai.shared.generated.resources.sign_in_value_chat
+import trendingai.shared.generated.resources.sign_in_value_dismiss
+import trendingai.shared.generated.resources.sign_in_value_footer
+import trendingai.shared.generated.resources.sign_in_value_profile
+import trendingai.shared.generated.resources.sign_in_value_star
+import trendingai.shared.generated.resources.sign_in_value_title
+import whl.trending.ai.core.platform.trackEvent
+
+/**
+ * 登录价值说明弹窗：在拉起 Logto 网页授权前，先告诉用户登录能得到什么。
+ *
+ * 背景：埋点显示登录失败几乎全是 user_canceled——用户被直接抛进陌生的浏览器授权页，
+ * 不知道登录有什么用就放弃了。此弹窗前置价值点并预告「会跳转浏览器」，降低授权中途放弃率。
+ * 只挂在无场景上下文的入口（首页头像）；star Snackbar / chat 配额卡等入口自带场景化说明，不套此弹窗。
+ *
+ * 注意：价值点只列已上线能力（star / chat 配额 / GitHub 主页），未上线的收藏同步不得出现在这里。
+ *
+ * @param source 埋点来源标识（如 "home_avatar"），随 sign_in_value_* 事件上报
+ */
+@Composable
+fun SignInValueDialog(
+    source: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    LaunchedEffect(Unit) { trackEvent("sign_in_value_shown", mapOf("source" to source)) }
+
+    val dismiss = {
+        trackEvent("sign_in_value_dismiss", mapOf("source" to source))
+        onDismiss()
+    }
+    AlertDialog(
+        onDismissRequest = dismiss,
+        title = { Text(stringResource(Res.string.sign_in_value_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                BenefitRow(Icons.Filled.Star, stringResource(Res.string.sign_in_value_star))
+                BenefitRow(Icons.AutoMirrored.Filled.Chat, stringResource(Res.string.sign_in_value_chat))
+                BenefitRow(Icons.Filled.Person, stringResource(Res.string.sign_in_value_profile))
+                Text(
+                    text = stringResource(Res.string.sign_in_value_footer),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                trackEvent("sign_in_value_confirm", mapOf("source" to source))
+                onConfirm()
+            }) {
+                Text(stringResource(Res.string.sign_in))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = dismiss) {
+                Text(stringResource(Res.string.sign_in_value_dismiss))
+            }
+        },
+    )
+}
+
+@Composable
+private fun BenefitRow(icon: ImageVector, text: String) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(20.dp),
+        )
+        Text(text = text, style = MaterialTheme.typography.bodyMedium)
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SignInValueDialog.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SignInValueDialog.kt
@@ -50,12 +50,13 @@ fun SignInValueDialog(
 ) {
     LaunchedEffect(Unit) { trackEvent("sign_in_value_shown", mapOf("source" to source)) }
 
-    val dismiss = {
-        trackEvent("sign_in_value_dismiss", mapOf("source" to source))
+    // method 区分「暂不」按钮（button）与外点/返回键（outside）：明确拒绝和随手关闭对文案迭代的含义不同
+    val dismiss = { method: String ->
+        trackEvent("sign_in_value_dismiss", mapOf("source" to source, "method" to method))
         onDismiss()
     }
     AlertDialog(
-        onDismissRequest = dismiss,
+        onDismissRequest = { dismiss("outside") },
         title = { Text(stringResource(Res.string.sign_in_value_title)) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -79,7 +80,7 @@ fun SignInValueDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = dismiss) {
+            TextButton(onClick = { dismiss("button") }) {
                 Text(stringResource(Res.string.sign_in_value_dismiss))
             }
         },

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -81,6 +81,7 @@ import whl.trending.ai.chat.globalChatScreen
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.ChatModelsProvider
 import whl.trending.ai.data.repository.UserRepository
+import whl.trending.ai.ui.common.SignInValueDialog
 import whl.trending.ai.ui.feed.FeedScreen
 import whl.trending.ai.ui.feed.FeedViewModel
 import whl.trending.ai.ui.picks.PicksScreen
@@ -107,6 +108,8 @@ fun HomeScreen(
     val selectedTab = HomeTab.valueOf(selectedTabName)
     var showFilterSheet by rememberSaveable { mutableStateOf(false) }
     var showHistorySheet by rememberSaveable { mutableStateOf(false) }
+    // 未登录点头像不直接拉起网页授权，先弹登录价值说明（见 SignInValueDialog）
+    var showSignInValueDialog by rememberSaveable { mutableStateOf(false) }
 
     val trendingViewModel: TrendingViewModel = viewModel { TrendingViewModel() }
     val trendingUiState by trendingViewModel.uiState.collectAsState()
@@ -166,7 +169,7 @@ fun HomeScreen(
                     authState = authState,
                     userAvatarUrl = userAvatarUrl,
                     onProfileClick = {
-                        if (authState is AuthState.LoggedIn) onNavigateToProfile() else authManager.signIn()
+                        if (authState is AuthState.LoggedIn) onNavigateToProfile() else showSignInValueDialog = true
                     },
                 )
                 HomeTab.Picks -> PicksTopBar(
@@ -305,6 +308,17 @@ fun HomeScreen(
                 viewModel = picksViewModel!!
             )
         }
+    }
+
+    if (showSignInValueDialog) {
+        SignInValueDialog(
+            source = "home_avatar",
+            onConfirm = {
+                showSignInValueDialog = false
+                authManager.signIn()
+            },
+            onDismiss = { showSignInValueDialog = false },
+        )
     }
 }
 


### PR DESCRIPTION
## 背景

埋点数据显示：约 117 台设备尝试登录，仅 22 台成功（约 19%）；0.19.0 版本 `sign_in_failed` 的 reason 全部为 `user_canceled`——用户是在 Logto 网页授权流程中主动放弃，并非技术故障。`repo_star` 渗透率仅 1.2%，基本被该漏斗锁死。

根因：首页 topbar 头像是唯一"零说明"的登录入口——未登录点击直接拉起网页授权，用户不知道登录能得到什么，也不知道会跳浏览器，遇到陌生流程即放弃。（chat 配额卡 / 发图弹窗 / star Snackbar 均已有场景化说明，保持现状，避免双重弹窗。）

## 改动

- 新增可复用组件 `SignInValueDialog`（shared/ui/common，M3 AlertDialog 惯例，带 `source` 埋点参数）：
  - 三条价值点：⭐ 一键 Star 喜欢的仓库 / 💬 更多 AI 对话额度与深度解读 / 👤 查看你的 GitHub 主页与关注动态
  - 底部小字预告「将跳转浏览器完成 GitHub 授权，只需片刻」——针对网页流程中途放弃设定预期
  - 不提未上线的收藏同步
- `HomeScreen`：未登录点头像 → 先弹窗，确认后才 `signIn()`；已登录行为不变
- 新增埋点 `sign_in_value_shown` / `sign_in_value_confirm` / `sign_in_value_dismiss`（带 `source=home_avatar`），与既有 `sign_in_success/failed` 串成完整漏斗
- 中英双语文案；设计文档见 `docs/superpowers/specs/2026-07-11-sign-in-value-prop-design.md`

## 验证

已在 Pixel 9 模拟器实机验证：
- 中/英文弹窗渲染正常（修复了英文文案 `\'` 在 Compose 资源中原样显示的转义问题，改用 `&apos;`）
- 「暂不」关闭无副作用；「登录」正常拉起 auth.trendingai.cn 授权页
- `./gradlew test` 通过

## 预期效果

上线后观察：`sign_in_value_*` 漏斗转化、`sign_in_failed(user_canceled)` 占比、`repo_star` 渗透变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在从首页头像入口触发 GitHub 网页授权之前，引入一个「登录价值主张」对话框，以减少用户主动取消的情况，并为其转化漏斗添加数据埋点。

New Features:
- 添加可复用的 `SignInValueDialog` 组件，在启动 GitHub 授权流程前向用户说明登录的好处。
- 当未登录用户点击首页顶部栏头像时显示 `SignInValueDialog`，通过显式确认来对现有登录流程进行「闸门控制」。

Bug Fixes:
- 修复 compose 资源中的英文文案转义问题，将直接使用的撇号转义替换为 `&apos;`。

Enhancements:
- 将「登录价值主张」文案本地化为中英文版本，并在 GitHub 登录期间对浏览器跳转的说明进行更清晰的表述。

Documentation:
- 添加设计规范文档，记录「登录价值主张」对话框的设计、文案、入口以及成功指标。

Chores:
- 为对话框生命周期（展示、确认、关闭）增加新的埋点事件，并带上来源标签，以完善登录漏斗的埋点跟踪。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a sign-in value proposition dialog before triggering GitHub web auth from the home avatar entry to reduce user-initiated cancellations and instrument its funnel.

New Features:
- Add a reusable SignInValueDialog component that explains the benefits of signing in before starting the GitHub authorization flow.
- Show the SignInValueDialog when unauthenticated users tap the home topbar avatar, gating the existing sign-in flow behind explicit confirmation.

Bug Fixes:
- Fix English copy escaping in compose resources by replacing literal apostrophe escapes with &apos;.

Enhancements:
- Localize sign-in value proposition copy in both Chinese and English, including clearer wording about browser redirection during GitHub sign-in.

Documentation:
- Add a design spec documenting the sign-in value proposition dialog, its copy, entry points, and success metrics.

Chores:
- Instrument new analytics events for the dialog lifecycle (shown, confirmed, dismissed) with a source tag to complete the sign-in funnel tracking.

</details>