### PR TITLE
feat(updater): 更新提示弹窗展示新版本更新内容

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -309,7 +309,29 @@ jobs:
           if [ -s diff-apk.txt ]; then
             FILES+=("diff-apk.txt")
           fi
-          
+
+          # whatsnew.json 上传为 release asset，供 app 更新弹窗展示更新内容（androidLibrary/updater
+          # 按固定文件名 whatsnew.json 查找并消费）。仅在 version==本次 tag 且内容非空时上传；
+          # 占位文件 / 生成失败则跳过，客户端找不到 asset 会回退为不带内容的更新弹窗。
+          if python3 - <<'EOF'
+          import json, os, sys
+          try:
+              with open(os.environ["WHATSNEW_PATH"]) as f:
+                  d = json.load(f)
+          except Exception:
+              sys.exit(1)
+          def items(key):
+              return [x for x in d.get(key, []) if isinstance(x, str) and x.strip()]
+          ok = d.get("version") == os.environ["VERSION_NAME"] and (items("zh") or items("en"))
+          sys.exit(0 if ok else 1)
+          EOF
+          then
+            echo "✅ whatsnew.json 内容有效，随 Release 上传"
+            FILES+=("$WHATSNEW_PATH")
+          else
+            echo "⚠️ whatsnew.json 无本版有效内容，跳过上传"
+          fi
+
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
             --notes-file release_summary.md \

--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -322,7 +322,8 @@ jobs:
               sys.exit(1)
           def items(key):
               return [x for x in d.get(key, []) if isinstance(x, str) and x.strip()]
-          ok = d.get("version") == os.environ["VERSION_NAME"] and (items("zh") or items("en"))
+          version = os.environ.get("VERSION_NAME", "")
+          ok = bool(version) and d.get("version") == version and (items("zh") or items("en"))
           sys.exit(0 if ok else 1)
           EOF
           then

--- a/androidLibrary/updater/build.gradle.kts
+++ b/androidLibrary/updater/build.gradle.kts
@@ -21,10 +21,11 @@ android {
 dependencies {
     implementation(project(":shared"))
     implementation(libs.ktor.client.okhttp)
-    implementation(libs.ktor.client.contentNegotiation)
-    implementation(libs.ktor.serialization.kotlinxJson)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.compose.material3)
     implementation(libs.compose.runtime)
     implementation(libs.androidx.lifecycle.viewmodelCompose)
+
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlin.test.junit)
 }

--- a/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateApi.kt
+++ b/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateApi.kt
@@ -5,6 +5,7 @@ import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -60,12 +61,16 @@ class UpdateApi {
                 "https://api.github.com/repos/HarlonWang/TrendingAI/releases/latest"
             ).bodyAsText()
         )
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }
 
     suspend fun fetchWhatsNew(url: String): WhatsNewInfo? = try {
         parseWhatsNew(client.get(url).bodyAsText())
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }

--- a/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateApi.kt
+++ b/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateApi.kt
@@ -1,36 +1,71 @@
 package whl.trending.updater
 
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
-import io.ktor.serialization.kotlinx.json.json
+import io.ktor.client.statement.bodyAsText
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import whl.trending.ai.update.WhatsNewInfo
+import whl.trending.ai.update.parseWhatsNew
 
 @Serializable
 private data class GitHubRelease(
-    @SerialName("tag_name") val tagName: String
+    @SerialName("tag_name") val tagName: String,
+    val assets: List<GitHubAsset> = emptyList(),
 )
+
+@Serializable
+private data class GitHubAsset(
+    val name: String = "",
+    @SerialName("browser_download_url") val browserDownloadUrl: String = "",
+)
+
+data class LatestRelease(
+    val tagName: String,
+    /** release 附件里 whatsnew.json 的下载地址；该版未上传时为 null（回退为不带更新内容的弹窗） */
+    val whatsNewAssetUrl: String?,
+)
+
+private val releaseJson = Json { ignoreUnknownKeys = true }
+
+internal fun parseLatestRelease(raw: String): LatestRelease? =
+    runCatching { releaseJson.decodeFromString<GitHubRelease>(raw) }.getOrNull()?.let { release ->
+        LatestRelease(
+            tagName = release.tagName,
+            whatsNewAssetUrl = release.assets
+                .firstOrNull { it.name == "whatsnew.json" }
+                ?.browserDownloadUrl
+                ?.takeIf { it.isNotBlank() },
+        )
+    }
+
+/** asset 内容须非空且 version 与本次 release 的 tag 一致才采用，防止串版展示。 */
+internal fun acceptWhatsNew(info: WhatsNewInfo?, tag: String): WhatsNewInfo? =
+    info?.takeIf { !it.isEmpty && it.version == tag }
 
 class UpdateApi {
     private val client = HttpClient(OkHttp) {
-        install(ContentNegotiation) {
-            json(Json { ignoreUnknownKeys = true })
-        }
         install(HttpTimeout) {
             requestTimeoutMillis = 10_000
             connectTimeoutMillis = 10_000
         }
     }
 
-    suspend fun fetchLatestVersion(): String? = try {
-        client.get(
-            "https://api.github.com/repos/HarlonWang/TrendingAI/releases/latest"
-        ).body<GitHubRelease>().tagName
+    suspend fun fetchLatestRelease(): LatestRelease? = try {
+        parseLatestRelease(
+            client.get(
+                "https://api.github.com/repos/HarlonWang/TrendingAI/releases/latest"
+            ).bodyAsText()
+        )
+    } catch (e: Exception) {
+        null
+    }
+
+    suspend fun fetchWhatsNew(url: String): WhatsNewInfo? = try {
+        parseWhatsNew(client.get(url).bodyAsText())
     } catch (e: Exception) {
         null
     }

--- a/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateDialog.kt
+++ b/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateDialog.kt
@@ -1,24 +1,53 @@
 package whl.trending.updater
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import whl.trending.ai.core.Constants
+import whl.trending.ai.core.platform.getSystemLanguage
 import whl.trending.ai.core.platform.openDownloadUrl
 import whl.trending.ai.core.platform.openUrl
+import whl.trending.ai.data.local.AppLanguage
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.update.pickByLanguage
 
 @Composable
 fun UpdateDialog(updateInfo: UpdateInfo, downloadUrl: String, onDismiss: () -> Unit) {
+    val appLanguage by globalSettingsManager.appLanguage
+        .collectAsState(AppLanguage.FOLLOW_SYSTEM)
+    val lang = appLanguage.isoCode ?: getSystemLanguage()
+    val items = updateInfo.whatsNew?.let { pickByLanguage(lang, it.zh, it.en) }.orEmpty()
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(stringResource(R.string.update_dialog_title, updateInfo.latestVersion))
         },
         text = {
-            Text(stringResource(R.string.update_dialog_message, updateInfo.currentVersion))
+            if (items.isEmpty()) {
+                Text(stringResource(R.string.update_dialog_message, updateInfo.currentVersion))
+            } else {
+                // 样式对齐升级首启的 WhatsNewDialog：逐条 • 列表、可滚动
+                Column(
+                    modifier = Modifier.verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items.forEach { item ->
+                        Text("• $item")
+                    }
+                }
+            }
         },
         confirmButton = {
             TextButton(onClick = {
@@ -31,11 +60,14 @@ fun UpdateDialog(updateInfo: UpdateInfo, downloadUrl: String, onDismiss: () -> U
         },
         dismissButton = {
             Row {
-                TextButton(onClick = {
-                    openUrl(Constants.RELEASES_URL)
-                    onDismiss()
-                }) {
-                    Text(stringResource(R.string.update_dialog_changelog))
+                // 更新内容已展示在弹窗内时不再提供跳转，避免三按钮拥挤
+                if (items.isEmpty()) {
+                    TextButton(onClick = {
+                        openUrl(Constants.RELEASES_URL)
+                        onDismiss()
+                    }) {
+                        Text(stringResource(R.string.update_dialog_changelog))
+                    }
                 }
                 TextButton(onClick = onDismiss) {
                     Text(stringResource(R.string.update_dialog_cancel))

--- a/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateInfo.kt
+++ b/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateInfo.kt
@@ -1,6 +1,10 @@
 package whl.trending.updater
 
+import whl.trending.ai.update.WhatsNewInfo
+
 data class UpdateInfo(
     val latestVersion: String,
-    val currentVersion: String
+    val currentVersion: String,
+    /** 新版本的更新内容（来自 release asset whatsnew.json）；取不到时为 null，弹窗回退纯版本提示 */
+    val whatsNew: WhatsNewInfo? = null,
 )

--- a/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateViewModel.kt
+++ b/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateViewModel.kt
@@ -51,13 +51,21 @@ class UpdateViewModel : ViewModel(), UpdateChecker {
         _isChecking.value = true
         _isUpToDate.value = false
 
-        val latest = withContext(Dispatchers.IO) { api.fetchLatestVersion() }
+        val latest = withContext(Dispatchers.IO) { api.fetchLatestRelease() }
 
         if (latest != null) {
             globalSettingsManager.setLastUpdateCheckTime(System.currentTimeMillis())
             val current = getAppVersion()
-            if (isNewer(latest, current)) {
-                _updateInfo.value = UpdateInfo(latest, current)
+            if (isNewer(latest.tagName, current)) {
+                // 更新内容取自 release asset，任一环节失败仅回退为不带内容的弹窗，不影响更新提示本身
+                val whatsNew = latest.whatsNewAssetUrl?.let { url ->
+                    withContext(Dispatchers.IO) { api.fetchWhatsNew(url) }
+                }
+                _updateInfo.value = UpdateInfo(
+                    latestVersion = latest.tagName,
+                    currentVersion = current,
+                    whatsNew = acceptWhatsNew(whatsNew, latest.tagName),
+                )
             } else {
                 _isUpToDate.value = true
                 delay(2000)

--- a/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateViewModel.kt
+++ b/androidLibrary/updater/src/main/kotlin/whl/trending/updater/UpdateViewModel.kt
@@ -58,8 +58,8 @@ class UpdateViewModel : ViewModel(), UpdateChecker {
             val current = getAppVersion()
             if (isNewer(latest.tagName, current)) {
                 // 更新内容取自 release asset，任一环节失败仅回退为不带内容的弹窗，不影响更新提示本身
-                val whatsNew = latest.whatsNewAssetUrl?.let { url ->
-                    withContext(Dispatchers.IO) { api.fetchWhatsNew(url) }
+                val whatsNew = withContext(Dispatchers.IO) {
+                    latest.whatsNewAssetUrl?.let { api.fetchWhatsNew(it) }
                 }
                 _updateInfo.value = UpdateInfo(
                     latestVersion = latest.tagName,

--- a/androidLibrary/updater/src/test/kotlin/whl/trending/updater/UpdateApiTest.kt
+++ b/androidLibrary/updater/src/test/kotlin/whl/trending/updater/UpdateApiTest.kt
@@ -1,0 +1,83 @@
+package whl.trending.updater
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import whl.trending.ai.update.WhatsNewInfo
+
+class UpdateApiTest {
+
+    // ---- parseLatestRelease ----
+
+    @Test
+    fun parse_release_with_whatsnew_asset() {
+        val release = parseLatestRelease(
+            """
+            {
+              "tag_name": "0.21.0",
+              "assets": [
+                {"name": "app.apk", "browser_download_url": "https://example.com/app.apk"},
+                {"name": "whatsnew.json", "browser_download_url": "https://example.com/whatsnew.json"}
+              ]
+            }
+            """.trimIndent()
+        )
+        assertEquals("0.21.0", release?.tagName)
+        assertEquals("https://example.com/whatsnew.json", release?.whatsNewAssetUrl)
+    }
+
+    @Test
+    fun parse_release_without_whatsnew_asset() {
+        val release = parseLatestRelease(
+            """{"tag_name":"0.21.0","assets":[{"name":"app.apk","browser_download_url":"https://example.com/app.apk"}]}"""
+        )
+        assertEquals("0.21.0", release?.tagName)
+        assertNull(release?.whatsNewAssetUrl)
+    }
+
+    @Test
+    fun parse_release_missing_assets_field() {
+        val release = parseLatestRelease("""{"tag_name":"0.21.0"}""")
+        assertEquals("0.21.0", release?.tagName)
+        assertNull(release?.whatsNewAssetUrl)
+    }
+
+    @Test
+    fun parse_release_ignores_unknown_keys() {
+        val release = parseLatestRelease(
+            """{"tag_name":"0.21.0","body":"### notes","draft":false,"assets":[]}"""
+        )
+        assertEquals("0.21.0", release?.tagName)
+    }
+
+    @Test
+    fun parse_invalid_json_returns_null() {
+        assertNull(parseLatestRelease("not json"))
+        assertNull(parseLatestRelease(""))
+    }
+
+    // ---- acceptWhatsNew ----
+
+    @Test
+    fun accept_matching_version_with_content() {
+        val info = WhatsNewInfo("0.21.0", zh = listOf("修复崩溃"), en = listOf("Fix crash"))
+        assertEquals(info, acceptWhatsNew(info, "0.21.0"))
+    }
+
+    @Test
+    fun reject_version_mismatch() {
+        val info = WhatsNewInfo("0.20.0", zh = listOf("旧内容"), en = emptyList())
+        assertNull(acceptWhatsNew(info, "0.21.0"))
+    }
+
+    @Test
+    fun reject_empty_content() {
+        val info = WhatsNewInfo("0.21.0", zh = emptyList(), en = emptyList())
+        assertNull(acceptWhatsNew(info, "0.21.0"))
+    }
+
+    @Test
+    fun reject_null_info() {
+        assertNull(acceptWhatsNew(null, "0.21.0"))
+    }
+}

--- a/docs/superpowers/specs/2026-07-12-update-dialog-release-notes-design.md
+++ b/docs/superpowers/specs/2026-07-12-update-dialog-release-notes-design.md
@@ -12,119 +12,111 @@ apk 渠道的更新提示弹窗(`androidLibrary/updater` 的 `UpdateDialog`)目�
 ## 现状梳理
 
 - `UpdateApi.fetchLatestVersion()` 请求 `GET /repos/HarlonWang/TrendingAI/releases/latest`,
-  但只反序列化了 `tag_name`,忽略了同一响应里的 `body` 字段。
-- GitHub Release 正文(`body`)由 CI(`android_release.yml` 的 Generate Release Notes 步骤)
-  从 whatsnew.json 拼出,格式稳定:
-  ```markdown
-  ### ✨ 更新内容
-  - 中文条目…
-
-  ### ✨ What's New
-  - English item…
-
-  ### Apk Diff
-  …(体积对比等内部信息)
-  ```
-  自动/手动两种 whatsnew 生成模式产出的 body 结构一致。
-  兜底格式(whatsnew 缺失时)为 `### 变更记录 (Changelog)` + 原始 commit 列表,不适合面向用户展示。
-- 升级后首启的 `WhatsNewDialog`(shared 模块)已经确立了更新说明的展示样式
-  (`• 条目` 列表、8dp 间距、可滚动)和语言选择规则(app 语言设置 → 系统语言,zh 缺失回退 en,反之亦然)。
+  只反序列化 `tag_name`;响应里还有 `body`(Release 正文 markdown)和 `assets[]`(附件列表)。
+- 更新说明的源头是 CI 构建时生成/采用的 whatsnew.json(结构化 JSON:`{version, zh[], en[]}`),
+  它随 APK 打包供升级后首启弹窗,同时被拼进 Release 正文;但 CI 目前**不把这份 JSON 上传为
+  release asset**,自动模式下仓库里提交的又只是占位文件——即结构化数据在发布后无处可取。
+- 升级后首启的 `WhatsNewDialog`(shared 模块)已确立更新说明的展示样式
+  (`• 条目` 列表、8dp 间距、可滚动)和语言选择规则(app 语言设置 → 系统语言,zh 缺失回退 en,
+  反之亦然);shared 里已有 `WhatsNewInfo` 数据类和 `parseWhatsNew()` 解析函数。
 
 ## 候选方案
 
-### 方案 A:复用 `releases/latest` 响应的 `body` 字段(推荐)
+### 方案 A:客户端解析 `releases/latest` 响应的 `body` markdown
 
-在现有请求里多解析一个 `body` 字段,客户端用纯函数从 markdown 中提取
-「✨ 更新内容 / ✨ What's New」两节的条目,在更新弹窗内直接展示。
+- 优点:零新增网络请求、不改 CI。
+- 缺点:依赖 Release 正文的标题格式约定(`### ✨ 更新内容` / `### ✨ What's New`),
+  markdown 解析天然脆弱;`gh release create` 还带 `--generate-notes`,正文里混有
+  GitHub 自动生成段落和 Apk Diff 等内部信息,解析器要逐一排雷。
 
-- 优点:零新增网络请求;对所有已发布的历史 release 立即生效;改动收敛在 updater 库;
-  解析器是纯函数,单测容易覆盖。
-- 缺点:依赖 release body 的标题格式约定(缓解:解析器宽松匹配 + 解析失败静默回退现状,
-  并在 CI 工作流的 Generate Release Notes 步骤加注释声明该格式已被客户端消费)。
+### 方案 B:CI 把 whatsnew.json 上传为 release asset,客户端二次请求(选定)
 
-### 方案 B:CI 把 whatsnew.json 作为 release asset 上传,客户端二次请求
-
-- 优点:结构化 JSON,无需解析 markdown。
-- 缺点:多一次网络请求;需要改 CI;对已发布的历史版本不生效(只有下个 tag 起才有 asset);
-  旧版本 app 升级路径上拿不到。
-- 注:改从 tag 对应 commit 的 raw.githubusercontent 读 whatsnew.json 不可行——
-  自动模式下仓库里提交的是占位文件,真实内容只存在于 CI 构建产物中。
+- 优点:结构化 JSON,客户端直接复用 shared 已有的 `WhatsNewInfo` / `parseWhatsNew()`,
+  无 markdown 解析;与 Release 正文格式解耦,正文以后随便改;数据契约就是 app 内已在消费的
+  whatsnew.json 本身,一处格式两处使用。
+- 缺点:发现新版本时多一次网络请求(仅在确认有更新后才发起,频率极低);需小改 CI。
+- 关于"对历史 release 不生效":实际影响可忽略——弹窗只展示 `releases/latest` 指向的
+  **最新** release,带此功能的 app 版本发布时 CI 改动同步上线,此后检查到的任何新版本都带 asset;
+  唯一拿不到 asset 的场景是 latest 恰为功能上线前的旧版本,而那时也不存在"有更新"可弹。
 
 ### 方案 C:官网/服务端维护结构化 changelog 接口
 
 - 优点:格式完全自主可控。
 - 缺点:新增服务端组件与发布流程,维护成本远超收益,违反 YAGNI。
 
-**结论:选方案 A。** B 的"结构化"收益不足以抵消额外请求 + 历史版本失效;C 过重。
+**结论:选方案 B**(用户拍板)。结构化契约的长期稳健性优于 A 省掉的那一次低频请求;C 过重。
 
-## 设计(方案 A)
+## 设计(方案 B)
+
+### CI:上传 whatsnew.json 为 release asset
+
+`android_release.yml` 的 Create Release 步骤,`FILES` 数组组装处追加条件上传:
+
+- 仅当 `whatsnew.json` 的 `version` 恰等于本次 tag 且 zh/en 至少一个非空时,
+  `FILES+=("$WHATSNEW_PATH")`;否则跳过(占位文件/生成失败不上传,
+  客户端"找不到 asset → 回退现状"即为正确行为)。
+- 判定逻辑与 Generate What's New 步骤的"手动模式"判定同构,用几行 python/jq 实现。
+- asset 文件名固定为 `whatsnew.json`(gh 按原文件名上传),这是客户端查找的契约。
 
 ### 数据层:`UpdateApi`
 
-- `GitHubRelease` 增加 `@SerialName("body") val body: String = ""`。
+- `GitHubRelease` 增加 `@SerialName("assets") val assets: List<GitHubAsset> = emptyList()`,
+  `GitHubAsset(name, @SerialName("browser_download_url") browserDownloadUrl)`。
 - `fetchLatestVersion(): String?` 改为 `fetchLatestRelease(): LatestRelease?`,
-  返回 `LatestRelease(tagName: String, body: String)`。
-
-### 解析:`ReleaseNotesParser`(updater 库内新文件,纯函数)
-
-```kotlin
-fun parseReleaseNotes(body: String): ReleaseNotes
-data class ReleaseNotes(val zh: List<String>, val en: List<String>)
-```
-
-逐行扫描:
-
-- 遇到 `###` 开头且含「更新内容」的标题 → 进入 zh 收集态;含「What's New」→ en 收集态;
-  其余 `###`/`##` 标题(Apk Diff、变更记录等)→ 退出收集态。
-- 收集态内,`- ` 或 `• ` 开头的行去前缀后收入当前语种列表;空行跳过。
-- 兜底格式(变更记录 + raw commits)没有目标标题 → 解析结果为空,由 UI 回退。
+  返回 `LatestRelease(tagName: String, whatsNewAssetUrl: String?)`
+  (从 assets 里找 `name == "whatsnew.json"`,找不到为 null)。
+- 新增 `suspend fun fetchWhatsNew(url: String): WhatsNewInfo?`:
+  GET 该 asset(okhttp 默认跟随 GitHub 的重定向),响应文本交给 shared 的 `parseWhatsNew()`;
+  任何异常返回 null。复用现有 client 与超时配置。
 
 ### 状态:`UpdateInfo` / `UpdateViewModel`
 
-- `UpdateInfo` 增加 `releaseNotes: ReleaseNotes`(默认空)。
-- `doCheck()` 中拿到 `LatestRelease` 后,`isNewer` 成立时以 `parseReleaseNotes(body)` 填入。
+- `UpdateInfo` 增加 `whatsNew: WhatsNewInfo?`(默认 null)。
+- `doCheck()`:`isNewer` 成立且 `whatsNewAssetUrl != null` 时,再请求 asset;
+  取到的 `WhatsNewInfo` 需通过版本校验 `info.version == tagName` 才采用
+  (防串版:asset 内容与 release 不符时宁可不展示),否则置 null。
+  asset 请求失败不影响弹窗本身,只是不带更新内容。
+- 版本校验收敛为纯函数以便测试:
+  `fun acceptWhatsNew(info: WhatsNewInfo?, tag: String): WhatsNewInfo?`
+  (null / isEmpty / version 不等于 tag → null)。
 
 ### UI:`UpdateDialog`
 
-- 语言选择:与 `WhatsNewHost` 相同规则——`globalSettingsManager.appLanguage`
-  (FOLLOW_SYSTEM 时取 `getSystemLanguage()`),zh 取 `zh` 列表(空则回退 `en`),否则反之。
-  updater 库已依赖 `:shared`,可直接复用这两个 API。
+- 语言选择:把 `WhatsNewHost` 里「按语言从 zh/en 双列表选一」抽成 shared 里的纯函数
+  (如 `WhatsNew.kt` 内 `pickByLanguage(lang, zh, en)`),`WhatsNewHost` 与 `UpdateDialog`
+  两处调用;语言来源同 `WhatsNewHost`:`globalSettingsManager.appLanguage`
+  (FOLLOW_SYSTEM 时取 `getSystemLanguage()`)。updater 库已依赖 `:shared`。
 - 选出的条目列表非空时:正文区改为可滚动 `Column`(`verticalScroll` + 8dp 间距),
   逐条渲染 `• 条目`,样式对齐 `WhatsNewDialog`;不再显示原「当前版本 x,前往官网下载」句
   (新版本号已在标题,下载动作已有按钮);同时隐藏「查看更新日志」按钮——
   内容已在弹窗内,该按钮只剩查看 Apk Diff 等内部信息的价值,不值得挤占三按钮空间。
-- 条目为空(解析失败/兜底格式/网络返回无 body):完全维持现状,包括「查看更新日志」按钮。
-
-### CI 配套
-
-`android_release.yml` 的 Generate Release Notes 步骤加一行注释:
-「### ✨ 更新内容 / ### ✨ What's New 标题被 app 更新弹窗解析消费,改格式需同步 updater 库」。
-不改任何行为。
+- 条目为空(无 asset / 请求失败 / 版本校验不过):完全维持现状,包括「查看更新日志」按钮。
 
 ### 错误处理
 
-- 解析全程不抛错:任何意外格式都落到"空列表 → 回退现状",不新增失败面。
+- asset 缺失、下载失败、JSON 解析失败、版本不匹配,全部落到「whatsNew = null → 回退现状」,
+  不新增失败面;更新弹窗本身的出现与否只由 `tag_name` 版本比较决定,与 asset 无关。
 - 网络层行为不变(超时、异常返回 null 的语义保持)。
 
 ### 测试
 
 updater 模块新增 `src/test`(现仅有 `main`),test 依赖复用 version catalog 现有 alias
-(与 shared 模块 JVM 单测所用一致,不新建重复条目)。用例覆盖 `parseReleaseNotes`:
+(与现有 JVM 单测所用一致,不新建重复条目)。用例:
 
-1. 标准双语 body(含 Apk Diff 后缀小节)→ zh/en 均正确、后缀小节不混入;
-2. 仅 en 小节 → zh 空、en 正确;
-3. 兜底格式(变更记录 + raw commits)→ 双语均空;
-4. 空字符串 / 无关 markdown → 双语均空;
-5. 条目前缀 `- ` 与 `• ` 混用、标题前后有空行 → 正常解析。
-
-语言选择逻辑:把 `WhatsNewHost` 里「按语言从 zh/en 双列表选一」抽成 shared 里的纯函数
-(如 `WhatsNew.kt` 内 `pickByLanguage(lang, zh, en)`),`WhatsNewHost` 与 `UpdateDialog` 两处调用,
-单测放在现有 `WhatsNewTest`。
+1. `acceptWhatsNew`:version 匹配且非空 → 采用;version 不匹配 / zh+en 均空 / null → 拒绝;
+2. `LatestRelease` 的 asset 查找:assets 含 `whatsnew.json` → 取到 url;
+   不含 / assets 为空 → null(可作为响应 JSON 反序列化测试,用 mockwebserver 或直接喂 Json 字符串);
+3. shared 的 `pickByLanguage`:zh 环境取 zh、zh 空回退 en、反之亦然
+   (放现有 `WhatsNewTest`,连同 `WhatsNewHost` 重构后的行为一并覆盖)。
 
 ### 影响范围
 
-- `androidLibrary/updater`:UpdateApi、UpdateInfo、UpdateViewModel、UpdateDialog、
-  新增 ReleaseNotesParser + 单测。
-- `shared`:可选的小重构(抽语言选择纯函数供 WhatsNewHost 与 UpdateDialog 复用)。
-- `.github/workflows/android_release.yml`:仅加注释。
+- `androidLibrary/updater`:UpdateApi、UpdateInfo、UpdateViewModel、UpdateDialog,新增单测。
+- `shared`:抽 `pickByLanguage` 纯函数(`WhatsNew.kt`),`WhatsNewHost` 改为调用它。
+- `.github/workflows/android_release.yml`:Create Release 步骤条件上传 whatsnew.json asset。
 - 不涉及 play / fdroid 渠道(它们不启用自建更新检查),不涉及 whatsnew 首启弹窗行为。
+
+### 发布注意事项
+
+功能上线后的**第一个** tag 必须包含本 CI 改动(否则该版 release 无 asset,弹窗回退旧样式,
+功能等于晚一个版本才可见);无需其他运维动作。

--- a/docs/superpowers/specs/2026-07-12-update-dialog-release-notes-design.md
+++ b/docs/superpowers/specs/2026-07-12-update-dialog-release-notes-design.md
@@ -1,0 +1,130 @@
+# 更新弹窗展示版本更新内容 — 设计方案
+
+日期:2026-07-12
+分支:feat/update-dialog-release-notes
+
+## 背景与问题
+
+apk 渠道的更新提示弹窗(`androidLibrary/updater` 的 `UpdateDialog`)目前只显示
+「发现新版本 x.y.z / 当前版本 x.y.z,前往官网下载最新版本」,不包含本次版本改了什么。
+用户要判断"值不值得更新"只能点「查看更新日志」跳浏览器打开 GitHub Releases 页,路径长、流失率高。
+
+## 现状梳理
+
+- `UpdateApi.fetchLatestVersion()` 请求 `GET /repos/HarlonWang/TrendingAI/releases/latest`,
+  但只反序列化了 `tag_name`,忽略了同一响应里的 `body` 字段。
+- GitHub Release 正文(`body`)由 CI(`android_release.yml` 的 Generate Release Notes 步骤)
+  从 whatsnew.json 拼出,格式稳定:
+  ```markdown
+  ### ✨ 更新内容
+  - 中文条目…
+
+  ### ✨ What's New
+  - English item…
+
+  ### Apk Diff
+  …(体积对比等内部信息)
+  ```
+  自动/手动两种 whatsnew 生成模式产出的 body 结构一致。
+  兜底格式(whatsnew 缺失时)为 `### 变更记录 (Changelog)` + 原始 commit 列表,不适合面向用户展示。
+- 升级后首启的 `WhatsNewDialog`(shared 模块)已经确立了更新说明的展示样式
+  (`• 条目` 列表、8dp 间距、可滚动)和语言选择规则(app 语言设置 → 系统语言,zh 缺失回退 en,反之亦然)。
+
+## 候选方案
+
+### 方案 A:复用 `releases/latest` 响应的 `body` 字段(推荐)
+
+在现有请求里多解析一个 `body` 字段,客户端用纯函数从 markdown 中提取
+「✨ 更新内容 / ✨ What's New」两节的条目,在更新弹窗内直接展示。
+
+- 优点:零新增网络请求;对所有已发布的历史 release 立即生效;改动收敛在 updater 库;
+  解析器是纯函数,单测容易覆盖。
+- 缺点:依赖 release body 的标题格式约定(缓解:解析器宽松匹配 + 解析失败静默回退现状,
+  并在 CI 工作流的 Generate Release Notes 步骤加注释声明该格式已被客户端消费)。
+
+### 方案 B:CI 把 whatsnew.json 作为 release asset 上传,客户端二次请求
+
+- 优点:结构化 JSON,无需解析 markdown。
+- 缺点:多一次网络请求;需要改 CI;对已发布的历史版本不生效(只有下个 tag 起才有 asset);
+  旧版本 app 升级路径上拿不到。
+- 注:改从 tag 对应 commit 的 raw.githubusercontent 读 whatsnew.json 不可行——
+  自动模式下仓库里提交的是占位文件,真实内容只存在于 CI 构建产物中。
+
+### 方案 C:官网/服务端维护结构化 changelog 接口
+
+- 优点:格式完全自主可控。
+- 缺点:新增服务端组件与发布流程,维护成本远超收益,违反 YAGNI。
+
+**结论:选方案 A。** B 的"结构化"收益不足以抵消额外请求 + 历史版本失效;C 过重。
+
+## 设计(方案 A)
+
+### 数据层:`UpdateApi`
+
+- `GitHubRelease` 增加 `@SerialName("body") val body: String = ""`。
+- `fetchLatestVersion(): String?` 改为 `fetchLatestRelease(): LatestRelease?`,
+  返回 `LatestRelease(tagName: String, body: String)`。
+
+### 解析:`ReleaseNotesParser`(updater 库内新文件,纯函数)
+
+```kotlin
+fun parseReleaseNotes(body: String): ReleaseNotes
+data class ReleaseNotes(val zh: List<String>, val en: List<String>)
+```
+
+逐行扫描:
+
+- 遇到 `###` 开头且含「更新内容」的标题 → 进入 zh 收集态;含「What's New」→ en 收集态;
+  其余 `###`/`##` 标题(Apk Diff、变更记录等)→ 退出收集态。
+- 收集态内,`- ` 或 `• ` 开头的行去前缀后收入当前语种列表;空行跳过。
+- 兜底格式(变更记录 + raw commits)没有目标标题 → 解析结果为空,由 UI 回退。
+
+### 状态:`UpdateInfo` / `UpdateViewModel`
+
+- `UpdateInfo` 增加 `releaseNotes: ReleaseNotes`(默认空)。
+- `doCheck()` 中拿到 `LatestRelease` 后,`isNewer` 成立时以 `parseReleaseNotes(body)` 填入。
+
+### UI:`UpdateDialog`
+
+- 语言选择:与 `WhatsNewHost` 相同规则——`globalSettingsManager.appLanguage`
+  (FOLLOW_SYSTEM 时取 `getSystemLanguage()`),zh 取 `zh` 列表(空则回退 `en`),否则反之。
+  updater 库已依赖 `:shared`,可直接复用这两个 API。
+- 选出的条目列表非空时:正文区改为可滚动 `Column`(`verticalScroll` + 8dp 间距),
+  逐条渲染 `• 条目`,样式对齐 `WhatsNewDialog`;不再显示原「当前版本 x,前往官网下载」句
+  (新版本号已在标题,下载动作已有按钮);同时隐藏「查看更新日志」按钮——
+  内容已在弹窗内,该按钮只剩查看 Apk Diff 等内部信息的价值,不值得挤占三按钮空间。
+- 条目为空(解析失败/兜底格式/网络返回无 body):完全维持现状,包括「查看更新日志」按钮。
+
+### CI 配套
+
+`android_release.yml` 的 Generate Release Notes 步骤加一行注释:
+「### ✨ 更新内容 / ### ✨ What's New 标题被 app 更新弹窗解析消费,改格式需同步 updater 库」。
+不改任何行为。
+
+### 错误处理
+
+- 解析全程不抛错:任何意外格式都落到"空列表 → 回退现状",不新增失败面。
+- 网络层行为不变(超时、异常返回 null 的语义保持)。
+
+### 测试
+
+updater 模块新增 `src/test`(现仅有 `main`),test 依赖复用 version catalog 现有 alias
+(与 shared 模块 JVM 单测所用一致,不新建重复条目)。用例覆盖 `parseReleaseNotes`:
+
+1. 标准双语 body(含 Apk Diff 后缀小节)→ zh/en 均正确、后缀小节不混入;
+2. 仅 en 小节 → zh 空、en 正确;
+3. 兜底格式(变更记录 + raw commits)→ 双语均空;
+4. 空字符串 / 无关 markdown → 双语均空;
+5. 条目前缀 `- ` 与 `• ` 混用、标题前后有空行 → 正常解析。
+
+语言选择逻辑:把 `WhatsNewHost` 里「按语言从 zh/en 双列表选一」抽成 shared 里的纯函数
+(如 `WhatsNew.kt` 内 `pickByLanguage(lang, zh, en)`),`WhatsNewHost` 与 `UpdateDialog` 两处调用,
+单测放在现有 `WhatsNewTest`。
+
+### 影响范围
+
+- `androidLibrary/updater`:UpdateApi、UpdateInfo、UpdateViewModel、UpdateDialog、
+  新增 ReleaseNotesParser + 单测。
+- `shared`:可选的小重构(抽语言选择纯函数供 WhatsNewHost 与 UpdateDialog 复用)。
+- `.github/workflows/android_release.yml`:仅加注释。
+- 不涉及 play / fdroid 渠道(它们不启用自建更新检查),不涉及 whatsnew 首启弹窗行为。

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/WhatsNewDialog.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/WhatsNewDialog.kt
@@ -26,6 +26,7 @@ import whl.trending.ai.data.local.AppLanguage
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.update.WhatsNewInfo
 import whl.trending.ai.update.parseWhatsNew
+import whl.trending.ai.update.pickByLanguage
 import whl.trending.ai.update.shouldShowWhatsNew
 
 /**
@@ -62,11 +63,7 @@ fun WhatsNewHost() {
         val appLanguage by globalSettingsManager.appLanguage
             .collectAsState(AppLanguage.FOLLOW_SYSTEM)
         val lang = appLanguage.isoCode ?: getSystemLanguage()
-        val items = if (lang.startsWith("zh")) {
-            whatsNew.zh.ifEmpty { whatsNew.en }
-        } else {
-            whatsNew.en.ifEmpty { whatsNew.zh }
-        }
+        val items = pickByLanguage(lang, whatsNew.zh, whatsNew.en)
         WhatsNewDialog(
             version = whatsNew.version,
             items = items,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/update/WhatsNew.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/update/WhatsNew.kt
@@ -24,6 +24,13 @@ fun parseWhatsNew(raw: String): WhatsNewInfo? =
     runCatching { whatsNewJson.decodeFromString<WhatsNewInfo>(raw) }.getOrNull()
 
 /**
+ * 按语言从中英双列表里选一份展示：zh 语言取 zh、缺失回退 en，其他语言反之。
+ * WhatsNewHost（升级首启弹窗）与 UpdateDialog（更新提示弹窗）共用。
+ */
+fun pickByLanguage(lang: String, zh: List<String>, en: List<String>): List<String> =
+    if (lang.startsWith("zh")) zh.ifEmpty { en } else en.ifEmpty { zh }
+
+/**
  * 升级后首启弹一次：
  * - lastSeen 为空（首次安装）不弹，由调用方静默写入当前版本
  * - lastSeen == 当前版本（日常启动）不弹

--- a/shared/src/commonTest/kotlin/whl/trending/ai/update/WhatsNewTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/update/WhatsNewTest.kt
@@ -74,4 +74,29 @@ class WhatsNewTest {
         assertNull(parseWhatsNew("not json"))
         assertNull(parseWhatsNew(""))
     }
+
+    // ---- pickByLanguage ----
+
+    @Test
+    fun chinese_picks_zh_list() {
+        assertEquals(listOf("中文"), pickByLanguage("zh", listOf("中文"), listOf("en")))
+        assertEquals(listOf("中文"), pickByLanguage("zh-Hans", listOf("中文"), listOf("en")))
+    }
+
+    @Test
+    fun non_chinese_picks_en_list() {
+        assertEquals(listOf("en"), pickByLanguage("en", listOf("中文"), listOf("en")))
+        assertEquals(listOf("en"), pickByLanguage("ja", listOf("中文"), listOf("en")))
+    }
+
+    @Test
+    fun empty_preferred_list_falls_back_to_other() {
+        assertEquals(listOf("en"), pickByLanguage("zh", emptyList(), listOf("en")))
+        assertEquals(listOf("中文"), pickByLanguage("en", listOf("中文"), emptyList()))
+    }
+
+    @Test
+    fun both_empty_returns_empty() {
+        assertEquals(emptyList(), pickByLanguage("zh", emptyList(), emptyList()))
+    }
 }


### PR DESCRIPTION
## 背景

apk 渠道的更新提示弹窗此前只显示版本号,用户想知道新版本改了什么必须跳浏览器看 GitHub Releases。

## 方案

whatsnew.json(app 内升级首启弹窗已在消费的结构化双语更新说明)由 CI 上传为 release asset,客户端发现新版本后二次请求该 asset 并在弹窗内展示。设计文档: docs/superpowers/specs/2026-07-12-update-dialog-release-notes-design.md

## 改动

- **CI**(android_release.yml): Create Release 步骤仅当 whatsnew.json 的 version==本次 tag 且内容非空时上传为 asset;占位/生成失败跳过,客户端回退
- **updater**: UpdateApi 解析 releases/latest 的 assets 找 whatsnew.json;确认有新版本后拉取 asset,经 acceptWhatsNew(version==tag 防串版)采用;UpdateDialog 有内容时正文改为可滚动 • 列表(样式对齐 WhatsNewDialog),隐藏「查看更新日志」按钮;任一环节失败完全回退原样式
- **shared**: 语言选择抽成纯函数 pickByLanguage,WhatsNewHost 与 UpdateDialog 共用
- **测试**: updater 新增 src/test(parseLatestRelease/acceptWhatsNew 9 例),WhatsNewTest 补 pickByLanguage 4 例

## 验证

- 全模块单测通过;CI 上传门控脚本本地实跑 4 种场景符合预期
- 模拟器端到端:0.19.0 包真实请求 API,无 asset 正确回退旧样式;临时注入验证新列表 UI 后已还原

## 发布注意

合并后的**第一个 tag 必须包含本 CI 改动**,否则该版 release 无 asset,新弹窗晚一个版本才可见。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在 Android 更新对话框中展示结构化的版本说明：从 GitHub Releases 中读取 `whatsnew.json` 资源，同时保留现有的回退行为。

New Features:
- 在 APK 更新提示对话框中，直接展示基于版本的更新亮点，使用双语的 `whatsnew.json` 数据。
- 在首次启动的 WhatsNew 对话框和更新提示中，根据应用/系统语言自动选择中文或英文的版本说明。

Enhancements:
- 扩展更新器 API，以读取发布资产（release assets）元数据，并为最新版本获取结构化的 `whatsnew.json` 内容。
- 更新 Android 更新对话框布局，在有版本说明时渲染可滚动的项目符号列表，并在这种情况下隐藏外部变更日志按钮。
- 重构共享的“whats-new”语言选择逻辑，将其抽取为可复用的 `pickByLanguage` 辅助函数，在多个对话框中复用。

Build:
- 在 Android 发布工作流中控制 `whatsnew.json` 作为 GitHub 发布资产的上传，仅在版本与标签匹配且内容非空时附加该文件。

Documentation:
- 添加设计规范文档，说明更新对话框的版本说明流程、CI 行为、语言处理及错误回退策略。

Tests:
- 为解析最新发布的 JSON 以及在更新器模块中校验合法的 `whatsnew` 负载添加单元测试。
- 扩展共享的 “whats-new” 测试，以覆盖基于语言的列表选择及回退行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Surface structured release notes in the Android update dialog by consuming a whatsnew.json asset from GitHub releases while preserving existing fallback behavior.

New Features:
- Show version-specific update highlights directly in the APK update prompt dialog using bilingual whatsnew.json data.
- Automatically select Chinese or English release notes in both the first-launch WhatsNew dialog and the update prompt based on app/system language.

Enhancements:
- Extend the updater API to read release assets metadata and fetch structured whatsnew.json content for the latest release.
- Update the Android update dialog layout to render a scrollable bullet list of changes when release notes are available and hide the external changelog button in that case.
- Refactor shared whats-new language selection into a reusable pickByLanguage helper used across dialogs.

Build:
- Gate uploading whatsnew.json as a GitHub release asset in the Android release workflow, only attaching it when the version matches the tag and contains non-empty content.

Documentation:
- Add a design spec documenting the update dialog release-notes flow, CI behavior, language handling, and error fallbacks.

Tests:
- Add unit tests for parsing latest release JSON and validating acceptable whatsnew payloads in the updater module.
- Expand shared whats-new tests to cover language-based list selection and fallbacks.

</details>