### PR TITLE
P1：chat 会话持久化——Room 多会话 + 抽屉 + 跨进程恢复

### DIFF
--- a/androidLibrary/chat/build.gradle.kts
+++ b/androidLibrary/chat/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.room)
     kotlin("plugin.serialization") version libs.versions.kotlin.get()
 }
 
@@ -16,6 +18,18 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+
+    testOptions {
+        unitTests {
+            // Robolectric 内存 Room 库跑 DAO/迁移测试
+            isIncludeAndroidResources = true
+        }
+    }
+}
+
+room {
+    // schema 入库：迁移测试的权威参照（EchoFlow 同款实践）
+    schemaDirectory("$projectDir/schemas")
 }
 
 dependencies {
@@ -42,9 +56,15 @@ dependencies {
     implementation(libs.commonmark)
     implementation(libs.commonmark.ext.gfm.tables)
 
+    implementation(libs.room.runtime)
+    implementation(libs.room.ktx)
+    ksp(libs.room.compiler)
+
     debugImplementation(libs.compose.uiTooling)
 
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlin.test.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core)
 }

--- a/androidLibrary/chat/schemas/whl.trending.chat.db.ChatDatabase/1.json
+++ b/androidLibrary/chat/schemas/whl.trending.chat.db.ChatDatabase/1.json
@@ -1,0 +1,158 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "ae21d0fbc5f9b1358f95dd493366b2b3",
+    "entities": [
+      {
+        "tableName": "chat_threads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `entryKey` TEXT NOT NULL, `contextJson` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryKey",
+            "columnName": "entryKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contextJson",
+            "columnName": "contextJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_threads_entryKey",
+            "unique": false,
+            "columnNames": [
+              "entryKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_threads_entryKey` ON `${TABLE_NAME}` (`entryKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `threadId` INTEGER NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `imagesJson` TEXT, `kind` TEXT NOT NULL, `model` TEXT, `segmentsJson` TEXT, `createdAt` INTEGER NOT NULL, FOREIGN KEY(`threadId`) REFERENCES `chat_threads`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "threadId",
+            "columnName": "threadId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imagesJson",
+            "columnName": "imagesJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "segmentsJson",
+            "columnName": "segmentsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_threadId",
+            "unique": false,
+            "columnNames": [
+              "threadId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_threadId` ON `${TABLE_NAME}` (`threadId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "chat_threads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "threadId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ae21d0fbc5f9b1358f95dd493366b2b3')"
+    ]
+  }
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatDemoActivity.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatDemoActivity.kt
@@ -48,6 +48,8 @@ private fun DemoContent(real: Boolean, onBack: () -> Unit) {
             onBack = onBack,
             engine = androidx.compose.runtime.remember { FakeChatEngine() },
             initialMessages = SampleData.messages,
+            // 纯内存：假引擎的样例会话不落真库
+            persistent = false,
         )
     }
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -2,13 +2,19 @@ package whl.trending.chat
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import whl.trending.ai.chat.ChatContext
 import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.ChatModelOption
 import whl.trending.ai.data.repository.ChatModelsProvider
 import whl.trending.chat.engine.ChatEngine
@@ -19,21 +25,30 @@ import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.ChatUiState
 import whl.trending.chat.model.MessageKind
 import whl.trending.chat.model.Role
+import whl.trending.chat.store.ChatStore
+
+/** 抽屉里的一条会话概要 */
+data class ThreadSummary(val id: Long, val title: String, val updatedAt: Long)
 
 /**
- * 聊天 ViewModel：内存级单会话，流式渲染（发送先追加空 assistant 占位，delta 到达增量更新）。
- * 通过 [engine] 注入实现 Demo / 正式切换。
+ * 聊天 ViewModel：单实例 + currentThreadId 状态（P1 起，多会话由 [ChatStore] 支撑）。
+ * 流式渲染不变（发送先追加空 assistant 占位，delta 到达增量更新）；落库为终局一次写。
  *
- * @param loadModels 模型目录拉取，注入点（便于测试替身）；默认走 [ChatModelsProvider] 的进程级缓存，
- *   避免每个会话都网络冷拉取导致选择器 chip 迟迟不出现（见冷首拉根因）。
- * @param track 埋点注入点（便于测试替身），默认 [trackEvent]。
+ * 会话切换语义：流按 threadId 分键（[streams]/[messagesByThread]）——切走后后台继续
+ * 完成并落库（服务端已在计费，取消才是浪费），切回可见全文；uiState 只镜像当前线。
+ *
+ * @param store 持久化层；null = 纯内存模式（Demo/预览与旧行为完全一致）
+ * @param selectedModelId 应答模型记录用（展示「哪个模型答的」）；默认读全局设置的用户选择
  */
 class ChatViewModel(
     private val engine: ChatEngine,
-    private val context: ChatContext? = null,
+    initialContext: ChatContext? = null,
     initialMessages: List<ChatMessage> = emptyList(),
+    private val store: ChatStore? = null,
     private val loadModels: suspend () -> List<ChatModelOption> = { ChatModelsProvider.get() },
     private val track: (String, Map<String, String>) -> Unit = { name, props -> trackEvent(name, props) },
+    private val selectedModelId: () -> String? =
+        { runCatching { globalSettingsManager.currentSelectedChatModel() }.getOrNull() },
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ChatUiState(messages = initialMessages))
@@ -43,9 +58,33 @@ class ChatViewModel(
     private val _models = MutableStateFlow<List<ChatModelOption>>(emptyList())
     val models: StateFlow<List<ChatModelOption>> = _models.asStateFlow()
 
+    /** 会话列表（抽屉数据源）；纯内存模式恒为空 */
+    val threads: StateFlow<List<ThreadSummary>> =
+        (store?.threads()?.map { list -> list.map { ThreadSummary(it.id, it.title, it.updatedAt) } }
+            ?: flowOf(emptyList()))
+            .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    private val _currentThreadId = MutableStateFlow<Long?>(null)
+    val currentThreadId: StateFlow<Long?> = _currentThreadId.asStateFlow()
+
+    /** 当前会话的 ChatContext（解读 chip / 服务端 context 注入）；随切换/恢复而变 */
+    private var activeContext: ChatContext? = initialContext
+
+    // 每线消息缓冲（真相源，uiState.messages 只是当前线的镜像）；null 键 = 尚未落库的新会话
+    private val messagesByThread = mutableMapOf<Long?, List<ChatMessage>>(null to initialMessages)
+
+    // 每线在途流（切走后后台继续）
+    private val streams = mutableMapOf<Long?, Job>()
+
     init {
         viewModelScope.launch {
             _models.value = runCatching { loadModels() }.getOrDefault(emptyList())
+        }
+        // 入口恢复：该入口最近会话（跨进程延续原 sessionKey 的「再次进入恢复」体验）
+        if (store != null) {
+            viewModelScope.launch {
+                store.resolveLatestThread(initialContext)?.let { openThread(it, fallbackContext = initialContext) }
+            }
         }
     }
 
@@ -85,11 +124,16 @@ class ChatViewModel(
      * 可见性由 [DetailSummaryPolicy] 保证（GitHub 条目 + README 达标 + 尚无成功解读）。
      */
     fun sendDetailSummary(promptText: String) {
+        val context = activeContext
         if (_uiState.value.isSending || context?.externalId == null) return
         track("detail_summary_generate", mapOf("from" to "chat"))
-        val userMessage = ChatMessage(nextId(), Role.USER, promptText, kind = MessageKind.DETAIL_SUMMARY)
-        _uiState.update { it.copy(messages = it.messages + userMessage, isSending = true) }
-        launchRequest(MessageKind.DETAIL_SUMMARY)
+        _uiState.update { it.copy(isSending = true) }
+        viewModelScope.launch {
+            val threadId = ensureThreadForSend(promptText)
+            val userMessage = ChatMessage(nextId(), Role.USER, promptText, kind = MessageKind.DETAIL_SUMMARY)
+            appendAndPersistUser(threadId, userMessage)
+            launchRequest(threadId, MessageKind.DETAIL_SUMMARY, context)
+        }
     }
 
     private fun sendMessage(text: String, images: List<String>) {
@@ -97,16 +141,13 @@ class ChatViewModel(
         if (images.isNotEmpty()) {
             track("chat_send_with_images", mapOf("image_count" to images.size.toString()))
         }
-        val userMessage = ChatMessage(nextId(), Role.USER, text, images = images)
-        _uiState.update {
-            it.copy(messages = it.messages + userMessage, isSending = true)
+        _uiState.update { it.copy(isSending = true) }
+        viewModelScope.launch {
+            val threadId = ensureThreadForSend(text)
+            val userMessage = ChatMessage(nextId(), Role.USER, text, images = images)
+            appendAndPersistUser(threadId, userMessage)
+            launchRequest(threadId, MessageKind.CHAT, activeContext)
         }
-        launchRequest(MessageKind.CHAT)
-    }
-
-    companion object {
-        /** 单条消息图片数上限，与服务端及 [whl.trending.chat.engine.ChatWire] 对齐 */
-        const val MAX_IMAGES_PER_MESSAGE = 4
     }
 
     /** 对可重试的失败消息重试：移除该错误条，按消息 [MessageKind] 路由回对应管线。
@@ -116,71 +157,147 @@ class ChatViewModel(
         val passthrough = error.code == ChatError.CODE_QUOTA_DEVICE ||
             error.code == ChatError.CODE_LOGIN_REQUIRED
         if (!error.category.retryable && !passthrough) return
+        val threadId = _currentThreadId.value
+        updateThreadMessages(threadId) { list -> list.filterNot { it.id == message.id } }
+        _uiState.update { it.copy(isSending = true) }
+        launchRequest(threadId, message.kind, activeContext)
+    }
+
+    // ---- 会话管理（抽屉） ----
+
+    fun switchThread(id: Long) {
+        if (id == _currentThreadId.value) return
+        viewModelScope.launch { openThread(id) }
+    }
+
+    /** 抽屉「新会话」：总是全新开始（通用入口），不复用任何历史 */
+    fun startNewThread() {
+        _currentThreadId.value = null
+        activeContext = null
+        messagesByThread[null] = emptyList()
         _uiState.update {
-            it.copy(messages = it.messages.filterNot { m -> m.id == message.id }, isSending = true)
+            it.copy(messages = emptyList(), isSending = false, input = "", pendingImages = emptyList())
         }
-        launchRequest(message.kind)
+    }
+
+    fun renameThread(id: Long, title: String) {
+        viewModelScope.launch { store?.renameThread(id, title) }
+    }
+
+    fun deleteThread(id: Long) {
+        viewModelScope.launch {
+            // 在途流一并取消：线程行将消失，终局落库会撞外键
+            streams.remove(id)?.cancel()
+            messagesByThread.remove(id)
+            store?.deleteThread(id)
+            if (_currentThreadId.value == id) startNewThread()
+        }
+    }
+
+    // ---- 内部 ----
+
+    private suspend fun openThread(id: Long, fallbackContext: ChatContext? = null) {
+        val s = store ?: return
+        val messages = messagesByThread[id] ?: s.loadMessages(id).also { messagesByThread[id] = it }
+        idSeq = maxOf(idSeq, messages.maxOfOrNull { it.id } ?: 0L)
+        _currentThreadId.value = id
+        activeContext = s.contextOf(id) ?: fallbackContext
+        _uiState.update {
+            it.copy(
+                messages = messages,
+                isSending = streams[id]?.isActive == true,
+                pendingImages = emptyList(),
+            )
+        }
+    }
+
+    /** 首条消息才建线（懒建）；当前线已存在则直接复用。内存模式恒为 null 键。 */
+    private suspend fun ensureThreadForSend(firstMessageText: String): Long? {
+        val s = store ?: return _currentThreadId.value
+        _currentThreadId.value?.let { return it }
+        val id = s.createThread(activeContext, firstMessageText)
+        // 未落库缓冲迁移到新线名下
+        messagesByThread[id] = messagesByThread.remove(null) ?: emptyList()
+        _currentThreadId.value = id
+        return id
+    }
+
+    private suspend fun appendAndPersistUser(threadId: Long?, message: ChatMessage) {
+        updateThreadMessages(threadId) { it + message }
+        if (store != null && threadId != null) {
+            val persisted = store.persistUserMessage(threadId, message)
+            if (persisted.images != message.images) {
+                // 图片已迁入 filesDir：回写新路径（cache 路径随时可能被系统清理）
+                updateThreadMessages(threadId) { list ->
+                    list.map { if (it.id == message.id) it.copy(images = persisted.images) else it }
+                }
+            }
+        }
     }
 
     /**
      * 统一请求路径：先追加空 assistant 占位消息，delta 到达时增量更新其 content；
-     * 成功以全文定稿，失败清空已渲染部分（整条重试）并挂上分类错误。
+     * 成功以全文定稿并终局落库，失败清空已渲染部分（整条重试）并挂上分类错误（不落库）。
      */
-    private fun launchRequest(kind: MessageKind) = viewModelScope.launch {
+    private fun launchRequest(threadId: Long?, kind: MessageKind, context: ChatContext?) {
         val placeholderId = nextId()
-        _uiState.update {
-            it.copy(messages = it.messages + ChatMessage(placeholderId, Role.ASSISTANT, "", kind = kind))
-        }
-        val result = runCatching {
-            when (kind) {
-                MessageKind.CHAT -> {
-                    val history = _uiState.value.messages.filterNot { it.id == placeholderId }
-                    engine.send(history, context) { delta -> appendDelta(placeholderId, delta) }
-                }
-                MessageKind.DETAIL_SUMMARY -> {
-                    val detail = engine.sendDetailSummary(requireNotNull(context)) { delta ->
-                        appendDelta(placeholderId, delta)
+        updateThreadMessages(threadId) { it + ChatMessage(placeholderId, Role.ASSISTANT, "", kind = kind) }
+        val job = viewModelScope.launch {
+            val result = runCatching {
+                when (kind) {
+                    MessageKind.CHAT -> {
+                        val history = (messagesByThread[threadId] ?: emptyList())
+                            .filterNot { it.id == placeholderId }
+                        engine.send(history, context) { delta -> appendDelta(threadId, placeholderId, delta) }
                     }
-                    if (detail.cached) track("detail_summary_cache_hit", mapOf("from" to "chat"))
-                    detail.content
+                    MessageKind.DETAIL_SUMMARY -> {
+                        val detail = engine.sendDetailSummary(requireNotNull(context)) { delta ->
+                            appendDelta(threadId, placeholderId, delta)
+                        }
+                        if (detail.cached) track("detail_summary_cache_hit", mapOf("from" to "chat"))
+                        detail.content
+                    }
                 }
             }
-        }
-        result.fold(
-            onSuccess = { full ->
-                _uiState.update { st ->
-                    st.copy(
-                        messages = st.messages.map { m ->
-                            if (m.id == placeholderId) m.copy(content = full) else m
-                        },
-                        isSending = false,
-                    )
-                }
-            },
-            onFailure = { e ->
-                val error = (e as? ChatException)?.error
-                    ?: ChatError(ChatErrorCategory.UNKNOWN, detail = e.toString())
-                trackFailure(kind, error)
-                _uiState.update { st ->
-                    st.copy(
+            result.fold(
+                onSuccess = { full ->
+                    updateThreadMessages(threadId) { list ->
+                        list.map { if (it.id == placeholderId) it.copy(content = full) else it }
+                    }
+                    if (store != null && threadId != null) {
+                        store.persistAssistantMessage(threadId, full, kind, selectedModelId())
+                    }
+                },
+                onFailure = { e ->
+                    val error = (e as? ChatException)?.error
+                        ?: ChatError(ChatErrorCategory.UNKNOWN, detail = e.toString())
+                    trackFailure(kind, error)
+                    updateThreadMessages(threadId) { list ->
                         // 已渲染部分丢弃，整条重试（中途断流语义）
-                        messages = st.messages.map { m ->
-                            if (m.id == placeholderId) m.copy(content = "", error = error) else m
-                        },
-                        isSending = false,
-                    )
-                }
-            },
-        )
-    }
-
-    private fun appendDelta(messageId: Long, delta: String) {
-        _uiState.update { st ->
-            st.copy(
-                messages = st.messages.map { m ->
-                    if (m.id == messageId) m.copy(content = m.content + delta) else m
+                        list.map { if (it.id == placeholderId) it.copy(content = "", error = error) else it }
+                    }
                 },
             )
+            streams.remove(threadId)
+            if (threadId == _currentThreadId.value) {
+                _uiState.update { it.copy(isSending = false) }
+            }
+        }
+        streams[threadId] = job
+    }
+
+    private fun appendDelta(threadId: Long?, messageId: Long, delta: String) {
+        updateThreadMessages(threadId) { list ->
+            list.map { if (it.id == messageId) it.copy(content = it.content + delta) else it }
+        }
+    }
+
+    /** 所有消息变更的唯一入口：写缓冲，且仅当该线是当前线时镜像进 uiState */
+    private fun updateThreadMessages(threadId: Long?, transform: (List<ChatMessage>) -> List<ChatMessage>) {
+        val updated = transform(messagesByThread[threadId] ?: emptyList())
+        messagesByThread[threadId] = updated
+        if (threadId == _currentThreadId.value) {
+            _uiState.update { it.copy(messages = updated) }
         }
     }
 
@@ -196,5 +313,10 @@ class ChatViewModel(
                 track("detail_summary_login_required", mapOf("from" to "chat"))
             }
         }
+    }
+
+    companion object {
+        /** 单条消息图片数上限，与服务端及 [whl.trending.chat.engine.ChatWire] 对齐 */
+        const val MAX_IMAGES_PER_MESSAGE = 4
     }
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -80,10 +80,26 @@ class ChatViewModel(
         viewModelScope.launch {
             _models.value = runCatching { loadModels() }.getOrDefault(emptyList())
         }
-        // 入口恢复：该入口最近会话（跨进程延续原 sessionKey 的「再次进入恢复」体验）
-        if (store != null) {
-            viewModelScope.launch {
-                store.resolveLatestThread(initialContext)?.let { openThread(it, fallbackContext = initialContext) }
+    }
+
+    /**
+     * 入口进入（Screen 每个新入口调用一次）：恢复该入口最近会话（跨进程延续原
+     * sessionKey 的「再次进入恢复」体验）；无历史则以该 context 呈现空会话态。
+     * 纯内存模式只切 context，不动 initialMessages。
+     */
+    fun enterEntry(context: ChatContext?) {
+        viewModelScope.launch {
+            activeContext = context
+            val s = store ?: return@launch
+            val id = s.resolveLatestThread(context)
+            if (id != null) {
+                openThread(id, fallbackContext = context)
+            } else {
+                _currentThreadId.value = null
+                messagesByThread[null] = emptyList()
+                _uiState.update {
+                    it.copy(messages = emptyList(), isSending = false, pendingImages = emptyList())
+                }
             }
         }
     }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/db/ChatDatabase.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/db/ChatDatabase.kt
@@ -1,0 +1,124 @@
+package whl.trending.chat.db
+
+import android.content.Context
+import androidx.room.Dao
+import androidx.room.Database
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.Insert
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * 会话线：一次对话的容器。
+ *
+ * @param entryKey 入口键（`repo:{externalId}` / `general`）——「同一入口再次进入恢复最近会话」
+ *   按此列查询（延续原 sessionKey 的体验，但跨进程存活）
+ * @param contextJson 进入时的 [whl.trending.ai.chat.ChatContext] 序列化（通用入口为 null）；
+ *   恢复历史会话后「一键解读」chip 与服务端 context 注入都依赖它——不存等于恢复的会话丢了灵魂
+ * @param updatedAt 排序键：列表按最近活跃倒序
+ */
+@Entity(tableName = "chat_threads", indices = [Index("entryKey")])
+data class ThreadEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val title: String,
+    val entryKey: String,
+    val contextJson: String?,
+    val createdAt: Long,
+    val updatedAt: Long,
+)
+
+/**
+ * 持久化消息。error 消息不落库（失败是瞬态 UI 状态，可重试；重启后无意义），
+ * 流式过程零写库——user 消息即发即落，assistant 仅在成功终局落一次。
+ *
+ * @param imagesJson 用户附图的本地路径列表（JSON）；持久化文件在 filesDir/chat_images，
+ *   删线程时先删文件再删行（CASCADE 之后路径就找不回了）
+ * @param model 应答模型 id（用户在选择器里选的；展示「哪个模型答的」用）
+ * @param segmentsJson P2 预留：富内容时间线信封（JSON，含 v 版本字段），本期恒 null
+ */
+@Entity(
+    tableName = "chat_messages",
+    foreignKeys = [
+        ForeignKey(
+            entity = ThreadEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["threadId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("threadId")],
+)
+data class MessageEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val threadId: Long,
+    val role: String,
+    val content: String,
+    val imagesJson: String?,
+    val kind: String,
+    val model: String?,
+    val segmentsJson: String?,
+    val createdAt: Long,
+)
+
+@Dao
+interface ThreadDao {
+    @Insert
+    suspend fun insert(thread: ThreadEntity): Long
+
+    @Query("SELECT * FROM chat_threads ORDER BY updatedAt DESC")
+    fun observeAll(): Flow<List<ThreadEntity>>
+
+    @Query("SELECT * FROM chat_threads WHERE id = :id")
+    suspend fun getById(id: Long): ThreadEntity?
+
+    /** 入口恢复语义：该入口最近活跃的会话线 */
+    @Query("SELECT * FROM chat_threads WHERE entryKey = :entryKey ORDER BY updatedAt DESC LIMIT 1")
+    suspend fun latestByEntry(entryKey: String): ThreadEntity?
+
+    @Query("UPDATE chat_threads SET title = :title WHERE id = :id")
+    suspend fun rename(id: Long, title: String)
+
+    /** 会话有新活动时冒泡到列表顶部 */
+    @Query("UPDATE chat_threads SET updatedAt = :now WHERE id = :id")
+    suspend fun touch(id: Long, now: Long)
+
+    @Query("DELETE FROM chat_threads WHERE id = :id")
+    suspend fun delete(id: Long)
+}
+
+@Dao
+interface MessageDao {
+    @Insert
+    suspend fun insert(message: MessageEntity): Long
+
+    @Query("SELECT * FROM chat_messages WHERE threadId = :threadId ORDER BY id")
+    suspend fun messagesFor(threadId: Long): List<MessageEntity>
+
+    /** 删线程前收集待删的图片文件路径（行删除交给 CASCADE） */
+    @Query("SELECT imagesJson FROM chat_messages WHERE threadId = :threadId AND imagesJson IS NOT NULL")
+    suspend fun imagesJsonFor(threadId: Long): List<String>
+}
+
+@Database(entities = [ThreadEntity::class, MessageEntity::class], version = 1, exportSchema = true)
+abstract class ChatDatabase : RoomDatabase() {
+    abstract fun threadDao(): ThreadDao
+    abstract fun messageDao(): MessageDao
+
+    companion object {
+        @Volatile private var instance: ChatDatabase? = null
+
+        fun get(context: Context): ChatDatabase =
+            instance ?: synchronized(this) {
+                instance ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    ChatDatabase::class.java,
+                    "chat.db",
+                ).build().also { instance = it }
+            }
+    }
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
@@ -1,0 +1,178 @@
+package whl.trending.chat.store
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import whl.trending.ai.chat.ChatContext
+import whl.trending.chat.db.ChatDatabase
+import whl.trending.chat.db.MessageEntity
+import whl.trending.chat.db.ThreadEntity
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.MessageKind
+import whl.trending.chat.model.Role
+import java.io.File
+import java.util.UUID
+
+/**
+ * 会话持久化层。落库策略（EchoFlow 经验的裁剪版，见 ai-chat/chat-改造评估方案-v2.md P1）：
+ * - 懒建：进入 chat 不落库，首条消息发出时才建 thread；
+ * - 终局一次写：流式过程零写库，user 消息即发即落，assistant 仅成功终局落一次，
+ *   error 消息不落（瞬态可重试，重启后无意义）；
+ * - 图片落库时从 cacheDir 拷入 [imagesDir]（filesDir 下，系统不清理），删线程先删文件再删行。
+ *
+ * @param clock 时间注入点（测试替身）；updatedAt 排序与懒建时间戳共用
+ */
+class ChatStore(
+    private val db: ChatDatabase,
+    private val imagesDir: File,
+    private val clock: () -> Long = { System.currentTimeMillis() },
+) {
+
+    /** 入口恢复语义：该入口最近活跃的会话 id；无历史返回 null（UI 呈现空态，不落库） */
+    suspend fun resolveLatestThread(context: ChatContext?): Long? =
+        db.threadDao().latestByEntry(entryKeyOf(context))?.id
+
+    /**
+     * 懒建或复用：同入口已有会话直接复用最近的，否则以首条消息建线。
+     * 标题优先取 context 标题（repo 名可读性最好），通用入口取首条消息截断。
+     */
+    suspend fun ensureThread(context: ChatContext?, firstMessageText: String): Long {
+        val entryKey = entryKeyOf(context)
+        db.threadDao().latestByEntry(entryKey)?.let { return it.id }
+        val now = clock()
+        return db.threadDao().insert(
+            ThreadEntity(
+                title = context?.title ?: titleFrom(firstMessageText),
+                entryKey = entryKey,
+                contextJson = context?.let { json.encodeToString(StoredContext.from(it)) },
+                createdAt = now,
+                updatedAt = now,
+            ),
+        )
+    }
+
+    /** 恢复会话的 ChatContext（解读 chip 与服务端 context 注入依赖）；通用入口/解析失败为 null */
+    suspend fun contextOf(threadId: Long): ChatContext? =
+        db.threadDao().getById(threadId)?.contextJson?.let { raw ->
+            runCatching { json.decodeFromString<StoredContext>(raw).toContext() }.getOrNull()
+        }
+
+    /** user 消息即发即落；图片从 cacheDir 拷入 filesDir 并回写新路径（cache 可被系统清理） */
+    suspend fun persistUserMessage(threadId: Long, message: ChatMessage): ChatMessage {
+        val persistedImages = message.images.map { copyIntoStore(it) }
+        val stored = message.copy(images = persistedImages)
+        db.messageDao().insert(stored.toEntity(threadId, clock()))
+        db.threadDao().touch(threadId, clock())
+        return stored
+    }
+
+    /** assistant 仅成功终局落一次；空内容（如内容过滤拒答）不落空行 */
+    suspend fun persistAssistantMessage(threadId: Long, content: String, kind: MessageKind, model: String?) {
+        if (content.isBlank()) return
+        db.messageDao().insert(
+            MessageEntity(
+                threadId = threadId,
+                role = ROLE_ASSISTANT,
+                content = content,
+                imagesJson = null,
+                kind = kind.name,
+                model = model,
+                segmentsJson = null,
+                createdAt = clock(),
+            ),
+        )
+        db.threadDao().touch(threadId, clock())
+    }
+
+    suspend fun loadMessages(threadId: Long): List<ChatMessage> =
+        db.messageDao().messagesFor(threadId).map { it.toModel() }
+
+    suspend fun renameThread(threadId: Long, title: String) =
+        db.threadDao().rename(threadId, title.trim().take(MAX_TITLE_LENGTH))
+
+    /** 删线程：先删图片文件（CASCADE 之后路径就找不回了），再删行 */
+    suspend fun deleteThread(threadId: Long) {
+        db.messageDao().imagesJsonFor(threadId).forEach { raw ->
+            runCatching { json.decodeFromString<List<String>>(raw) }.getOrNull()
+                ?.forEach { path -> File(path).delete() }
+        }
+        db.threadDao().delete(threadId)
+    }
+
+    fun threads() = db.threadDao().observeAll()
+
+    // ---- 内部 ----
+
+    private fun copyIntoStore(sourcePath: String): String {
+        val source = File(sourcePath)
+        if (!source.exists() || source.parentFile?.absolutePath == imagesDir.absolutePath) return sourcePath
+        imagesDir.mkdirs()
+        val target = File(imagesDir, "${UUID.randomUUID()}.jpg")
+        return runCatching {
+            source.copyTo(target, overwrite = true)
+            target.absolutePath
+        }.getOrDefault(sourcePath) // 拷贝失败退回原路径：宁可将来图裂，不阻塞发送
+    }
+
+    private fun titleFrom(text: String): String =
+        text.trim().take(MAX_TITLE_LENGTH).ifBlank { DEFAULT_TITLE }
+
+    private fun MessageEntity.toModel() = ChatMessage(
+        id = id,
+        role = if (role == ROLE_USER) Role.USER else Role.ASSISTANT,
+        content = content,
+        images = imagesJson?.let { runCatching { json.decodeFromString<List<String>>(it) }.getOrNull() }
+            ?: emptyList(),
+        kind = runCatching { MessageKind.valueOf(kind) }.getOrDefault(MessageKind.CHAT),
+    )
+
+    private fun ChatMessage.toEntity(threadId: Long, now: Long) = MessageEntity(
+        threadId = threadId,
+        role = if (role == Role.USER) ROLE_USER else ROLE_ASSISTANT,
+        content = content,
+        imagesJson = images.takeIf { it.isNotEmpty() }?.let { json.encodeToString(it) },
+        kind = kind.name,
+        model = null,
+        segmentsJson = null,
+        createdAt = now,
+    )
+
+    /**
+     * ChatContext 的持久化镜像（shared 里的原类未标 @Serializable，此处 DTO 隔离序列化关注点）。
+     * autoDetailSummary 是一次性触发标记，不持久化。
+     */
+    @Serializable
+    private data class StoredContext(
+        val title: String,
+        val summary: String? = null,
+        val sourceUrl: String? = null,
+        val source: String? = null,
+        val externalId: String? = null,
+        val readmeLength: Int? = null,
+    ) {
+        fun toContext() = ChatContext(
+            title = title, summary = summary, sourceUrl = sourceUrl,
+            source = source, externalId = externalId, readmeLength = readmeLength,
+        )
+
+        companion object {
+            fun from(c: ChatContext) = StoredContext(
+                title = c.title, summary = c.summary, sourceUrl = c.sourceUrl,
+                source = c.source, externalId = c.externalId, readmeLength = c.readmeLength,
+            )
+        }
+    }
+
+    companion object {
+        const val MAX_TITLE_LENGTH = 20
+        const val DEFAULT_TITLE = "新对话"
+        const val ENTRY_GENERAL = "general"
+        private const val ROLE_USER = "user"
+        private const val ROLE_ASSISTANT = "assistant"
+
+        private val json = Json { ignoreUnknownKeys = true }
+
+        /** 入口键：repo 条目按 externalId 隔离，其余（含 HN/PH 无 externalId 的场景）归通用 */
+        fun entryKeyOf(context: ChatContext?): String =
+            context?.externalId?.let { "repo:$it" } ?: ENTRY_GENERAL
+    }
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
@@ -36,13 +36,17 @@ class ChatStore(
      * 标题优先取 context 标题（repo 名可读性最好），通用入口取首条消息截断。
      */
     suspend fun ensureThread(context: ChatContext?, firstMessageText: String): Long {
-        val entryKey = entryKeyOf(context)
-        db.threadDao().latestByEntry(entryKey)?.let { return it.id }
+        db.threadDao().latestByEntry(entryKeyOf(context))?.let { return it.id }
+        return createThread(context, firstMessageText)
+    }
+
+    /** 总是新建（抽屉「新会话」语义）——入口复用由 [resolveLatestThread] 在进入时单独承担 */
+    suspend fun createThread(context: ChatContext?, firstMessageText: String): Long {
         val now = clock()
         return db.threadDao().insert(
             ThreadEntity(
                 title = context?.title ?: titleFrom(firstMessageText),
-                entryKey = entryKey,
+                entryKey = entryKeyOf(context),
                 contextJson = context?.let { json.encodeToString(StoredContext.from(it)) },
                 createdAt = now,
                 updatedAt = now,

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
@@ -110,7 +110,9 @@ class ChatStore(
         val source = File(sourcePath)
         if (!source.exists() || source.parentFile?.absolutePath == imagesDir.absolutePath) return sourcePath
         imagesDir.mkdirs()
-        val target = File(imagesDir, "${UUID.randomUUID()}.jpg")
+        // 保留源扩展名（当前附件层恒产 JPEG，此处是对未来透传原图的加固；无扩展名回退 jpg）
+        val extension = source.extension.takeIf { it.isNotBlank() } ?: "jpg"
+        val target = File(imagesDir, "${UUID.randomUUID()}.$extension")
         return runCatching {
             source.copyTo(target, overwrite = true)
             target.absolutePath

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -155,7 +155,7 @@ fun ChatScreen(
                         if (store != null) {
                             IconButton(onClick = { scope.launch { drawerState.open() } }) {
                                 Icon(
-                                    imageVector = Icons.Filled.History,
+                                    imageVector = Icons.Filled.Menu,
                                     contentDescription = stringResource(R.string.chat_history),
                                 )
                             }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -10,46 +10,55 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.launch
 import whl.trending.ai.chat.ChatContext
 import whl.trending.chat.ChatViewModel
 import whl.trending.chat.DetailSummaryPolicy
 import whl.trending.chat.R
+import whl.trending.chat.db.ChatDatabase
 import whl.trending.chat.engine.ChatApi
 import whl.trending.chat.engine.ChatEngine
+import whl.trending.chat.store.ChatStore
+import java.io.File
 
-/**
- * 按入口计算稳定的会话 key，使 Activity 级 ViewModelStore 按会话线各自缓存一个
- * [ChatViewModel]，从而实现"按会话线隔离 + 再次进入恢复"。
- *
- * - 首页通用助手：[context] == null → 固定唯一的 `"chat:general"`。
- * - 仓库详情：优先用 [ChatContext.sourceUrl]（仓库 URL，天然唯一稳定），
- *   为空时回退 [ChatContext.title]（即 `owner/repo`，同样唯一）。
- */
-private fun sessionKeyOf(context: ChatContext?): String =
-    if (context == null) "chat:general"
-    else "chat:" + (context.sourceUrl ?: context.title)
+/** 入口键：与 [ChatStore.entryKeyOf] 同源语义，驱动「同一入口只 enterEntry 一次」 */
+private fun entryKeyOf(context: ChatContext?): String = ChatStore.entryKeyOf(context)
 
 /**
  * 全屏聊天页。通用入口传 [initialContext] = null；带上下文入口传具体条目。
  *
+ * P1 起单 ViewModel（key 固定）+ 会话抽屉：入口进入时 [ChatViewModel.enterEntry]
+ * 恢复该入口最近会话（跨进程），抽屉可开新会话/切历史/重命名/删除。
+ *
  * @param engine 默认正式引擎 [ChatApi]；Demo 可注入 FakeChatEngine。
+ * @param persistent Demo/预览可关（纯内存模式，行为与 P1 前一致）
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -58,16 +67,35 @@ fun ChatScreen(
     onBack: () -> Unit,
     engine: ChatEngine = ChatApi.shared,
     initialMessages: List<whl.trending.chat.model.ChatMessage> = emptyList(),
+    persistent: Boolean = true,
 ) {
-    val sessionKey = sessionKeyOf(initialContext)
-    val viewModel: ChatViewModel =
-        viewModel(key = sessionKey) { ChatViewModel(engine, initialContext, initialMessages) }
+    val appContext = LocalContext.current.applicationContext
+    val store = remember(persistent) {
+        if (!persistent) null
+        else ChatStore(ChatDatabase.get(appContext), File(appContext.filesDir, "chat_images"))
+    }
+    val viewModel: ChatViewModel = viewModel(key = "chat") {
+        ChatViewModel(engine, initialContext, initialMessages, store)
+    }
     val state by viewModel.uiState.collectAsState()
+    val threads by viewModel.threads.collectAsState()
+    val currentThreadId by viewModel.currentThreadId.collectAsState()
+
+    val entryKey = entryKeyOf(initialContext)
+    // 每个屏实例对每个入口只 enter 一次：配置变更（rememberSaveable）不重进，
+    // 避免抽屉切走后旋转屏幕又被拽回入口会话
+    var enteredKey by rememberSaveable { mutableStateOf<String?>(null) }
+    LaunchedEffect(entryKey) {
+        if (enteredKey != entryKey) {
+            viewModel.enterEntry(initialContext)
+            enteredKey = entryKey
+        }
+    }
 
     // README 详情页「一键解读」入口：进入会话后自动触发一次详细解读，省去手动点 chip。
     // chipVisible 已含「GitHub + README 达标 + 尚无成功解读」判定，天然幂等、防重复触发。
     val autoDetailPrompt = stringResource(R.string.chat_action_detail_summary)
-    LaunchedEffect(sessionKey) {
+    LaunchedEffect(entryKey) {
         if (initialContext?.autoDetailSummary == true &&
             DetailSummaryPolicy.chipVisible(initialContext, viewModel.uiState.value.messages)
         ) {
@@ -75,95 +103,130 @@ fun ChatScreen(
         }
     }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = initialContext?.title
-                                ?: stringResource(R.string.chat_assistant_title),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f, fill = false),
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        BetaBadge()
-                    }
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
+    val scope = rememberCoroutineScope()
+    fun closeDrawer() = scope.launch { drawerState.close() }
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        drawerContent = {
+            ThreadDrawer(
+                threads = threads,
+                currentThreadId = currentThreadId,
+                onNewThread = {
+                    viewModel.startNewThread()
+                    closeDrawer()
                 },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.chat_back),
-                        )
-                    }
+                onSwitch = { id ->
+                    viewModel.switchThread(id)
+                    closeDrawer()
                 },
+                onRename = viewModel::renameThread,
+                onDelete = viewModel::deleteThread,
             )
         },
-        bottomBar = {
-            Column {
-                // 「一键详细解读」chip：GitHub 条目 + README 达标 + 尚无成功解读 → 常驻显示
-                // （不同于介绍 chip 的「messages 为空才显示」）；生成中置灰，成功一次后隐藏。
-                if (DetailSummaryPolicy.chipVisible(initialContext, state.messages)) {
-                    val detailPrompt = stringResource(R.string.chat_action_detail_summary)
-                    Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp)) {
-                        AssistChip(
-                            onClick = { viewModel.sendDetailSummary(detailPrompt) },
-                            enabled = !state.isSending,
-                            label = { Text(detailPrompt) },
-                        )
+    ) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = initialContext?.title
+                                    ?: stringResource(R.string.chat_assistant_title),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f, fill = false),
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            BetaBadge()
+                        }
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = stringResource(R.string.chat_back),
+                            )
+                        }
+                    },
+                    actions = {
+                        // 会话抽屉入口（纯内存模式无历史可言，隐藏）
+                        if (store != null) {
+                            IconButton(onClick = { scope.launch { drawerState.open() } }) {
+                                Icon(
+                                    imageVector = Icons.Filled.History,
+                                    contentDescription = stringResource(R.string.chat_history),
+                                )
+                            }
+                        }
+                    },
+                )
+            },
+            bottomBar = {
+                Column {
+                    // 「一键详细解读」chip：GitHub 条目 + README 达标 + 尚无成功解读 → 常驻显示
+                    // （不同于介绍 chip 的「messages 为空才显示」）；生成中置灰，成功一次后隐藏。
+                    if (DetailSummaryPolicy.chipVisible(initialContext, state.messages)) {
+                        val detailPrompt = stringResource(R.string.chat_action_detail_summary)
+                        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp)) {
+                            AssistChip(
+                                onClick = { viewModel.sendDetailSummary(detailPrompt) },
+                                enabled = !state.isSending,
+                                label = { Text(detailPrompt) },
+                            )
+                        }
                     }
-                }
-                // 尚无对话时在输入框上方显示入口对应的快捷问（label 资源 to prompt 资源）：
-                // 通用助手入口问能力，README 入口问项目介绍。messages 非空即隐藏，
-                // 天然覆盖"发送后隐藏"与"恢复历史会话不再显示"。
-                val quickAction = when {
-                    initialContext == null ->
-                        R.string.chat_action_what_can_you_do to R.string.chat_action_what_can_you_do_prompt
-                    initialContext.sourceUrl != null ->
-                        R.string.chat_action_what_is_this to R.string.chat_action_what_is_this_prompt
-                    else -> null
-                }
-                if (quickAction != null && state.messages.isEmpty()) {
-                    val prompt = stringResource(quickAction.second)
-                    Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp)) {
-                        AssistChip(
-                            onClick = { viewModel.sendText(prompt) },
-                            enabled = !state.isSending,
-                            label = { Text(stringResource(quickAction.first)) },
-                        )
+                    // 尚无对话时在输入框上方显示入口对应的快捷问（label 资源 to prompt 资源）：
+                    // 通用助手入口问能力，README 入口问项目介绍。messages 非空即隐藏，
+                    // 天然覆盖"发送后隐藏"与"恢复历史会话不再显示"。
+                    val quickAction = when {
+                        initialContext == null ->
+                            R.string.chat_action_what_can_you_do to R.string.chat_action_what_can_you_do_prompt
+                        initialContext.sourceUrl != null ->
+                            R.string.chat_action_what_is_this to R.string.chat_action_what_is_this_prompt
+                        else -> null
                     }
+                    if (quickAction != null && state.messages.isEmpty()) {
+                        val prompt = stringResource(quickAction.second)
+                        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp)) {
+                            AssistChip(
+                                onClick = { viewModel.sendText(prompt) },
+                                enabled = !state.isSending,
+                                label = { Text(stringResource(quickAction.first)) },
+                            )
+                        }
+                    }
+                    // 常驻模型选择器（≤1 个模型时自动隐藏）
+                    val models by viewModel.models.collectAsState()
+                    ModelPicker(
+                        models = models,
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                    )
+                    ChatInputBar(
+                        input = state.input,
+                        canSend = state.canSend,
+                        pendingImages = state.pendingImages,
+                        onInputChange = viewModel::updateInput,
+                        onSend = viewModel::send,
+                        onAddImage = viewModel::addPendingImage,
+                        onRemoveImage = viewModel::removePendingImage,
+                    )
                 }
-                // 常驻模型选择器（≤1 个模型时自动隐藏）
-                val models by viewModel.models.collectAsState()
-                ModelPicker(
-                    models = models,
-                    modifier = Modifier.padding(horizontal = 12.dp),
-                )
-                ChatInputBar(
-                    input = state.input,
-                    canSend = state.canSend,
-                    pendingImages = state.pendingImages,
-                    onInputChange = viewModel::updateInput,
-                    onSend = viewModel::send,
-                    onAddImage = viewModel::addPendingImage,
-                    onRemoveImage = viewModel::removePendingImage,
-                )
-            }
-        },
-    ) { padding ->
-        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
-            if (state.messages.isEmpty()) {
-                // 尚无对话：展示欢迎区（实验性 + 每日额度说明）。发出第一条后 messages 非空，
-                // 自动切到 MessageList，与「介绍这个项目」chip 的隐藏时机一致。
-                ChatWelcome(hasContext = initialContext != null)
-            } else {
-                MessageList(
-                    messages = state.messages,
-                    isSending = state.isSending,
-                    onRetry = viewModel::retry,
-                )
+            },
+        ) { padding ->
+            Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+                if (state.messages.isEmpty()) {
+                    // 尚无对话：展示欢迎区（实验性 + 每日额度说明）。发出第一条后 messages 非空，
+                    // 自动切到 MessageList，与「介绍这个项目」chip 的隐藏时机一致。
+                    ChatWelcome(hasContext = initialContext != null)
+                } else {
+                    MessageList(
+                        messages = state.messages,
+                        isSending = state.isSending,
+                        onRetry = viewModel::retry,
+                    )
+                }
             }
         }
     }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ThreadDrawer.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ThreadDrawer.kt
@@ -1,0 +1,164 @@
+package whl.trending.chat.ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import whl.trending.chat.R
+import whl.trending.chat.ThreadSummary
+
+/**
+ * 会话抽屉：新会话 + 历史列表（点击切换；条目「更多」菜单提供重命名/删除）。
+ * P1 不做搜索与分组（Recent 单列表足够，量大再议）。
+ */
+@Composable
+fun ThreadDrawer(
+    threads: List<ThreadSummary>,
+    currentThreadId: Long?,
+    onNewThread: () -> Unit,
+    onSwitch: (Long) -> Unit,
+    onRename: (Long, String) -> Unit,
+    onDelete: (Long) -> Unit,
+) {
+    var renameTarget by remember { mutableStateOf<ThreadSummary?>(null) }
+    var deleteTarget by remember { mutableStateOf<ThreadSummary?>(null) }
+
+    ModalDrawerSheet {
+        Text(
+            text = stringResource(R.string.chat_history),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 28.dp, vertical = 16.dp),
+        )
+        NavigationDrawerItem(
+            label = { Text(stringResource(R.string.chat_new_thread)) },
+            icon = { Icon(Icons.Filled.Add, contentDescription = null) },
+            selected = false,
+            onClick = onNewThread,
+            modifier = Modifier.padding(horizontal = 12.dp),
+        )
+        HorizontalDivider(Modifier.padding(vertical = 8.dp))
+        LazyColumn {
+            items(threads, key = { it.id }) { thread ->
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    NavigationDrawerItem(
+                        label = {
+                            Text(thread.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        },
+                        selected = thread.id == currentThreadId,
+                        onClick = { onSwitch(thread.id) },
+                        badge = { ThreadItemMenu(thread, { renameTarget = it }, { deleteTarget = it }) },
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                    )
+                }
+            }
+        }
+    }
+
+    renameTarget?.let { target ->
+        RenameDialog(
+            initial = target.title,
+            onConfirm = { newTitle ->
+                onRename(target.id, newTitle)
+                renameTarget = null
+            },
+            onDismiss = { renameTarget = null },
+        )
+    }
+
+    deleteTarget?.let { target ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text(stringResource(R.string.chat_thread_delete_title)) },
+            text = { Text(stringResource(R.string.chat_thread_delete_text)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    onDelete(target.id)
+                    deleteTarget = null
+                }) { Text(stringResource(R.string.chat_thread_delete)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteTarget = null }) {
+                    Text(stringResource(R.string.chat_dialog_cancel))
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun ThreadItemMenu(
+    thread: ThreadSummary,
+    onRenameRequest: (ThreadSummary) -> Unit,
+    onDeleteRequest: (ThreadSummary) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    IconButton(onClick = { expanded = true }) {
+        Icon(
+            Icons.Filled.MoreVert,
+            contentDescription = stringResource(R.string.chat_thread_more),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.chat_thread_rename)) },
+            onClick = {
+                expanded = false
+                onRenameRequest(thread)
+            },
+        )
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.chat_thread_delete)) },
+            onClick = {
+                expanded = false
+                onDeleteRequest(thread)
+            },
+        )
+    }
+}
+
+@Composable
+private fun RenameDialog(initial: String, onConfirm: (String) -> Unit, onDismiss: () -> Unit) {
+    var value by remember { mutableStateOf(initial) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.chat_thread_rename)) },
+        text = {
+            OutlinedTextField(value = value, onValueChange = { value = it }, singleLine = true)
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { if (value.isNotBlank()) onConfirm(value) },
+            ) { Text(stringResource(R.string.chat_dialog_confirm)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.chat_dialog_cancel)) }
+        },
+    )
+}

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -59,4 +59,14 @@
     <string name="chat_detail_login_message">生成详细解读需要登录。</string>
     <string name="chat_detail_login_unlocked">已登录，点击重试继续生成。</string>
     <string name="chat_error_readme_too_short">这个项目的 README 太短，暂不支持详细解读。</string>
+    <!-- 会话抽屉 -->
+    <string name="chat_history">会话</string>
+    <string name="chat_new_thread">新会话</string>
+    <string name="chat_thread_more">更多</string>
+    <string name="chat_thread_rename">重命名</string>
+    <string name="chat_thread_delete">删除</string>
+    <string name="chat_thread_delete_title">删除该会话？</string>
+    <string name="chat_thread_delete_text">该会话中的消息将被永久删除。</string>
+    <string name="chat_dialog_cancel">取消</string>
+    <string name="chat_dialog_confirm">确定</string>
 </resources>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -59,4 +59,14 @@
     <string name="chat_detail_login_message">Sign in to generate an in-depth overview.</string>
     <string name="chat_detail_login_unlocked">Signed in — tap retry to continue generating.</string>
     <string name="chat_error_readme_too_short">This project\'s README is too short for an in-depth overview.</string>
+    <!-- 会话抽屉 -->
+    <string name="chat_history">Conversations</string>
+    <string name="chat_new_thread">New chat</string>
+    <string name="chat_thread_more">More</string>
+    <string name="chat_thread_rename">Rename</string>
+    <string name="chat_thread_delete">Delete</string>
+    <string name="chat_thread_delete_title">Delete this conversation?</string>
+    <string name="chat_thread_delete_text">Messages in this conversation will be permanently removed.</string>
+    <string name="chat_dialog_cancel">Cancel</string>
+    <string name="chat_dialog_confirm">OK</string>
 </resources>

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
@@ -93,8 +93,10 @@ class ChatViewModelPersistenceTest {
         imagesDir.deleteRecursively()
     }
 
+    /** 构造并执行入口进入（Screen 的 enterEntry 时序在测试里显式驱动） */
     private fun vm(engine: ChatEngine, context: ChatContext? = null) =
         ChatViewModel(engine, context, store = store, loadModels = { emptyList() }, track = { _, _ -> }, selectedModelId = { "gpt-5.5" })
+            .also { it.enterEntry(context) }
 
     @Test
     fun `首条发送懒建线程，user 与 assistant 终局各落一行，model 记录在案`() = runTest(dispatcher) {

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
@@ -1,0 +1,225 @@
+package whl.trending.chat
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import whl.trending.ai.chat.ChatContext
+import whl.trending.chat.engine.ChatEngine
+import whl.trending.chat.engine.ChatException
+import whl.trending.chat.engine.DetailSummaryResult
+import whl.trending.chat.db.ChatDatabase
+import whl.trending.chat.model.ChatError
+import whl.trending.chat.model.ChatErrorCategory
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.Role
+import whl.trending.chat.store.ChatStore
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * VM × 持久化联动：懒建落库 / 终局一次写 / 入口恢复 / 会话切换 / 后台流完成落库。
+ * 真 ChatStore + 内存 Room（Robolectric，sdk 钉 35 同前）；引擎为可编程假实现。
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class ChatViewModelPersistenceTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private lateinit var db: ChatDatabase
+    private lateinit var imagesDir: File
+    private lateinit var store: ChatStore
+
+    private val repoContext = ChatContext(
+        title = "octo/demo", source = "github", externalId = "octo/demo", readmeLength = 5000,
+    )
+
+    /** 可挂起的假引擎：release 前流不结束，模拟「切换会话时流仍在进行」 */
+    private class GatedEngine(
+        var reply: String = "回答",
+        var failWith: ChatError? = null,
+        var gate: kotlinx.coroutines.CompletableDeferred<Unit>? = null,
+    ) : ChatEngine {
+        override suspend fun send(
+            history: List<ChatMessage>,
+            context: ChatContext?,
+            onDelta: (String) -> Unit,
+        ): String {
+            failWith?.let { throw ChatException(it) }
+            onDelta(reply)
+            gate?.await()
+            return reply
+        }
+
+        override suspend fun sendDetailSummary(context: ChatContext, onDelta: (String) -> Unit): DetailSummaryResult {
+            onDelta(reply)
+            return DetailSummaryResult(reply, cached = false)
+        }
+    }
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(), ChatDatabase::class.java,
+        )
+            // 直通执行器：Room suspend DAO 默认走自有线程池，advanceUntilIdle 等不到真实线程
+            // 上的恢复点会早返回——直通后全部调度都留在测试调度器里
+            .setQueryExecutor { it.run() }
+            .setTransactionExecutor { it.run() }
+            .allowMainThreadQueries()
+            .build()
+        imagesDir = File.createTempFile("imgs", null).apply { delete(); mkdirs() }
+        store = ChatStore(db, imagesDir, clock = { 1000L })
+    }
+
+    @After
+    fun teardown() {
+        Dispatchers.resetMain()
+        db.close()
+        imagesDir.deleteRecursively()
+    }
+
+    private fun vm(engine: ChatEngine, context: ChatContext? = null) =
+        ChatViewModel(engine, context, store = store, loadModels = { emptyList() }, track = { _, _ -> }, selectedModelId = { "gpt-5.5" })
+
+    @Test
+    fun `首条发送懒建线程，user 与 assistant 终局各落一行，model 记录在案`() = runTest(dispatcher) {
+        val v = vm(GatedEngine(reply = "你好"), repoContext)
+        advanceUntilIdle()
+        v.updateInput("介绍一下")
+        v.send()
+        advanceUntilIdle()
+
+        val threads = store.threads().first()
+        assertEquals(1, threads.size)
+        assertEquals("octo/demo", threads[0].title)
+        val rows = db.messageDao().messagesFor(threads[0].id)
+        assertEquals(listOf("user", "assistant"), rows.map { it.role })
+        assertEquals("你好", rows[1].content)
+        assertEquals("gpt-5.5", rows[1].model)
+    }
+
+    @Test
+    fun `失败回复不落库，user 消息保留`() = runTest(dispatcher) {
+        val v = vm(GatedEngine(failWith = ChatError(ChatErrorCategory.NETWORK)))
+        advanceUntilIdle()
+        v.updateInput("hi")
+        v.send()
+        advanceUntilIdle()
+
+        val threads = store.threads().first()
+        val rows = db.messageDao().messagesFor(threads[0].id)
+        assertEquals(listOf("user"), rows.map { it.role })
+        // UI 上错误条可见可重试
+        assertNotNull(v.uiState.value.messages.last().error)
+    }
+
+    @Test
+    fun `入口恢复：同 repo 再次构造 VM 载入历史消息`() = runTest(dispatcher) {
+        val first = vm(GatedEngine(reply = "答一"), repoContext)
+        advanceUntilIdle()
+        first.updateInput("问一")
+        first.send()
+        advanceUntilIdle()
+
+        val second = vm(GatedEngine(), repoContext)
+        advanceUntilIdle()
+        val restored = second.uiState.value.messages
+        assertEquals(listOf("问一", "答一"), restored.map { it.content })
+        assertEquals(listOf(Role.USER, Role.ASSISTANT), restored.map { it.role })
+    }
+
+    @Test
+    fun `startNewThread 后发送总是新建线程，不复用入口最近会话`() = runTest(dispatcher) {
+        val v = vm(GatedEngine(reply = "答"), repoContext)
+        advanceUntilIdle()
+        v.updateInput("第一线")
+        v.send()
+        advanceUntilIdle()
+
+        v.startNewThread()
+        assertTrue(v.uiState.value.messages.isEmpty())
+        v.updateInput("第二线")
+        v.send()
+        advanceUntilIdle()
+
+        assertEquals(2, store.threads().first().size)
+    }
+
+    @Test
+    fun `switchThread 载入目标线程消息与 id 续位`() = runTest(dispatcher) {
+        val v = vm(GatedEngine(reply = "答A"), repoContext)
+        advanceUntilIdle()
+        v.updateInput("问A")
+        v.send()
+        advanceUntilIdle()
+        val threadA = store.threads().first()[0].id
+
+        v.startNewThread()
+        v.updateInput("问B")
+        v.send()
+        advanceUntilIdle()
+
+        v.switchThread(threadA)
+        advanceUntilIdle()
+        assertEquals(listOf("问A", "答A"), v.uiState.value.messages.map { it.content })
+    }
+
+    @Test
+    fun `切换会话时后台流继续完成并落库，切回可见全文`() = runTest(dispatcher) {
+        val gate = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val v = vm(GatedEngine(reply = "慢答案", gate = gate), repoContext)
+        advanceUntilIdle()
+        v.updateInput("慢问题")
+        v.send()
+        advanceUntilIdle() // 流启动，卡在 gate
+        val threadA = store.threads().first()[0].id
+        assertTrue(v.uiState.value.isSending)
+
+        v.startNewThread() // 切走：A 的流在后台继续
+        assertEquals(false, v.uiState.value.isSending)
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        // A 已终局落库
+        val rows = db.messageDao().messagesFor(threadA)
+        assertEquals(listOf("user", "assistant"), rows.map { it.role })
+        assertEquals("慢答案", rows[1].content)
+
+        // 切回 A 看到全文
+        v.switchThread(threadA)
+        advanceUntilIdle()
+        assertEquals("慢答案", v.uiState.value.messages.last().content)
+    }
+
+    @Test
+    fun `deleteThread 删除当前会话后回到空态，行与文件同清`() = runTest(dispatcher) {
+        val v = vm(GatedEngine(reply = "答"), repoContext)
+        advanceUntilIdle()
+        v.updateInput("问")
+        v.send()
+        advanceUntilIdle()
+        val threadId = store.threads().first()[0].id
+
+        v.deleteThread(threadId)
+        advanceUntilIdle()
+
+        assertTrue(store.threads().first().isEmpty())
+        assertTrue(v.uiState.value.messages.isEmpty())
+    }
+}

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/db/ChatDatabaseTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/db/ChatDatabaseTest.kt
@@ -1,0 +1,107 @@
+package whl.trending.chat.db
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * schema 特征测试：钉住表结构契约（入口恢复查询 / 排序 / 级联删除 / 字段往返）。
+ * Robolectric 内存库，行为即真实 SQLite。
+ * sdk 钉 35：Robolectric 4.16.x 不支持 37，SDK 36 沙箱又要求 Java 21（测试 JVM 为 17）
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class ChatDatabaseTest {
+
+    private lateinit var db: ChatDatabase
+
+    @Before
+    fun setup() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            ChatDatabase::class.java,
+        ).build()
+    }
+
+    @After
+    fun teardown() = db.close()
+
+    private fun thread(entryKey: String = "general", updatedAt: Long = 0L, title: String = "t") =
+        ThreadEntity(title = title, entryKey = entryKey, contextJson = null, createdAt = updatedAt, updatedAt = updatedAt)
+
+    private fun message(threadId: Long, content: String = "hi", role: String = "user") =
+        MessageEntity(
+            threadId = threadId, role = role, content = content,
+            imagesJson = null, kind = "CHAT", model = null, segmentsJson = null, createdAt = 0L,
+        )
+
+    @Test
+    fun `入口恢复：latestByEntry 返回该入口最近活跃的会话`() = runTest {
+        db.threadDao().insert(thread(entryKey = "repo:octo/demo", updatedAt = 100))
+        val newer = db.threadDao().insert(thread(entryKey = "repo:octo/demo", updatedAt = 200))
+        db.threadDao().insert(thread(entryKey = "general", updatedAt = 300))
+
+        val latest = db.threadDao().latestByEntry("repo:octo/demo")
+        assertEquals(newer, latest?.id)
+    }
+
+    @Test
+    fun `列表按 updatedAt 倒序，touch 冒泡到顶部`() = runTest {
+        val a = db.threadDao().insert(thread(title = "a", updatedAt = 100))
+        val b = db.threadDao().insert(thread(title = "b", updatedAt = 200))
+
+        assertEquals(listOf(b, a), db.threadDao().observeAll().first().map { it.id })
+
+        db.threadDao().touch(a, now = 300)
+        assertEquals(listOf(a, b), db.threadDao().observeAll().first().map { it.id })
+    }
+
+    @Test
+    fun `删线程级联删消息`() = runTest {
+        val t = db.threadDao().insert(thread())
+        db.messageDao().insert(message(t))
+        db.messageDao().insert(message(t, role = "assistant", content = "ok"))
+
+        db.threadDao().delete(t)
+
+        assertNull(db.threadDao().getById(t))
+        assertTrue(db.messageDao().messagesFor(t).isEmpty())
+    }
+
+    @Test
+    fun `消息字段完整往返，按插入顺序读出`() = runTest {
+        val t = db.threadDao().insert(thread())
+        db.messageDao().insert(
+            message(t).copy(imagesJson = """["/data/img1.jpg"]""", kind = "DETAIL_SUMMARY", model = "gpt-5.5"),
+        )
+        db.messageDao().insert(message(t, role = "assistant", content = "答案"))
+
+        val loaded = db.messageDao().messagesFor(t)
+        assertEquals(2, loaded.size)
+        assertEquals("""["/data/img1.jpg"]""", loaded[0].imagesJson)
+        assertEquals("DETAIL_SUMMARY", loaded[0].kind)
+        assertEquals("gpt-5.5", loaded[0].model)
+        assertNull(loaded[0].segmentsJson)
+        assertEquals("答案", loaded[1].content)
+    }
+
+    @Test
+    fun `imagesJsonFor 只取带图消息的路径列`() = runTest {
+        val t = db.threadDao().insert(thread())
+        db.messageDao().insert(message(t))
+        db.messageDao().insert(message(t).copy(imagesJson = """["/a.jpg","/b.jpg"]"""))
+
+        val jsons = db.messageDao().imagesJsonFor(t)
+        assertEquals(listOf("""["/a.jpg","/b.jpg"]"""), jsons)
+    }
+}

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/store/ChatStoreTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/store/ChatStoreTest.kt
@@ -1,0 +1,189 @@
+package whl.trending.chat.store
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import whl.trending.ai.chat.ChatContext
+import whl.trending.chat.db.ChatDatabase
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.MessageKind
+import whl.trending.chat.model.Role
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * 持久化层行为测试：懒建会话 / 入口恢复复用 / context 往返 / 标题策略 /
+ * 图片迁移 filesDir / 终局一次写（空回复不落）/ 删除先删文件。
+ * sdk 钉 35：同 ChatDatabaseTest（Robolectric 4.16.x + 测试 JVM 17 的上限）
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class ChatStoreTest {
+
+    private lateinit var db: ChatDatabase
+    private lateinit var imagesDir: File
+    private lateinit var cacheDir: File
+    private var now = 1000L
+    private lateinit var store: ChatStore
+
+    private val repoContext = ChatContext(
+        title = "octo/demo",
+        summary = "A demo repo",
+        sourceUrl = "https://github.com/octo/demo",
+        source = "github",
+        externalId = "octo/demo",
+        readmeLength = 2000,
+    )
+
+    @Before
+    fun setup() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            ChatDatabase::class.java,
+        ).build()
+        imagesDir = File.createTempFile("imgs", null).apply { delete(); mkdirs() }
+        cacheDir = File.createTempFile("cache", null).apply { delete(); mkdirs() }
+        store = ChatStore(db, imagesDir, clock = { now })
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+        imagesDir.deleteRecursively()
+        cacheDir.deleteRecursively()
+    }
+
+    private fun userMsg(text: String, images: List<String> = emptyList()) =
+        ChatMessage(id = 0, role = Role.USER, content = text, images = images)
+
+    private fun cacheImage(name: String): String =
+        File(cacheDir, name).apply { writeBytes(byteArrayOf(1, 2, 3)) }.absolutePath
+
+    // ---- 懒建与入口恢复 ----
+
+    @Test
+    fun `repo 入口懒建：标题取 context 标题，entryKey 为 repo 前缀`() = runTest {
+        val id = store.ensureThread(repoContext, firstMessageText = "介绍一下")
+        val thread = db.threadDao().getById(id)!!
+        assertEquals("octo/demo", thread.title)
+        assertEquals("repo:octo/demo", thread.entryKey)
+    }
+
+    @Test
+    fun `同入口再次 ensure 复用最近会话，不新建`() = runTest {
+        val first = store.ensureThread(repoContext, firstMessageText = "hi")
+        val second = store.ensureThread(repoContext, firstMessageText = "again")
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `resolveLatestThread 无历史返回 null（进入即空态，不落库）`() = runTest {
+        assertNull(store.resolveLatestThread(null))
+        assertEquals(0, db.threadDao().observeAll().first().size)
+    }
+
+    // ---- context 往返 ----
+
+    @Test
+    fun `contextJson 往返：恢复的会话还原 ChatContext 关键字段`() = runTest {
+        val id = store.ensureThread(repoContext, firstMessageText = "hi")
+        val restored = store.contextOf(id)!!
+        assertEquals("octo/demo", restored.title)
+        assertEquals("github", restored.source)
+        assertEquals("octo/demo", restored.externalId)
+        assertEquals(2000, restored.readmeLength)
+        // autoDetailSummary 是一次性触发标记，不持久化
+        assertFalse(restored.autoDetailSummary)
+    }
+
+    // ---- 标题策略 ----
+
+    @Test
+    fun `通用入口标题取首条消息，超长截断`() = runTest {
+        val id = store.ensureThread(null, firstMessageText = "这是一条非常非常非常非常非常非常长的首条消息内容")
+        val title = db.threadDao().getById(id)!!.title
+        assertTrue(title.length <= ChatStore.MAX_TITLE_LENGTH)
+        assertTrue(title.startsWith("这是一条"))
+    }
+
+    @Test
+    fun `纯图消息无文本 → 默认标题`() = runTest {
+        val id = store.ensureThread(null, firstMessageText = "")
+        assertEquals(ChatStore.DEFAULT_TITLE, db.threadDao().getById(id)!!.title)
+    }
+
+    // ---- 消息落库 ----
+
+    @Test
+    fun `persistUserMessage 把图片从 cache 拷入 filesDir 并回写新路径`() = runTest {
+        val cachePath = cacheImage("a.jpg")
+        val id = store.ensureThread(null, firstMessageText = "看图")
+        val persisted = store.persistUserMessage(id, userMsg("看图", images = listOf(cachePath)))
+
+        assertEquals(1, persisted.images.size)
+        val newPath = persisted.images[0]
+        assertTrue(newPath.startsWith(imagesDir.absolutePath))
+        assertTrue(File(newPath).exists())
+
+        val rows = db.messageDao().messagesFor(id)
+        assertEquals(1, rows.size)
+        assertTrue(rows[0].imagesJson!!.contains(newPath))
+    }
+
+    @Test
+    fun `persistAssistantMessage 成功终局落一次，空内容不落`() = runTest {
+        val id = store.ensureThread(null, firstMessageText = "hi")
+        store.persistAssistantMessage(id, content = "回答", kind = MessageKind.CHAT, model = "gpt-5.4")
+        store.persistAssistantMessage(id, content = "", kind = MessageKind.CHAT, model = null)
+
+        val rows = db.messageDao().messagesFor(id)
+        assertEquals(1, rows.size)
+        assertEquals("assistant", rows[0].role)
+        assertEquals("gpt-5.4", rows[0].model)
+    }
+
+    @Test
+    fun `loadMessages 完整还原 model 层字段（kind与图片）`() = runTest {
+        val id = store.ensureThread(repoContext, firstMessageText = "解读")
+        store.persistUserMessage(
+            id,
+            ChatMessage(0, Role.USER, "解读", kind = MessageKind.DETAIL_SUMMARY),
+        )
+        store.persistAssistantMessage(id, "解读内容", MessageKind.DETAIL_SUMMARY, model = null)
+
+        val loaded = store.loadMessages(id)
+        assertEquals(2, loaded.size)
+        assertEquals(MessageKind.DETAIL_SUMMARY, loaded[0].kind)
+        assertEquals(Role.ASSISTANT, loaded[1].role)
+        assertEquals("解读内容", loaded[1].content)
+        // id 单调递增（VM 的 idSeq 从 max(id) 续）
+        assertTrue(loaded[1].id > loaded[0].id)
+    }
+
+    // ---- 删除 ----
+
+    @Test
+    fun `deleteThread 先删图片文件再删行`() = runTest {
+        val cachePath = cacheImage("b.jpg")
+        val id = store.ensureThread(null, firstMessageText = "看图")
+        val persisted = store.persistUserMessage(id, userMsg("看图", images = listOf(cachePath)))
+        val storedFile = File(persisted.images[0])
+        assertTrue(storedFile.exists())
+
+        store.deleteThread(id)
+
+        assertFalse(storedFile.exists())
+        assertNull(db.threadDao().getById(id))
+        assertTrue(db.messageDao().messagesFor(id).isEmpty())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,13 @@ material-kolor = "5.0.0"
 commonmark = "0.29.0"
 kmp-webview = "0.1.7"
 logto = "3.0.0-beta"
+# 会话持久化（androidLibrary/chat）。必须 ≥2.7.0：2.6.x 的老 keep 规则在 R8 full mode
+# 下裁掉 *Database_Impl 构造器导致启动即崩（0.20.0 事故，见 memory r8-room-workdatabase-crash）
+room = "2.8.4"
+# KSP2 起版本线与 Kotlin 解耦（不再是 kotlin-x.y.z 配对命名）
+ksp = "2.3.10"
+robolectric = "4.16.1"
+androidx-test-core = "1.7.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -76,6 +83,11 @@ commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" 
 commonmark-ext-gfm-tables = { module = "org.commonmark:commonmark-ext-gfm-tables", version.ref = "commonmark" }
 kmp-webview = { module = "wang.harlon:kmp-webview", version.ref = "kmp-webview" }
 logto-android = { module = "io.logto.sdk:android", version.ref = "logto" }
+room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
+room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -84,3 +96,5 @@ androidKotlinMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.lib
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+room = { id = "androidx.room", version.ref = "room" }


### PR DESCRIPTION
## 概要

Chat 改造 v2 方案的 P1 阶段（设计见 TrendingProjects/ai-chat/chat-改造评估方案-v2.md）：会话从「内存级、退出即焚」升级为 Room 落库的多会话体系。

## 变更

**数据层**
- Room 2.8.4 + KSP 首次进入 chat 模块（≥2.7.0 是 R8 full mode 硬前提，0.20.0 崩溃前科）；依赖走 version catalog，schema JSON 入库
- `chat_threads`（entryKey 入口恢复 + contextJson 会话上下文）+ `chat_messages`（imagesJson/kind/model/segmentsJson P2 预留）
- ChatStore：懒建（首条消息才建线）、终局一次写（流中零写库、失败/空回复不落）、图片 cacheDir→filesDir 迁移、删线程先删文件再删行

**VM 重构**
- 多实例 keyed → 单实例 + currentThreadId；messagesByThread 为真相源，uiState 只镜像当前线
- 切换会话不打断在途流：按 threadId 分键后台完成并落库（服务端已计费，取消才是浪费），切回可见全文
- enterEntry 入口语义：同入口再次进入恢复最近会话（跨进程延续原 sessionKey 体验）

**UI**
- 会话抽屉：新会话/历史列表/重命名/删除，当前线高亮；双语字符串
- Demo 假引擎走纯内存模式（persistent=false），样例数据不落真库

## 验证

- 模块 75 个单元测试全绿（新增 22 个：DAO 特征 / Store 行为 / VM 持久化联动含「切换中后台流完成落库」门控用例）
- Pixel_9_2 真机：发送/流式回复（生产链路）、**杀进程重进对话完整恢复**、抽屉全功能，截图取证
- **release-smoke PASS**：R8 minify 包安装启动无崩溃（Room 首入模块的高危场景）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7b1EyajFyydKthdYtfiCV

## Summary by Sourcery

为聊天模块引入基于 Room 的持久化多会话支持，包括会话恢复以及会话抽屉 UI。

New Features:
- 添加基于 Room 的聊天线程和消息存储，以支持多会话持久化以及跨进程恢复。
- 在聊天 UI 中暴露会话抽屉，支持发起新聊天、在线程之间切换、重命名和删除会话。
- 添加非持久化的演示模式支持，在该模式下示例会话仅保存在内存中且不会被存储。

Enhancements:
- 重构 ChatViewModel，使其在单个实例中管理多个线程，在保持各线程中的流式消息进行的同时，仅将当前激活的会话镜像到 UI 状态。
- 将全局模型选择集成到助手回复中，使已存储消息能够记录是哪一个模型进行的回复。
- 通过将附加图片从缓存迁移到专用的应用文件目录并在会话删除时清理它们，改进图片处理。

Build:
- 在聊天模块的构建配置中启用 Room 和 KSP，包括用于基于 Robolectric 的单元测试的 schema 导出和测试选项。
- 扩展依赖目录，加入 Room、KSP、Robolectric 和 AndroidX test core 条目，并将它们接入聊天模块。

Tests:
- 添加基于 Robolectric 的 Room 数据库 schema 测试，以锁定线程/消息存储行为和级联删除。
- 添加 ChatStore 行为测试，涵盖惰性线程创建、基于条目的恢复、上下文往返、图片迁移以及删除语义。
- 为 ChatViewModel 添加以持久化为重点的测试，以验证惰性线程创建、条目恢复、线程切换、带持久化的后台流式完成以及删除行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce persistent multi-conversation support to the chat module backed by Room, including session recovery and a conversation drawer UI.

New Features:
- Add Room-based storage for chat threads and messages to support multi-conversation persistence and cross-process recovery.
- Expose a conversation drawer in the chat UI with support for starting new chats, switching between threads, renaming, and deleting conversations.
- Add support for a non-persistent demo mode where sample conversations remain in memory and are not stored.

Enhancements:
- Refactor ChatViewModel to manage multiple threads in a single instance, preserving in-flight streaming per thread while mirroring only the active conversation to UI state.
- Integrate global model selection into assistant replies so stored messages track which model answered.
- Improve image handling by migrating attached images from cache to a dedicated app files directory and cleaning them up when conversations are deleted.

Build:
- Configure Room and KSP in the chat module build, including schema export and test options for Robolectric-based unit tests.
- Extend dependency catalog with Room, KSP, Robolectric, and AndroidX test core entries and wire them into the chat module.

Tests:
- Add Robolectric-backed tests for the Room database schema to lock in thread/message storage behavior and cascading deletes.
- Add tests for ChatStore behavior covering lazy thread creation, entry-based restoration, context round-tripping, image migration, and deletion semantics.
- Add persistence-focused tests for ChatViewModel to verify lazy thread creation, entry recovery, thread switching, background streaming completion with persistence, and deletion behavior.

</details>