### PR TITLE
feat(picks): 两档结构——GitHub 上新 + 深度解读

### DIFF
--- a/androidLibrary/notifier/src/main/kotlin/whl/trending/notifier/DailyPicksWorker.kt
+++ b/androidLibrary/notifier/src/main/kotlin/whl/trending/notifier/DailyPicksWorker.kt
@@ -44,7 +44,8 @@ class DailyPicksWorker(
         } catch (e: Exception) {
             return retryOrGiveUp()
         }
-        val items = picks.debut + picks.deepDive + picks.controversy + picks.speedRead
+        // 与 Picks 页空态判定同口径：只认两档（speedRead/controversy 已退役，UI 不再渲染）
+        val items = picks.debut + picks.deepDive
         if (items.isEmpty()) return retryOrGiveUp()
 
         val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)

--- a/androidLibrary/notifier/src/main/kotlin/whl/trending/notifier/DailyPicksWorker.kt
+++ b/androidLibrary/notifier/src/main/kotlin/whl/trending/notifier/DailyPicksWorker.kt
@@ -44,7 +44,7 @@ class DailyPicksWorker(
         } catch (e: Exception) {
             return retryOrGiveUp()
         }
-        val items = picks.deepDive + picks.controversy + picks.speedRead
+        val items = picks.debut + picks.deepDive + picks.controversy + picks.speedRead
         if (items.isEmpty()) return retryOrGiveUp()
 
         val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)

--- a/androidLibrary/notifier/src/main/kotlin/whl/trending/notifier/DailyPicksWorker.kt
+++ b/androidLibrary/notifier/src/main/kotlin/whl/trending/notifier/DailyPicksWorker.kt
@@ -107,7 +107,12 @@ class DailyPicksWorker(
             .setContentIntent(pendingIntent)
             .setAutoCancel(true)
             .build()
-        manager.notify(NOTIFICATION_ID, notification)
+        try {
+            manager.notify(NOTIFICATION_ID, notification)
+        } catch (_: SecurityException) {
+            // POST_NOTIFICATIONS 在 doWork 的 areNotificationsEnabled 检查后被收回（竞态窗口极小）：
+            // 静默放弃本次通知，符合"宁缺勿错"策略；lint 的跨方法流分析看不到上游守卫，此处显式处理
+        }
     }
 
     private fun localizedContext(context: Context, lang: String): Context {

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -51,7 +51,7 @@
     <string name="no_data">暂无数据</string>
     <string name="filter_new_only">只看 New</string>
     <string name="no_new_repos">今日暂无新上榜项目</string>
-    <string name="new_only_hint">近期首次登上 GitHub 日榜（全语言）的新项目</string>
+    <string name="new_only_hint">24 小时内首次登上 GitHub 日榜（全语言）的新项目</string>
     <string name="default_home_tab">默认首页</string>
     <string name="default_home_tab_desc">启动时进入的标签页</string>
     <string name="daily_picks_notification">每日精选提醒</string>
@@ -119,9 +119,8 @@
     <string name="hackernews_placeholder">Hacker News 内容即将上线</string>
     <string name="producthunt_placeholder">Product Hunt 内容即将上线</string>
     <string name="picks_no_data">暂无精选</string>
+    <string name="picks_section_debut">GitHub 上新</string>
     <string name="picks_section_deep_dive">深度解读</string>
-    <string name="picks_section_controversy">争议话题</string>
-    <string name="picks_section_speed_read">Top 5 速览</string>
     <string name="picks_label_action">适合场景</string>
     <string name="picks_label_alternatives">类似产品</string>
     <string name="picks_label_terms">关键词</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -51,7 +51,7 @@
     <string name="no_data">No data available</string>
     <string name="filter_new_only">New only</string>
     <string name="no_new_repos">No new repos today</string>
-    <string name="new_only_hint">Projects new to the GitHub daily all-language trending board</string>
+    <string name="new_only_hint">First appeared on the GitHub daily (all languages) list within 24 hours</string>
     <string name="default_home_tab">Default home tab</string>
     <string name="default_home_tab_desc">Which tab the app opens to at launch</string>
     <string name="daily_picks_notification">Daily Picks reminder</string>
@@ -119,9 +119,8 @@
     <string name="hackernews_placeholder">Hacker News content coming soon</string>
     <string name="producthunt_placeholder">Product Hunt content coming soon</string>
     <string name="picks_no_data">No picks available</string>
+    <string name="picks_section_debut">New on Trending</string>
     <string name="picks_section_deep_dive">Deep Dive</string>
-    <string name="picks_section_controversy">Controversy</string>
-    <string name="picks_section_speed_read">Top 5 Speed Read</string>
     <string name="picks_label_action">Use case</string>
     <string name="picks_label_alternatives">Alternatives</string>
     <string name="picks_label_terms">Keywords</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
@@ -105,7 +105,7 @@ internal expect fun platformTrackEvent(name: String, props: Map<String, Any>)
  * @param source 数据来源：github / hackernews / producthunt
  * @param rank 条目在列表中的排名（从 1 开始）
  * @param title 条目标题，截断至 100 字符
- * @param section 仅 Picks 页使用：deep_dive / controversy / speed_read
+ * @param section 仅 Picks 页使用：deep_dive / debut
  */
 fun trackItemClick(
     source: String,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/PicksResponse.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/PicksResponse.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 data class PicksResponse(
     val success: Boolean = false,
     val metadata: PicksMetadata = PicksMetadata(),
+    val debut: List<PickItem> = emptyList(),
     val speedRead: List<PickItem> = emptyList(),
     val deepDive: List<PickItem> = emptyList(),
     val controversy: List<PickItem> = emptyList()

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
@@ -206,6 +206,8 @@ private fun PicksList(
             items(debut, key = { "debut_${it.rank}" }) { item ->
                 DebutCard(
                     item = item,
+                    isFavorite = item.url in favoriteUrls,
+                    onToggleFavorite = { togglePickFavorite(item, favoriteUrls) },
                     onClick = { onItemClick(item, "debut") }
                 )
             }
@@ -403,6 +405,8 @@ private fun DeepDiveCard(item: PickItem, isFavorite: Boolean, onToggleFavorite: 
 @Composable
 private fun DebutCard(
     item: PickItem,
+    isFavorite: Boolean,
+    onToggleFavorite: () -> Unit,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -456,6 +460,29 @@ private fun DebutCard(
             } ?: item.summary?.takeIf { it.isNotBlank() }?.let {
                 Spacer(Modifier.height(6.dp))
                 Text(text = it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+
+            // 底部三点菜单（与 DeepDiveCard 同交互模式）
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                val shareContent = aiShareText(item.title, item.analysis?.core ?: item.summary, item.url)
+                ItemActionMenu(
+                    isFavorite = isFavorite,
+                    onToggle = onToggleFavorite,
+                    onShare = {
+                        shareText(shareContent)
+                        trackEvent(
+                            "share_to_ai",
+                            mapOf(
+                                "source" to item.source,
+                                "has_summary" to (item.analysis != null || !item.summary.isNullOrBlank()),
+                                "from" to "debut"
+                            )
+                        )
+                    }
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
@@ -453,7 +453,7 @@ private fun DebutCard(
                         color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f),
                     )
                 }
-            } ?: item.summary?.let {
+            } ?: item.summary?.takeIf { it.isNotBlank() }?.let {
                 Spacer(Modifier.height(6.dp))
                 Text(text = it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
@@ -1,7 +1,6 @@
 package whl.trending.ai.ui.picks
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,7 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -57,12 +55,10 @@ import trendingai.shared.generated.resources.close
 import trendingai.shared.generated.resources.picks_newsletter_desc
 import trendingai.shared.generated.resources.picks_newsletter_title
 import trendingai.shared.generated.resources.picks_no_data
-import trendingai.shared.generated.resources.picks_section_controversy
+import trendingai.shared.generated.resources.picks_section_debut
 import trendingai.shared.generated.resources.picks_section_deep_dive
-import trendingai.shared.generated.resources.picks_section_speed_read
 import trendingai.shared.generated.resources.retry
 import whl.trending.ai.core.DateTimeUtils
-import whl.trending.ai.ui.common.AiSummaryBox
 import whl.trending.ai.core.platform.trackItemClick
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.FavoriteItem
@@ -127,7 +123,7 @@ fun PicksScreen(
 
             else -> {
                 val picks = uiState.picks
-                if (picks == null || (picks.deepDive.isEmpty() && picks.controversy.isEmpty() && picks.speedRead.isEmpty())) {
+                if (picks == null || (picks.debut.isEmpty() && picks.deepDive.isEmpty())) {
                     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Text(text = stringResource(Res.string.picks_no_data))
                     }
@@ -142,9 +138,8 @@ fun PicksScreen(
                         remember { globalSettingsManager.currentPicksNewsletterBannerDismissed() }
                     )
                     PicksList(
+                        debut = picks.debut,
                         deepDive = picks.deepDive,
-                        controversy = picks.controversy,
-                        speedRead = picks.speedRead,
                         favoriteUrls = favoriteUrls,
                         showNewsletterBanner = subscribedEmail == null && !bannerDismissed,
                         onSubscribeClick = {
@@ -187,9 +182,8 @@ private fun handleItemClick(
 
 @Composable
 private fun PicksList(
+    debut: List<PickItem>,
     deepDive: List<PickItem>,
-    controversy: List<PickItem>,
-    speedRead: List<PickItem>,
     favoriteUrls: Set<String>,
     showNewsletterBanner: Boolean,
     onSubscribeClick: () -> Unit,
@@ -206,8 +200,22 @@ private fun PicksList(
             item { NewsletterBanner(onClick = onSubscribeClick, onDismiss = onDismissBanner) }
         }
 
+        // Debut — GitHub 上新
+        if (debut.isNotEmpty()) {
+            item { SectionHeader(title = stringResource(Res.string.picks_section_debut)) }
+            items(debut, key = { "debut_${it.rank}" }) { item ->
+                DebutCard(
+                    item = item,
+                    onClick = { onItemClick(item, "debut") }
+                )
+            }
+        }
+
         // Deep Dive
         if (deepDive.isNotEmpty()) {
+            if (debut.isNotEmpty()) {
+                item { SectionDivider() }
+            }
             item { SectionHeader(title = stringResource(Res.string.picks_section_deep_dive)) }
             items(deepDive, key = { "deep_${it.rank}" }) { item ->
                 DeepDiveCard(
@@ -219,34 +227,8 @@ private fun PicksList(
             }
         }
 
-        // Controversy
-        if (controversy.isNotEmpty()) {
-            item { SectionDivider() }
-            item { SectionHeader(title = stringResource(Res.string.picks_section_controversy)) }
-            item {
-                ControversyGroup(
-                    items = controversy,
-                    favoriteUrls = favoriteUrls,
-                    onItemClick = { item -> onItemClick(item, "controversy") }
-                )
-            }
-        }
-
-        // Speed Read
-        if (speedRead.isNotEmpty()) {
-            item { SectionDivider() }
-            item { SectionHeader(title = stringResource(Res.string.picks_section_speed_read)) }
-            items(speedRead, key = { "speed_${it.rank}" }) { item ->
-                SpeedReadItem(
-                    item = item,
-                    isFavorite = item.url in favoriteUrls,
-                    onToggleFavorite = { togglePickFavorite(item, favoriteUrls) },
-                    onClick = { onItemClick(item, "speed_read") }
-                )
-            }
-            // 尾部间距
-            item { Spacer(modifier = Modifier.height(16.dp)) }
-        }
+        // 尾部间距
+        item { Spacer(modifier = Modifier.height(16.dp)) }
     }
 }
 
@@ -419,153 +401,63 @@ private fun DeepDiveCard(item: PickItem, isFavorite: Boolean, onToggleFavorite: 
 }
 
 @Composable
-private fun ControversyGroup(items: List<PickItem>, favoriteUrls: Set<String>, onItemClick: (PickItem) -> Unit) {
+private fun DebutCard(
+    item: PickItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     OutlinedCard(
-        modifier = Modifier
+        onClick = onClick,
+        modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 6.dp)
     ) {
-        items.forEachIndexed { index, item ->
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onItemClick(item) }
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = item.title,
-                        modifier = Modifier.weight(1f),
-                        style = MaterialTheme.typography.titleSmall,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    SourceTag(source = item.source, label = item.sourceLabel)
-                }
-
-                item.analysis?.let { analysis ->
-                    Text(
-                        text = analysis.core,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.tertiary
-                    )
-                }
-
-                // 底部三点菜单
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End
-                ) {
-                    val shareContent = aiShareText(item.title, item.summary, item.url)
-                    ItemActionMenu(
-                        isFavorite = item.url in favoriteUrls,
-                        onToggle = { togglePickFavorite(item, favoriteUrls) },
-                        onShare = {
-                            shareText(shareContent)
-                            trackEvent(
-                                "share_to_ai",
-                                mapOf(
-                                    "source" to item.source,
-                                    "has_summary" to !item.summary.isNullOrBlank(),
-                                    "from" to "list"
-                                )
-                            )
-                        }
-                    )
-                }
-            }
-            if (index < items.lastIndex) {
-                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-            }
-        }
-    }
-}
-
-@Composable
-private fun SpeedReadItem(item: PickItem, isFavorite: Boolean, onToggleFavorite: () -> Unit, onClick: () -> Unit) {
-    Column {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { onClick() }
-                .padding(horizontal = 16.dp, vertical = 10.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
-            ) {
-                // 序号
-                Box(
-                    modifier = Modifier
-                        .size(24.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.primary,
-                            shape = CircleShape
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = "${item.rank}",
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onPrimary
-                    )
-                }
-
-                // 标题
+        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                SourceTag(source = item.source, label = item.sourceLabel)
+                Spacer(Modifier.width(8.dp))
                 Text(
                     text = item.title,
-                    modifier = Modifier.weight(1f),
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
                 )
-
-                // 来源标签 + 分数
-                SourceTag(source = item.source, label = "${item.sourceLabel} ${formatScore(item.source, item.score)}")
-            }
-
-            // AI 总结
-            if (!item.summary.isNullOrBlank()) {
-                AiSummaryBox(
-                    summary = item.summary,
-                    modifier = Modifier.padding(start = 34.dp)
+                Text(
+                    text = formatScore(item.source, item.score),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-
-            // 底部三点菜单
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End
-            ) {
-                val shareContent = aiShareText(item.title, item.summary, item.url)
-                ItemActionMenu(
-                    isFavorite = isFavorite,
-                    onToggle = onToggleFavorite,
-                    onShare = {
-                        shareText(shareContent)
-                        trackEvent(
-                            "share_to_ai",
-                            mapOf(
-                                "source" to item.source,
-                                "has_summary" to !item.summary.isNullOrBlank(),
-                                "from" to "list"
-                            )
-                        )
-                    }
+            item.analysis?.let { analysis ->
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    text = analysis.core,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
                 )
+                if (analysis.whyImportant.isNotBlank()) {
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = analysis.whyImportant,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                analysis.action?.takeIf { it.isNotBlank() }?.let {
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f),
+                    )
+                }
+            } ?: item.summary?.let {
+                Spacer(Modifier.height(6.dp))
+                Text(text = it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
         }
-        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
     }
 }
 

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/picks/PicksViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/picks/PicksViewModelTest.kt
@@ -38,7 +38,7 @@ class PicksViewModelTest {
     private fun response(date: String) = PicksResponse(
         success = true,
         metadata = PicksMetadata(date = date),
-        speedRead = listOf(PickItem(rank = 1, title = "item-$date")),
+        deepDive = listOf(PickItem(rank = 1, title = "item-$date")),
     )
 
     private fun settings(): SettingsManager =


### PR DESCRIPTION
配合后端两档改版（github-ai-trending-api PR #19，已合并上线）：

## 改动

- **Picks 页两档化**：新增「GitHub 上新」区块（`DebutCard` 轻量卡片：来源/标题/星数行 + core 加粗 + why_important + action，analysis 缺失回退 summary），置于「深度解读」之前；删除「争议话题」「Top 5 速览」区块及 `ControversyGroup`/`SpeedReadItem` composable
- **模型**：`PicksResponse` 加 `debut` 字段（旧字段保留，兼容历史缓存与 API 过渡字段）
- **strings（en+zh）**：新增 `picks_section_debut`；删除争议/速览标题；`new_only_hint` 改 24h 口径（与后端 isNew 收紧同步）
- **杂项**：DailyPicksWorker 通知拼接加 debut、PicksViewModelTest fixture、Platform.kt 注释

## 验证

- `:shared:compileAndroidMain` + `:shared:testAndroidHostTest` + `:androidLibrary:notifier:compileDebugKotlin` 全绿
- grep 确认旧 composable/string 零残留
- 后端两档数据已上线，可装 debug 包看真实效果（07-14：上新 1 条 graphify + 深读 3 条）

旧版 App 兼容：靠 `ignoreUnknownKeys` + 空区块 `isNotEmpty()` 守卫自然降级为只看深读，无需强制升级。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

将 Picks 体验重构为双层布局，聚焦于新的 GitHub 条目和深度解析，并相应更新数据模型、通知、文案和测试。

New Features:
- 在 Picks 页面引入首发（debut）区块，使用轻量卡片突出显示新近走红的 GitHub 项目。

Enhancements:
- 通过移除 Controversy 和 Top 5 Speed Read 区块并更新空状态处理，简化 Picks 布局。
- 扩展 `PicksResponse` 和通知内容以包含首发条目，并更新分析（analytics）区块的标签。
- 收紧“仅显示新内容”提示文案，将时间范围明确为 24 小时（覆盖英文和中文字符串）。

Tests:
- 调整 `PicksViewModel` 测试基准，使其使用深度解析条目来替代已移除的 Speed Read 区块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restructure the Picks experience into a two-tier layout focused on new GitHub entries and deep dives, updating data models, notifications, copy, and tests accordingly.

New Features:
- Introduce a debut section on the Picks screen with lightweight cards highlighting newly trending GitHub projects.

Enhancements:
- Simplify Picks layout by removing the Controversy and Top 5 Speed Read sections and updating empty-state handling.
- Extend PicksResponse and notification content to include debut items and update analytics section labelling.
- Tighten the copy for the 'new only' hint to a 24-hour window in both English and Chinese strings.

Tests:
- Adjust PicksViewModel test fixtures to use deep-dive items instead of the removed speed-read section.

</details>