### PR TITLE
feat: 首页 tab 支持设置默认显示哪一个

### DIFF
--- a/docs/superpowers/plans/2026-07-11-home-default-tab.md
+++ b/docs/superpowers/plans/2026-07-11-home-default-tab.md
@@ -1,0 +1,358 @@
+# 首页默认 tab 设置 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 允许用户在设置页选择冷启动时首页默认显示哪个底部 tab（GitHub / Hacker News / Product Hunt / Picks），当前写死为 GitHub。
+
+**Architecture:** KMP 分层架构，全部改动在 `shared/commonMain`。数据层 `SettingsManager` 新增字符串偏好 `default_home_tab`（存 `HomeTab.name`，默认 `"GitHub"`）；`HomeTab` 枚举增加防御性解析 `fromNameOrDefault`；`HomeScreen` 初始 tab 改为读该偏好；`SettingsScreen` 新增 ListItem + DropdownMenu 单选项，写入前埋点。
+
+**Tech Stack:** Kotlin Multiplatform / Compose Multiplatform / multiplatform-settings（`com.russhwolf.settings`，测试用 `MapSettings`）/ kotlin.test + kotlinx-coroutines-test
+
+**Spec:** `docs/superpowers/specs/2026-07-11-home-default-tab-design.md`
+
+## Global Constraints
+
+- 全部改动在 `shared/src/commonMain`（+ `commonTest`），不动 androidApp / iosApp。
+- 偏好存 `HomeTab.name` 字符串而非 ordinal（data 层不得 import ui 层的 `HomeTab`；`SettingsManager` 只处理 String）。
+- 埋点模式固定：`trackEvent("settings_default_home_tab_change", mapOf("tab" to tab.name.lowercase()))`，置于写入前（参照 SettingsScreen.kt:468 语言设置写法）。
+- 字符串资源必须 en/zh 两份同步加（`values/strings.xml` 与 `values-zh/strings.xml` key 一一对应）。
+- 单元测试命令：`./gradlew :shared:testAndroidHostTest`，全绿才允许 commit。
+- Commit 规范：`feat:` 前缀，中文描述，结尾加 `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`。
+
+---
+
+### Task 1: SettingsManager 新增 defaultHomeTab 偏好
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt`（key 常量区 :56 后、类尾 :287 前）
+- Test: `shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt`
+
+**Interfaces:**
+- Consumes: 现有 `SettingsManager(settings: ObservableSettings)` 与 `settings.getStringFlow/getString/putString`。
+- Produces: `val defaultHomeTab: Flow<String>`、`fun currentDefaultHomeTab(): String`、`fun setDefaultHomeTab(name: String)`——Task 2/3 依赖这三个签名；默认值字符串为 `"GitHub"`。
+
+- [ ] **Step 1: 写失败测试**
+
+在 `SettingsManagerTest.kt` 末尾（`openLinksInCustomTab_defaults_true_and_persists` 之后、类结束花括号前）追加：
+
+```kotlin
+    @Test
+    fun defaultHomeTab_defaults_to_github_and_persists() = runTest {
+        // 默认值：GitHub
+        assertEquals("GitHub", manager.currentDefaultHomeTab())
+        assertEquals("GitHub", manager.defaultHomeTab.first())
+
+        // 改为 Picks
+        manager.setDefaultHomeTab("Picks")
+        assertEquals("Picks", manager.currentDefaultHomeTab())
+        assertEquals("Picks", manager.defaultHomeTab.first())
+
+        // 模拟应用重启：同一份底层存储，新建 manager
+        val rebuilt = SettingsManager(settings)
+        assertEquals("Picks", rebuilt.currentDefaultHomeTab())
+    }
+```
+
+（所需 import：`runTest`、`first`、`assertEquals` 均已存在于该文件。）
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "whl.trending.ai.data.local.SettingsManagerTest" 2>&1 | tail -20`
+Expected: 编译失败，报 `unresolved reference: currentDefaultHomeTab`（新 API 尚不存在）。
+
+- [ ] **Step 3: 最小实现**
+
+`SettingsManager.kt` 两处修改。
+
+(a) key 常量区，在 `PICKS_NEWSLETTER_BANNER_DISMISSED_KEY`（:56）之后加：
+
+```kotlin
+    private val DEFAULT_HOME_TAB_KEY = "prefs_default_home_tab"
+```
+
+(b) 类内 `picksNewsletterBannerDismissed` 三件套（:287 附近）之后、类结束花括号前加：
+
+```kotlin
+    /**
+     * 冷启动默认显示的首页 tab，存 ui 层 HomeTab 枚举的 name（如 "GitHub"、"Picks"）。
+     * data 层不依赖 ui 层枚举，只存取字符串；解析与回落由 HomeTab.fromNameOrDefault 负责。
+     * 只决定初始值；会话内切 tab 不回写此设置。
+     */
+    val defaultHomeTab: Flow<String> = settings.getStringFlow(DEFAULT_HOME_TAB_KEY, "GitHub")
+
+    fun currentDefaultHomeTab(): String = settings.getString(DEFAULT_HOME_TAB_KEY, "GitHub")
+
+    fun setDefaultHomeTab(name: String) {
+        settings.putString(DEFAULT_HOME_TAB_KEY, name)
+    }
+```
+
+（`getStringFlow` import 已存在，:9。）
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "whl.trending.ai.data.local.SettingsManagerTest" 2>&1 | tail -20`
+Expected: `BUILD SUCCESSFUL`，全部用例 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt
+git commit -m "feat(settings): SettingsManager 新增首页默认 tab 偏好
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: HomeTab.fromNameOrDefault + HomeScreen 初始 tab 读设置
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt`（枚举 :94-96、初始值 :108-109）
+- Create: `shared/src/commonTest/kotlin/whl/trending/ai/ui/home/HomeTabTest.kt`
+
+**Interfaces:**
+- Consumes: Task 1 的 `globalSettingsManager.currentDefaultHomeTab(): String`（`globalSettingsManager` 已在 HomeScreen.kt:81 import）。
+- Produces: `HomeTab.fromNameOrDefault(name: String): HomeTab`（companion 函数，非法/未知输入回落 `HomeTab.GitHub`）——Task 3 的设置页也会用到。
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `shared/src/commonTest/kotlin/whl/trending/ai/ui/home/HomeTabTest.kt`：
+
+```kotlin
+package whl.trending.ai.ui.home
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HomeTabTest {
+
+    @Test
+    fun fromNameOrDefault_resolves_every_valid_name() {
+        HomeTab.entries.forEach { tab ->
+            assertEquals(tab, HomeTab.fromNameOrDefault(tab.name))
+        }
+    }
+
+    @Test
+    fun fromNameOrDefault_falls_back_to_github_on_unknown_name() {
+        assertEquals(HomeTab.GitHub, HomeTab.fromNameOrDefault("NoSuchTab"))
+    }
+
+    @Test
+    fun fromNameOrDefault_falls_back_to_github_on_blank() {
+        assertEquals(HomeTab.GitHub, HomeTab.fromNameOrDefault(""))
+    }
+
+    @Test
+    fun fromNameOrDefault_is_case_sensitive_like_storage() {
+        // 存储值就是 HomeTab.name 原文，大小写不符视为非法、回落 GitHub
+        assertEquals(HomeTab.GitHub, HomeTab.fromNameOrDefault("picks"))
+    }
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "whl.trending.ai.ui.home.HomeTabTest" 2>&1 | tail -20`
+Expected: 编译失败，报 `unresolved reference: fromNameOrDefault`。
+
+- [ ] **Step 3: 最小实现**
+
+`HomeScreen.kt` 两处修改。
+
+(a) 枚举（:94-96）改为：
+
+```kotlin
+enum class HomeTab {
+    GitHub, HackerNews, ProductHunt, Picks;
+
+    companion object {
+        /** 解析持久化的 tab name；非法值（枚举改名、脏数据）回落 GitHub */
+        fun fromNameOrDefault(name: String): HomeTab =
+            entries.firstOrNull { it.name == name } ?: GitHub
+    }
+}
+```
+
+(b) 初始值（:108-109）由：
+
+```kotlin
+    var selectedTabName by rememberSaveable { mutableStateOf(HomeTab.GitHub.name) }
+    val selectedTab = HomeTab.valueOf(selectedTabName)
+```
+
+改为：
+
+```kotlin
+    // 冷启动进入设置页选的默认 tab；仅初始值，会话内切换与 rememberSaveable 恢复不受影响
+    var selectedTabName by rememberSaveable {
+        mutableStateOf(HomeTab.fromNameOrDefault(globalSettingsManager.currentDefaultHomeTab()).name)
+    }
+    val selectedTab = HomeTab.fromNameOrDefault(selectedTabName)
+```
+
+（`valueOf` 一并换成防御性解析；`globalSettingsManager` import 已存在 :81。）
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "whl.trending.ai.ui.home.HomeTabTest" 2>&1 | tail -20`
+Expected: `BUILD SUCCESSFUL`，4 个用例 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt shared/src/commonTest/kotlin/whl/trending/ai/ui/home/HomeTabTest.kt
+git commit -m "feat(home): 首页初始 tab 改为读默认 tab 设置，解析失败回落 GitHub
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: 设置页新增「默认首页」下拉单选 + 字符串资源
+
+**Files:**
+- Modify: `shared/src/commonMain/composeResources/values/strings.xml`（:53 `new_only_default_desc` 之后）
+- Modify: `shared/src/commonMain/composeResources/values-zh/strings.xml`（:53 同位置）
+- Modify: `shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt`（状态收集 :180 附近、「只看 New」item :514-529 之后、文件尾私有函数区）
+
+**Interfaces:**
+- Consumes: Task 1 的 `defaultHomeTab: Flow<String>` / `currentDefaultHomeTab()` / `setDefaultHomeTab(name)`；Task 2 的 `HomeTab.fromNameOrDefault(name)`；现有字符串 `hackernews_title` / `producthunt_title` / `picks_title`。
+- Produces: 设置页 UI 项（无下游代码依赖）；埋点事件 `settings_default_home_tab_change`。
+
+- [ ] **Step 1: 新增字符串资源（en/zh 同步）**
+
+`values/strings.xml` :53 `new_only_default_desc` 行后插入：
+
+```xml
+    <string name="default_home_tab">Default home tab</string>
+    <string name="default_home_tab_desc">Which tab the app opens to at launch</string>
+```
+
+`values-zh/strings.xml` :53 同位置插入：
+
+```xml
+    <string name="default_home_tab">默认首页</string>
+    <string name="default_home_tab_desc">启动时进入的标签页</string>
+```
+
+- [ ] **Step 2: SettingsScreen 状态收集与 import**
+
+(a) import 区补齐（对照文件头现有风格，各自插到对应字母序附近即可）：
+
+```kotlin
+import androidx.compose.material.icons.filled.Home
+import whl.trending.ai.ui.home.HomeTab
+import trendingai.shared.generated.resources.default_home_tab
+import trendingai.shared.generated.resources.default_home_tab_desc
+import trendingai.shared.generated.resources.hackernews_title
+import trendingai.shared.generated.resources.producthunt_title
+import trendingai.shared.generated.resources.picks_title
+```
+
+注意：`picks_title` 等三个 tab 名字符串若已被该文件 import 则跳过重复项（当前未 import，需新增）。
+
+(b) 状态收集，在 `trendingNewOnlyDefault`（:180）之后加一行：
+
+```kotlin
+    val defaultHomeTab by globalSettingsManager.defaultHomeTab.collectAsState(
+        remember { globalSettingsManager.currentDefaultHomeTab() }
+    )
+```
+
+- [ ] **Step 3: 新增设置项 UI**
+
+在「只看 New」默认开关的 `item { ... }`（:514-529）之后插入：
+
+```kotlin
+            // 默认首页 tab：只决定冷启动进入哪个 tab，会话内切换不回写
+            item {
+                var expanded by remember { mutableStateOf(false) }
+                ListItem(
+                    headlineContent = { Text(stringResource(Res.string.default_home_tab)) },
+                    supportingContent = { Text(stringResource(Res.string.default_home_tab_desc)) },
+                    leadingContent = { Icon(Icons.Default.Home, null) },
+                    trailingContent = {
+                        Box {
+                            Text(
+                                text = homeTabOptionText(HomeTab.fromNameOrDefault(defaultHomeTab)),
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.clickable { expanded = true }
+                            )
+                            DropdownMenu(
+                                expanded = expanded,
+                                onDismissRequest = { expanded = false }
+                            ) {
+                                HomeTab.entries.forEach { tab ->
+                                    DropdownMenuItem(
+                                        text = { Text(homeTabOptionText(tab)) },
+                                        onClick = {
+                                            expanded = false
+                                            trackEvent("settings_default_home_tab_change", mapOf("tab" to tab.name.lowercase()))
+                                            globalSettingsManager.setDefaultHomeTab(tab.name)
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+                )
+            }
+```
+
+- [ ] **Step 4: 新增选项显示名函数**
+
+在文件尾私有函数区（`languageOptionText` 附近）加：
+
+```kotlin
+@Composable
+private fun homeTabOptionText(tab: HomeTab): String = when (tab) {
+    HomeTab.GitHub -> "GitHub"
+    HomeTab.HackerNews -> stringResource(Res.string.hackernews_title)
+    HomeTab.ProductHunt -> stringResource(Res.string.producthunt_title)
+    HomeTab.Picks -> stringResource(Res.string.picks_title)
+}
+```
+
+（"GitHub" 为品牌名，中英一致，与首页底部栏的写法保持字面量；其余复用现有 title 字符串。）
+
+- [ ] **Step 5: 编译 + 全量测试**
+
+Run: `./gradlew :shared:testAndroidHostTest 2>&1 | tail -20`
+Expected: `BUILD SUCCESSFUL`（资源生成 + 编译 + 既有/新增测试全绿）。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/src/commonMain/composeResources/values/strings.xml shared/src/commonMain/composeResources/values-zh/strings.xml shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+git commit -m "feat(settings): 设置页新增「默认首页」tab 选择项
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: 运行时验证（真机行为取证）
+
+**Files:**
+- 无代码改动；产出验证截图/结论。
+
+**Interfaces:**
+- Consumes: Task 1-3 的完整功能。
+- Produces: 验证结论与截图证据。
+
+- [ ] **Step 1: 按项目 verify 配方构建安装并驱动 UI**
+
+使用项目的 `verify` skill（构建、安装到 Pixel_9_2 模拟器、驱动 UI、截图取证），验证以下场景：
+
+1. 设置页出现「默认首页」条目，点开下拉可见 GitHub / Hacker News / Product Hunt / Picks 四项。
+2. 选择 Picks 后，杀进程冷启动 app，首页落在 Picks tab。
+3. 会话内手动切到 GitHub 再进设置页，「默认首页」仍显示 Picks（切 tab 不回写）。
+4. 改回 GitHub，冷启动落在 GitHub tab。
+
+Expected: 四个场景全部符合预期，留存关键截图。
+
+- [ ] **Step 2: 汇报验证结果**
+
+整理场景结论 + 截图路径，向用户汇报；不符合预期则回到对应 Task 修复。

--- a/docs/superpowers/specs/2026-07-11-home-default-tab-design.md
+++ b/docs/superpowers/specs/2026-07-11-home-default-tab-design.md
@@ -1,0 +1,57 @@
+# 首页默认 tab 设置 — 设计文档
+
+日期：2026-07-11
+分支：feat/home-default-tab
+
+## 背景与目标
+
+首页底部有 4 个 tab（GitHub / Hacker News / Product Hunt / Picks），当前冷启动默认选中写死为 `HomeTab.GitHub`（`shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt:108`）。目标：允许用户在设置页选择冷启动时默认显示哪个 tab。
+
+方案已确认：**设置项固定默认 tab**（不做「记住上次浏览」）。
+
+## 数据层（SettingsManager.kt）
+
+`shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt`：
+
+- 新增 key 常量 `DEFAULT_HOME_TAB_KEY = "default_home_tab"`。
+- 按现有偏好三件套模式暴露：
+  - `val defaultHomeTab: Flow<String>` — `settings.getStringFlow(DEFAULT_HOME_TAB_KEY, "GitHub")`
+  - `fun currentDefaultHomeTab(): String` — 同步读，默认 `"GitHub"`
+  - `fun setDefaultHomeTab(name: String)` — 写入
+- 存 `HomeTab.name` 字符串而非 ordinal：`HomeTab` 枚举定义在 ui 层，data 层不反向依赖 ui；字符串也抗枚举顺序调整。
+
+## 首页（HomeScreen.kt）
+
+- `selectedTabName` 的初始值从写死的 `HomeTab.GitHub.name` 改为读 `globalSettingsManager.currentDefaultHomeTab()`。
+- 解析用 `runCatching { HomeTab.valueOf(it) }`，失败回落 `HomeTab.GitHub`（防御存储值异常/枚举改名）。该解析逻辑抽为可测的纯函数（如 `HomeTab.fromNameOrDefault(name)`）。
+- 仅影响**初始值**：会话内切 tab、`rememberSaveable` 进程恢复、通知深链 `HomeTabRequest` 的消费时机与优先级均不变（深链在组合后消费，天然覆盖默认值）。
+
+## 设置页（SettingsScreen.kt）
+
+- 新增「默认首页」条目，参照现有「应用语言」的 `ListItem` + `DropdownMenu` 单选写法（4 个选项用 SegmentedButton 过挤）。
+- 下拉选项：GitHub / Hacker News / Product Hunt / Picks——用全称，不用底部栏的 HN/PH 缩写；Picks 复用 `picks_title`。
+- 条目放在主题、语言所在的通用分组。
+- 选中即调 `globalSettingsManager.setDefaultHomeTab(tab.name)`，写入前按现有模式埋点：
+  `trackEvent("settings_default_home_tab_change", mapOf("tab" to tab.name.lowercase()))`。
+
+## 字符串资源
+
+`shared/src/commonMain/composeResources/values/strings.xml` 与 `values-zh/strings.xml` 各新增：
+
+- 设置项标题：Default home tab / 默认首页
+- 选项显示名（GitHub、Hacker News、Product Hunt 如无现成全称字符串则新增；Picks 复用 `picks_title`）
+
+## 测试
+
+- `commonTest`：用内存版 `Settings`（`MapSettings`）覆盖 `SettingsManager` 默认值与读写。
+- `HomeTab.fromNameOrDefault` 纯函数：合法值、非法值回落、空值回落。
+
+## 埋点
+
+沿用统一模式：`trackEvent("settings_default_home_tab_change", mapOf("tab" to <枚举>.name.lowercase()))`，置于设置页点击回调、写入之前。
+
+## 不做（YAGNI）
+
+- 不加「记住上次浏览的 tab」选项。
+- iOS 无需特殊处理，全部改动在 commonMain。
+- 不改底部导航 UI 与 tab 顺序。

--- a/docs/superpowers/specs/2026-07-11-home-default-tab-design.md
+++ b/docs/superpowers/specs/2026-07-11-home-default-tab-design.md
@@ -13,7 +13,7 @@
 
 `shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt`：
 
-- 新增 key 常量 `DEFAULT_HOME_TAB_KEY = "default_home_tab"`。
+- 新增 key 常量 `DEFAULT_HOME_TAB_KEY = "prefs_default_home_tab"`（沿用现有 `prefs_` 前缀约定）。
 - 按现有偏好三件套模式暴露：
   - `val defaultHomeTab: Flow<String>` — `settings.getStringFlow(DEFAULT_HOME_TAB_KEY, "GitHub")`
   - `fun currentDefaultHomeTab(): String` — 同步读，默认 `"GitHub"`

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -51,6 +51,8 @@
     <string name="new_only_hint">近期首次登上 GitHub 日榜（全语言）的新项目</string>
     <string name="new_only_default">默认只看 New</string>
     <string name="new_only_default_desc">启动时自动开启 GitHub 榜的「只看 New」过滤</string>
+    <string name="default_home_tab">默认首页</string>
+    <string name="default_home_tab_desc">启动时进入的标签页</string>
     <string name="daily_picks_notification">每日精选提醒</string>
     <string name="daily_picks_notification_desc">每日精选更新后本地通知提醒，无需推送服务</string>
     <string name="notification_permission_denied">未获得通知权限，请在系统设置中允许通知</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -51,6 +51,8 @@
     <string name="new_only_hint">Projects new to the GitHub daily all-language trending board</string>
     <string name="new_only_default">New only by default</string>
     <string name="new_only_default_desc">Turn on the New filter for the GitHub list at launch</string>
+    <string name="default_home_tab">Default home tab</string>
+    <string name="default_home_tab_desc">Which tab the app opens to at launch</string>
     <string name="daily_picks_notification">Daily Picks reminder</string>
     <string name="daily_picks_notification_desc">A local notification when the day&#8217;s AI picks are ready — no push service required</string>
     <string name="notification_permission_denied">Notification permission is off. Allow it in system settings to get reminders.</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -27,6 +27,9 @@ enum class ThemeMode(val title: String) {
 
 const val DEFAULT_SEED_ARGB: Long = 0xFF6750A4L
 
+/** 默认首页 tab 的持久化值（HomeTab.name），仅 SettingsManager 内部作缺省值使用 */
+private const val DEFAULT_HOME_TAB_NAME = "GitHub"
+
 enum class AppLanguage(val isoCode: String?) {
     FOLLOW_SYSTEM(null),
     CHINESE("zh"),
@@ -292,9 +295,9 @@ class SettingsManager(private val settings: ObservableSettings) {
      * data 层不依赖 ui 层枚举，只存取字符串；解析与回落由 HomeTab.fromNameOrDefault 负责。
      * 只决定初始值；会话内切 tab 不回写此设置。
      */
-    val defaultHomeTab: Flow<String> = settings.getStringFlow(DEFAULT_HOME_TAB_KEY, "GitHub")
+    val defaultHomeTab: Flow<String> = settings.getStringFlow(DEFAULT_HOME_TAB_KEY, DEFAULT_HOME_TAB_NAME)
 
-    fun currentDefaultHomeTab(): String = settings.getString(DEFAULT_HOME_TAB_KEY, "GitHub")
+    fun currentDefaultHomeTab(): String = settings.getString(DEFAULT_HOME_TAB_KEY, DEFAULT_HOME_TAB_NAME)
 
     fun setDefaultHomeTab(name: String) {
         settings.putString(DEFAULT_HOME_TAB_KEY, name)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -54,6 +54,7 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val TRENDING_NEW_ONLY_DEFAULT_KEY = "prefs_trending_new_only_default"
     private val DAILY_PICKS_NOTIFICATION_KEY = "prefs_daily_picks_notification"
     private val PICKS_NEWSLETTER_BANNER_DISMISSED_KEY = "prefs_picks_newsletter_banner_dismissed"
+    private val DEFAULT_HOME_TAB_KEY = "prefs_default_home_tab"
 
     /**
      * 安装级匿名标识：首次访问时生成并持久化，之后保持不变（卸载重装才会重新生成）。
@@ -284,6 +285,19 @@ class SettingsManager(private val settings: ObservableSettings) {
 
     fun setPicksNewsletterBannerDismissed(value: Boolean) {
         settings.putBoolean(PICKS_NEWSLETTER_BANNER_DISMISSED_KEY, value)
+    }
+
+    /**
+     * 冷启动默认显示的首页 tab，存 ui 层 HomeTab 枚举的 name（如 "GitHub"、"Picks"）。
+     * data 层不依赖 ui 层枚举，只存取字符串；解析与回落由 HomeTab.fromNameOrDefault 负责。
+     * 只决定初始值；会话内切 tab 不回写此设置。
+     */
+    val defaultHomeTab: Flow<String> = settings.getStringFlow(DEFAULT_HOME_TAB_KEY, "GitHub")
+
+    fun currentDefaultHomeTab(): String = settings.getString(DEFAULT_HOME_TAB_KEY, "GitHub")
+
+    fun setDefaultHomeTab(name: String) {
+        settings.putString(DEFAULT_HOME_TAB_KEY, name)
     }
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -92,7 +92,13 @@ import whl.trending.ai.ui.trending.TrendingViewModel
 import kotlin.time.Clock
 
 enum class HomeTab {
-    GitHub, HackerNews, ProductHunt, Picks
+    GitHub, HackerNews, ProductHunt, Picks;
+
+    companion object {
+        /** 解析持久化的 tab name；非法值（枚举改名、脏数据）回落 GitHub */
+        fun fromNameOrDefault(name: String): HomeTab =
+            entries.firstOrNull { it.name == name } ?: GitHub
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -105,8 +111,11 @@ fun HomeScreen(
     onNavigateToProfile: () -> Unit = {},
     onNavigateToSubscribe: () -> Unit = {}
 ) {
-    var selectedTabName by rememberSaveable { mutableStateOf(HomeTab.GitHub.name) }
-    val selectedTab = HomeTab.valueOf(selectedTabName)
+    // 冷启动进入设置页选的默认 tab；仅初始值，会话内切换与 rememberSaveable 恢复不受影响
+    var selectedTabName by rememberSaveable {
+        mutableStateOf(HomeTab.fromNameOrDefault(globalSettingsManager.currentDefaultHomeTab()).name)
+    }
+    val selectedTab = HomeTab.fromNameOrDefault(selectedTabName)
 
     // 组合树外的切 tab 请求（通知点击深链等）：置位状态可跨冷启动等到这里再消费
     LaunchedEffect(Unit) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -18,6 +18,7 @@ import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.data.remote.ApiException
 import whl.trending.ai.data.repository.TrendingRepository
 import whl.trending.ai.ui.home.githubLogoPainter
+import whl.trending.ai.ui.home.HomeTab
 import whl.trending.ai.notification.globalDailyPicksNotifier
 import whl.trending.ai.ui.theme.PRESET_PALETTE
 import whl.trending.ai.ui.theme.ThemeSeed
@@ -51,6 +52,7 @@ import androidx.compose.material.icons.filled.ColorLens
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FiberNew
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PrivacyTip
 import androidx.compose.material.icons.filled.Language
@@ -121,6 +123,11 @@ import trendingai.shared.generated.resources.daily_picks_notification
 import trendingai.shared.generated.resources.daily_picks_notification_desc
 import trendingai.shared.generated.resources.notification_permission_denied
 import trendingai.shared.generated.resources.dark_mode
+import trendingai.shared.generated.resources.default_home_tab
+import trendingai.shared.generated.resources.default_home_tab_desc
+import trendingai.shared.generated.resources.hackernews_title
+import trendingai.shared.generated.resources.producthunt_title
+import trendingai.shared.generated.resources.picks_title
 import trendingai.shared.generated.resources.language_settings
 import trendingai.shared.generated.resources.language_option_chinese
 import trendingai.shared.generated.resources.language_option_english
@@ -178,6 +185,9 @@ fun SettingsScreen(
     val appLanguage by globalSettingsManager.appLanguage.collectAsState(AppLanguage.FOLLOW_SYSTEM)
     val openLinksInCustomTab by globalSettingsManager.openLinksInCustomTab.collectAsState(true)
     val trendingNewOnlyDefault by globalSettingsManager.trendingNewOnlyDefault.collectAsState(false)
+    val defaultHomeTab by globalSettingsManager.defaultHomeTab.collectAsState(
+        remember { globalSettingsManager.currentDefaultHomeTab() }
+    )
     val appVersion = remember { getAppVersion() }
     val isChecking by globalUpdateChecker.isChecking.collectAsState()
     val isUpToDate by globalUpdateChecker.isUpToDate.collectAsState()
@@ -527,6 +537,39 @@ fun SettingsScreen(
                     }
                 )
             }
+            // 默认首页 tab：只决定冷启动进入哪个 tab，会话内切换不回写
+            item {
+                var expanded by remember { mutableStateOf(false) }
+                ListItem(
+                    headlineContent = { Text(stringResource(Res.string.default_home_tab)) },
+                    supportingContent = { Text(stringResource(Res.string.default_home_tab_desc)) },
+                    leadingContent = { Icon(Icons.Default.Home, null) },
+                    trailingContent = {
+                        Box {
+                            Text(
+                                text = homeTabOptionText(HomeTab.fromNameOrDefault(defaultHomeTab)),
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.clickable { expanded = true }
+                            )
+                            DropdownMenu(
+                                expanded = expanded,
+                                onDismissRequest = { expanded = false }
+                            ) {
+                                HomeTab.entries.forEach { tab ->
+                                    DropdownMenuItem(
+                                        text = { Text(homeTabOptionText(tab)) },
+                                        onClick = {
+                                            expanded = false
+                                            trackEvent("settings_default_home_tab_change", mapOf("tab" to tab.name.lowercase()))
+                                            globalSettingsManager.setDefaultHomeTab(tab.name)
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+                )
+            }
             // 每日精选提醒：本地定时通知（WorkManager），全渠道可用；iOS 未支持则隐藏
             if (globalDailyPicksNotifier.isSupported) {
                 item {
@@ -672,6 +715,14 @@ private fun languageOptionText(language: AppLanguage): String {
         AppLanguage.ENGLISH -> Res.string.language_option_english
     }
     return stringResource(labelRes)
+}
+
+@Composable
+private fun homeTabOptionText(tab: HomeTab): String = when (tab) {
+    HomeTab.GitHub -> "GitHub"
+    HomeTab.HackerNews -> stringResource(Res.string.hackernews_title)
+    HomeTab.ProductHunt -> stringResource(Res.string.producthunt_title)
+    HomeTab.Picks -> stringResource(Res.string.picks_title)
 }
 
 @OptIn(ExperimentalLayoutApi::class)

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt
@@ -114,4 +114,20 @@ class SettingsManagerTest {
         manager.setOpenLinksInCustomTab(true)
         assertEquals(true, manager.currentOpenLinksInCustomTab())
     }
+
+    @Test
+    fun defaultHomeTab_defaults_to_github_and_persists() = runTest {
+        // 默认值：GitHub
+        assertEquals("GitHub", manager.currentDefaultHomeTab())
+        assertEquals("GitHub", manager.defaultHomeTab.first())
+
+        // 改为 Picks
+        manager.setDefaultHomeTab("Picks")
+        assertEquals("Picks", manager.currentDefaultHomeTab())
+        assertEquals("Picks", manager.defaultHomeTab.first())
+
+        // 模拟应用重启：同一份底层存储，新建 manager
+        val rebuilt = SettingsManager(settings)
+        assertEquals("Picks", rebuilt.currentDefaultHomeTab())
+    }
 }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/home/HomeTabTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/home/HomeTabTest.kt
@@ -1,0 +1,30 @@
+package whl.trending.ai.ui.home
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HomeTabTest {
+
+    @Test
+    fun fromNameOrDefault_resolves_every_valid_name() {
+        HomeTab.entries.forEach { tab ->
+            assertEquals(tab, HomeTab.fromNameOrDefault(tab.name))
+        }
+    }
+
+    @Test
+    fun fromNameOrDefault_falls_back_to_github_on_unknown_name() {
+        assertEquals(HomeTab.GitHub, HomeTab.fromNameOrDefault("NoSuchTab"))
+    }
+
+    @Test
+    fun fromNameOrDefault_falls_back_to_github_on_blank() {
+        assertEquals(HomeTab.GitHub, HomeTab.fromNameOrDefault(""))
+    }
+
+    @Test
+    fun fromNameOrDefault_is_case_sensitive_like_storage() {
+        // 存储值就是 HomeTab.name 原文，大小写不符视为非法、回落 GitHub
+        assertEquals(HomeTab.GitHub, HomeTab.fromNameOrDefault("picks"))
+    }
+}


### PR DESCRIPTION
## 背景

首页底部 4 个 tab（GitHub / Hacker News / Product Hunt / Picks）冷启动默认选中写死为 GitHub。本 PR 允许用户在设置页选择启动时进入哪个 tab。

## 改动

- **数据层**：`SettingsManager` 新增 `prefs_default_home_tab` 字符串偏好（Flow + 同步读 + 写三件套，默认 "GitHub"），只存 `HomeTab.name` 字符串，不反向依赖 ui 层枚举
- **首页**：`HomeScreen` 初始 tab 改为读该设置，新增防御性解析 `HomeTab.fromNameOrDefault`（非法值回落 GitHub，同时消除原 `valueOf` 的崩溃风险）；仅影响初始值，会话内切 tab、`rememberSaveable` 恢复、通知深链 `HomeTabRequest` 优先级均不变
- **设置页**：「应用设置」分组新增「默认首页」ListItem + DropdownMenu（参照应用语言项写法），选项用全称，写入前埋点 `settings_default_home_tab_change`
- **资源**：en/zh 同步新增 `default_home_tab` / `default_home_tab_desc`，选项名复用现有 title 字符串
- **测试**：`SettingsManagerTest` 覆盖默认值/读写/跨实例持久化；新增 `HomeTabTest` 覆盖解析回落

## 验证

- `./gradlew :shared:testAndroidHostTest` 全绿
- Pixel 9 模拟器实机验证 4 场景全部通过：下拉四项齐全；选 Picks 冷启动落 Picks；会话内切 tab 不回写设置；改回 GitHub 冷启动落 GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在应用启动时新增对默认首页标签的配置支持，并将其贯穿数据层、首页和设置界面。

新功能：
- 引入一个可持久化的默认首页标签偏好设置，用于控制应用冷启动时首页初始标签。
- 在应用设置中新增“默认首页标签”选项，允许用户在 GitHub、Hacker News、Product Hunt 和 Picks 之间进行选择。

错误修复：
- 通过用安全解析器替换直接使用枚举 `valueOf` 的方式来增强首页标签选择的健壮性，当存储的值无效时回退到 GitHub。

优化改进：
- 添加 `HomeTab.fromNameOrDefault` 辅助方法，以在应用中安全解析已存储的标签名称。
- 为新的默认首页标签设置提供英文和中文本地化文案。
- 在新的 Markdown 规格说明和计划文档中记录默认首页标签功能的设计和实现方案。

测试：
- 扩展 `SettingsManager` 测试，覆盖默认首页标签偏好的生命周期以及在不同管理器实例间的持久化行为。
- 为 `HomeTab.fromNameOrDefault` 添加单元测试，以验证其解析和回退行为的正确性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for configuring which home tab is shown by default on app launch and wire it through data, home screen, and settings UI.

New Features:
- Introduce a persisted default home tab preference that controls the initial home screen tab on cold start.
- Expose a new "Default home tab" option in app settings allowing users to choose among GitHub, Hacker News, Product Hunt, and Picks.

Bug Fixes:
- Harden home tab selection by replacing direct enum valueOf usage with a safe parser that falls back to GitHub on invalid stored values.

Enhancements:
- Add a HomeTab.fromNameOrDefault helper to safely parse stored tab names across the app.
- Localize copy for the new default home tab setting in both English and Chinese.
- Document the design and implementation plan for the default home tab feature in new markdown specs and plans.

Tests:
- Extend SettingsManager tests to cover the default home tab preference lifecycle and persistence across manager instances.
- Add unit tests for HomeTab.fromNameOrDefault to verify correct parsing and fallback behavior.

</details>