### PR TITLE
P2：联网搜索客户端——ChatMode 框架 + 搜索事件流 + 来源持久化

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -327,7 +327,7 @@ class ChatViewModel(
         streams[threadId] = job
     }
 
-    /** 搜索事件落到占位消息：searching 瞬态 + sources 累积（url 去重由服务端保证） */
+    /** 搜索事件落到占位消息：searching 瞬态 + sources 累积（服务端已按 url 去重，客户端再防御一层） */
     private fun applySearchEvent(threadId: Long?, messageId: Long, event: SearchEvent) {
         updateThreadMessages(threadId) { list ->
             list.map { m ->
@@ -335,7 +335,8 @@ class ChatViewModel(
                 else when (event) {
                     is SearchEvent.Started -> m.copy(searching = true)
                     is SearchEvent.Done -> m.copy(searching = false)
-                    is SearchEvent.Source -> m.copy(sources = m.sources + SourceRef(event.title, event.url))
+                    is SearchEvent.Source ->
+                        m.copy(sources = (m.sources + SourceRef(event.title, event.url)).distinctBy { it.url })
                 }
             }
         }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -22,9 +22,12 @@ import whl.trending.chat.engine.ChatException
 import whl.trending.chat.model.ChatError
 import whl.trending.chat.model.ChatErrorCategory
 import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.ChatMode
 import whl.trending.chat.model.ChatUiState
 import whl.trending.chat.model.MessageKind
 import whl.trending.chat.model.Role
+import whl.trending.chat.model.SearchEvent
+import whl.trending.chat.model.SourceRef
 import whl.trending.chat.store.ChatStore
 
 /** 抽屉里的一条会话概要 */
@@ -66,6 +69,15 @@ class ChatViewModel(
 
     private val _currentThreadId = MutableStateFlow<Long?>(null)
     val currentThreadId: StateFlow<Long?> = _currentThreadId.asStateFlow()
+
+    /** 会话能力模式（P2：联网搜索）。粘滞语义：开启后对后续每条消息生效，直到手动关闭 */
+    private val _chatMode = MutableStateFlow<ChatMode>(ChatMode.Normal)
+    val chatMode: StateFlow<ChatMode> = _chatMode.asStateFlow()
+
+    /** EchoFlow 单选互斥范式：再点同项回 Normal，点别项自动顶掉 */
+    fun toggleWebSearch() {
+        _chatMode.value = if (_chatMode.value == ChatMode.WebSearch) ChatMode.Normal else ChatMode.WebSearch
+    }
 
     /** 当前会话的 ChatContext（解读 chip / 服务端 context 注入）；随切换/恢复而变 */
     private var activeContext: ChatContext? = initialContext
@@ -264,7 +276,14 @@ class ChatViewModel(
                     MessageKind.CHAT -> {
                         val history = (messagesByThread[threadId] ?: emptyList())
                             .filterNot { it.id == placeholderId }
-                        engine.send(history, context) { delta -> appendDelta(threadId, placeholderId, delta) }
+                        val useSearch = _chatMode.value == ChatMode.WebSearch
+                        engine.send(
+                            history,
+                            context,
+                            onDelta = { delta -> appendDelta(threadId, placeholderId, delta) },
+                            search = useSearch,
+                            onSearch = { event -> applySearchEvent(threadId, placeholderId, event) },
+                        )
                     }
                     MessageKind.DETAIL_SUMMARY -> {
                         val detail = engine.sendDetailSummary(requireNotNull(context)) { delta ->
@@ -277,11 +296,17 @@ class ChatViewModel(
             }
             result.fold(
                 onSuccess = { full ->
+                    var sources: List<SourceRef> = emptyList()
                     updateThreadMessages(threadId) { list ->
-                        list.map { if (it.id == placeholderId) it.copy(content = full) else it }
+                        list.map {
+                            if (it.id == placeholderId) {
+                                sources = it.sources
+                                it.copy(content = full, searching = false)
+                            } else it
+                        }
                     }
                     if (store != null && threadId != null) {
-                        store.persistAssistantMessage(threadId, full, kind, selectedModelId())
+                        store.persistAssistantMessage(threadId, full, kind, selectedModelId(), sources)
                     }
                 },
                 onFailure = { e ->
@@ -290,7 +315,7 @@ class ChatViewModel(
                     trackFailure(kind, error)
                     updateThreadMessages(threadId) { list ->
                         // 已渲染部分丢弃，整条重试（中途断流语义）
-                        list.map { if (it.id == placeholderId) it.copy(content = "", error = error) else it }
+                        list.map { if (it.id == placeholderId) it.copy(content = "", error = error, searching = false) else it }
                     }
                 },
             )
@@ -300,6 +325,20 @@ class ChatViewModel(
             }
         }
         streams[threadId] = job
+    }
+
+    /** 搜索事件落到占位消息：searching 瞬态 + sources 累积（url 去重由服务端保证） */
+    private fun applySearchEvent(threadId: Long?, messageId: Long, event: SearchEvent) {
+        updateThreadMessages(threadId) { list ->
+            list.map { m ->
+                if (m.id != messageId) m
+                else when (event) {
+                    is SearchEvent.Started -> m.copy(searching = true)
+                    is SearchEvent.Done -> m.copy(searching = false)
+                    is SearchEvent.Source -> m.copy(sources = m.sources + SourceRef(event.title, event.url))
+                }
+            }
+        }
     }
 
     private fun appendDelta(threadId: Long?, messageId: Long, delta: String) {

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -36,6 +36,7 @@ import whl.trending.ai.data.repository.ChatModelsProvider
 import whl.trending.chat.model.ChatError
 import whl.trending.chat.model.ChatErrorCategory
 import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.SearchEvent
 import whl.trending.chat.model.Role
 
 private const val TAG = "ChatApi"
@@ -76,6 +77,8 @@ class ChatApi(
         val context: WireContext? = null,
         val model: String? = null,
         val stream: Boolean,
+        // P2 联网搜索开关：默认 false 时被 encodeDefaults=false 省略，旧服务端零感知
+        val search: Boolean = false,
     )
 
     @Serializable
@@ -120,10 +123,12 @@ class ChatApi(
         history: List<ChatMessage>,
         context: ChatContext?,
         onDelta: (String) -> Unit,
+        search: Boolean,
+        onSearch: (SearchEvent) -> Unit,
     ): String {
         val lang = resolveLang()
         val imagePlaceholder = if (lang == "zh") "[图片]" else "[image]"
-        return executeStreaming(path = "chat", onDelta = onDelta) {
+        return executeStreaming(path = "chat", onDelta = onDelta, onSearch = onSearch) {
             setBody(
                 ChatRequest(
                     messages = history.mapIndexed { index, m ->
@@ -151,6 +156,7 @@ class ChatApi(
                         globalSettingsManager.currentIsPro(),
                     ),
                     stream = true,
+                    search = search,
                 ),
             )
         }.content
@@ -176,6 +182,7 @@ class ChatApi(
     private suspend fun executeStreaming(
         path: String,
         onDelta: (String) -> Unit,
+        onSearch: (SearchEvent) -> Unit = {},
         configure: HttpRequestBuilder.() -> Unit,
     ): DetailSummaryResult {
         try {
@@ -209,6 +216,9 @@ class ChatApi(
                             onDelta(event.text)
                         }
                         is ChatSse.Event.Done -> done = event
+                        is ChatSse.Event.SearchStarted -> onSearch(SearchEvent.Started)
+                        is ChatSse.Event.SearchDone -> onSearch(SearchEvent.Done(event.query))
+                        is ChatSse.Event.Source -> onSearch(SearchEvent.Source(event.title, event.url))
                         null -> Unit
                     }
                 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatEngine.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatEngine.kt
@@ -25,6 +25,8 @@ interface ChatEngine {
         history: List<ChatMessage>,
         context: ChatContext?,
         onDelta: (String) -> Unit = {},
+        search: Boolean = false,
+        onSearch: (whl.trending.chat.model.SearchEvent) -> Unit = {},
     ): String
 
     /**

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatSse.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatSse.kt
@@ -16,6 +16,15 @@ internal object ChatSse {
     sealed interface Event {
         data class Delta(val text: String) : Event
         data class Done(val cached: Boolean) : Event
+
+        /** P2 搜索事件：一次搜索开始（transient 指示器） */
+        data object SearchStarted : Event
+
+        /** 单次搜索完成；query 服务端尽力而为（open_page 等动作无 query） */
+        data class SearchDone(val query: String?) : Event
+
+        /** 引用来源（服务端已按 url 去重） */
+        data class Source(val title: String, val url: String) : Event
     }
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -29,6 +38,19 @@ internal object ChatSse {
         (obj["delta"] as? JsonPrimitive)?.contentOrNull?.let { return Event.Delta(it) }
         if ((obj["done"] as? JsonPrimitive)?.booleanOrNull == true) {
             return Event.Done(cached = (obj["cached"] as? JsonPrimitive)?.booleanOrNull == true)
+        }
+        (obj["search"])?.let { search ->
+            val s = runCatching { search.jsonObject }.getOrNull() ?: return null
+            return when ((s["state"] as? JsonPrimitive)?.contentOrNull) {
+                "started" -> Event.SearchStarted
+                "done" -> Event.SearchDone((s["query"] as? JsonPrimitive)?.contentOrNull)
+                else -> null // 未知 state 忽略（向前兼容）
+            }
+        }
+        (obj["source"])?.let { source ->
+            val s = runCatching { source.jsonObject }.getOrNull() ?: return null
+            val url = (s["url"] as? JsonPrimitive)?.contentOrNull ?: return null
+            return Event.Source(title = (s["title"] as? JsonPrimitive)?.contentOrNull ?: url, url = url)
         }
         return null
     }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatMessage.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatMessage.kt
@@ -18,6 +18,8 @@ enum class MessageKind { CHAT, DETAIL_SUMMARY }
  *   UI 直接按路径渲染，发送时由 transport 层读文件转 base64 内嵌
  * @param error 非空表示这条 assistant 消息是一次失败（按 [ChatError.category] 区分展示）
  * @param kind 生成管线标记，默认普通对话
+ * @param sources 联网搜索的引用来源（随消息持久化，尾部 SourcesRow 渲染）
+ * @param searching 流式过程中「正在搜索」瞬态指示（不持久化）
  */
 data class ChatMessage(
     val id: Long,
@@ -26,4 +28,6 @@ data class ChatMessage(
     val images: List<String> = emptyList(),
     val error: ChatError? = null,
     val kind: MessageKind = MessageKind.CHAT,
+    val sources: List<SourceRef> = emptyList(),
+    val searching: Boolean = false,
 )

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/SearchModels.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/SearchModels.kt
@@ -1,0 +1,20 @@
+package whl.trending.chat.model
+
+/**
+ * 会话能力模式（EchoFlow 的单选互斥范式）：sealed 单值天然排斥「两个开关同时亮」。
+ * P2 仅 WebSearch；P3 加 DeepResearch 时只增枚举值，toggle 逻辑不变。
+ */
+sealed interface ChatMode {
+    data object Normal : ChatMode
+    data object WebSearch : ChatMode
+}
+
+/** 引用来源（服务端按 url 去重后下发；随 assistant 消息持久化） */
+data class SourceRef(val title: String, val url: String)
+
+/** 流式过程中的搜索事件（引擎 → VM），与服务端 SSE 协议一一对应 */
+sealed interface SearchEvent {
+    data object Started : SearchEvent
+    data class Done(val query: String?) : SearchEvent
+    data class Source(val title: String, val url: String) : SearchEvent
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/sample/FakeChatEngine.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/sample/FakeChatEngine.kt
@@ -25,7 +25,15 @@ class FakeChatEngine(
         history: List<ChatMessage>,
         context: ChatContext?,
         onDelta: (String) -> Unit,
+        search: Boolean,
+        onSearch: (whl.trending.chat.model.SearchEvent) -> Unit,
     ): String {
+        if (search) {
+            onSearch(whl.trending.chat.model.SearchEvent.Started)
+            delay(600)
+            onSearch(whl.trending.chat.model.SearchEvent.Done("demo query"))
+            onSearch(whl.trending.chat.model.SearchEvent.Source("Kotlin", "https://kotlinlang.org"))
+        }
         val reply = replies[index % replies.size]
         index++
         return streamOut(reply, onDelta)

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
@@ -9,6 +9,7 @@ import whl.trending.chat.db.ThreadEntity
 import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.MessageKind
 import whl.trending.chat.model.Role
+import whl.trending.chat.model.SourceRef
 import java.io.File
 import java.util.UUID
 
@@ -70,7 +71,13 @@ class ChatStore(
     }
 
     /** assistant 仅成功终局落一次；空内容（如内容过滤拒答）不落空行 */
-    suspend fun persistAssistantMessage(threadId: Long, content: String, kind: MessageKind, model: String?) {
+    suspend fun persistAssistantMessage(
+        threadId: Long,
+        content: String,
+        kind: MessageKind,
+        model: String?,
+        sources: List<SourceRef> = emptyList(),
+    ) {
         if (content.isBlank()) return
         db.messageDao().insert(
             MessageEntity(
@@ -80,7 +87,8 @@ class ChatStore(
                 imagesJson = null,
                 kind = kind.name,
                 model = model,
-                segmentsJson = null,
+                segmentsJson = sources.takeIf { it.isNotEmpty() }
+                    ?.let { json.encodeToString(StoredSegments(sources = it.map { s -> StoredSource(s.title, s.url) })) },
                 createdAt = clock(),
             ),
         )
@@ -129,6 +137,10 @@ class ChatStore(
         images = imagesJson?.let { runCatching { json.decodeFromString<List<String>>(it) }.getOrNull() }
             ?: emptyList(),
         kind = runCatching { MessageKind.valueOf(kind) }.getOrDefault(MessageKind.CHAT),
+        sources = segmentsJson?.let { raw ->
+            runCatching { json.decodeFromString<StoredSegments>(raw) }.getOrNull()
+                ?.sources?.map { SourceRef(it.title, it.url) }
+        } ?: emptyList(),
     )
 
     private fun ChatMessage.toEntity(threadId: Long, now: Long) = MessageEntity(
@@ -141,6 +153,16 @@ class ChatStore(
         segmentsJson = null,
         createdAt = now,
     )
+
+    /**
+     * segmentsJson 信封 v1（P2）：目前只承载搜索来源；v 字段为演进留位，
+     * 反序列化 ignoreUnknownKeys 保证老版本读新数据不崩（EchoFlow 教训的版本化版）
+     */
+    @Serializable
+    private data class StoredSegments(val v: Int = 1, val sources: List<StoredSource> = emptyList())
+
+    @Serializable
+    private data class StoredSource(val title: String, val url: String)
 
     /**
      * ChatContext 的持久化镜像（shared 里的原类未标 @Serializable，此处 DTO 隔离序列化关注点）。

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatInputBar.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatInputBar.kt
@@ -26,6 +26,8 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.PhotoCamera
+import androidx.compose.material.icons.outlined.TravelExplore
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -76,6 +78,8 @@ fun ChatInputBar(
     input: String,
     canSend: Boolean,
     pendingImages: List<String>,
+    searchActive: Boolean = false,
+    onToggleSearch: () -> Unit = {},
     onInputChange: (String) -> Unit,
     onSend: () -> Unit,
     onAddImage: (String) -> Unit,
@@ -169,18 +173,11 @@ fun ChatInputBar(
                 )
             }
             Row(verticalAlignment = Alignment.CenterVertically) {
-                // 登录能力不可用的构建（如无 auth 渠道）直接隐藏图片入口
-                if (globalAuthManager.isSupported) {
+                // + 菜单常开：搜索 toggle 对匿名可用；图片两项在点击时才做登录闸
+                run {
                     Box {
                         IconButton(
-                            onClick = {
-                                if (authState !is AuthState.LoggedIn) {
-                                    showLoginDialog = true
-                                } else {
-                                    menuExpanded = true
-                                }
-                            },
-                            enabled = remaining > 0,
+                            onClick = { menuExpanded = true },
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Add,
@@ -196,11 +193,27 @@ fun ChatInputBar(
                             expanded = menuExpanded,
                             onDismissRequest = { menuExpanded = false },
                         ) {
+                            // 能力开关：联网搜索（勾选态 = 已开启；EchoFlow 的「菜单开启 + chip 回显」范式）
                             DropdownMenuItem(
+                                text = { Text(stringResource(R.string.chat_web_search)) },
+                                leadingIcon = { Icon(Icons.Outlined.TravelExplore, contentDescription = null) },
+                                trailingIcon = {
+                                    if (searchActive) Icon(Icons.Filled.Check, contentDescription = null)
+                                },
+                                onClick = {
+                                    menuExpanded = false
+                                    onToggleSearch()
+                                },
+                            )
+                            if (globalAuthManager.isSupported) DropdownMenuItem(
                                 text = { Text(stringResource(R.string.chat_attach_camera)) },
                                 leadingIcon = { Icon(Icons.Outlined.PhotoCamera, contentDescription = null) },
                                 onClick = {
                                     menuExpanded = false
+                                    if (authState !is AuthState.LoggedIn) {
+                                        showLoginDialog = true
+                                        return@DropdownMenuItem
+                                    }
                                     val target = ChatImages.newCaptureTarget(context)
                                     captureTarget = target
                                     // 极少数无相机应用的设备：launch 会抛 ActivityNotFoundException
@@ -211,11 +224,15 @@ fun ChatInputBar(
                                         }
                                 },
                             )
-                            DropdownMenuItem(
+                            if (globalAuthManager.isSupported) DropdownMenuItem(
                                 text = { Text(stringResource(R.string.chat_attach_album)) },
                                 leadingIcon = { Icon(Icons.Outlined.Image, contentDescription = null) },
                                 onClick = {
                                     menuExpanded = false
+                                    if (authState !is AuthState.LoggedIn) {
+                                        showLoginDialog = true
+                                        return@DropdownMenuItem
+                                    }
                                     albumLauncher.launch(
                                         PickVisualMediaRequest(
                                             ActivityResultContracts.PickVisualMedia.ImageOnly,

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.DrawerValue
@@ -197,6 +198,24 @@ fun ChatScreen(
                             )
                         }
                     }
+                    // 能力 chip 回显区：开启的模式可见可撤（EchoFlow「菜单开启 + chip 回显」范式）
+                    val mode by viewModel.chatMode.collectAsState()
+                    if (mode == whl.trending.chat.model.ChatMode.WebSearch) {
+                        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 2.dp)) {
+                            androidx.compose.material3.InputChip(
+                                selected = true,
+                                onClick = { viewModel.toggleWebSearch() },
+                                label = { Text(stringResource(R.string.chat_web_search)) },
+                                trailingIcon = {
+                                    Icon(
+                                        Icons.Filled.Close,
+                                        contentDescription = stringResource(R.string.chat_dialog_cancel),
+                                        modifier = Modifier.padding(0.dp),
+                                    )
+                                },
+                            )
+                        }
+                    }
                     // 常驻模型选择器（≤1 个模型时自动隐藏）
                     val models by viewModel.models.collectAsState()
                     ModelPicker(
@@ -207,6 +226,8 @@ fun ChatScreen(
                         input = state.input,
                         canSend = state.canSend,
                         pendingImages = state.pendingImages,
+                        searchActive = mode == whl.trending.chat.model.ChatMode.WebSearch,
+                        onToggleSearch = viewModel::toggleWebSearch,
                         onInputChange = viewModel::updateInput,
                         onSend = viewModel::send,
                         onAddImage = viewModel::addPendingImage,

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
@@ -298,7 +298,12 @@ private fun SourcesRow(sources: List<SourceRef>) {
     FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
         sources.forEach { source ->
             SuggestionChip(
-                onClick = { runCatching { uriHandler.openUri(source.url) } },
+                // 全局 UriHandler 已含「无浏览器 → 应用内 WebView」兜底，此处仅防极端 URL 异常；
+                // 失败留日志便于排查，不打扰用户（Sourcery 建议采纳日志、toast 评估后不做）
+                onClick = {
+                    runCatching { uriHandler.openUri(source.url) }
+                        .onFailure { android.util.Log.w("SourcesRow", "open source failed: ${'$'}{source.url}", it) }
+                },
                 label = {
                     Text(source.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 },

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
@@ -48,7 +48,17 @@ import whl.trending.chat.R
 import whl.trending.chat.markdown.MarkdownText
 import whl.trending.chat.model.ChatError
 import whl.trending.chat.model.ChatErrorCategory
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.ui.platform.LocalUriHandler
 import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.SourceRef
 import whl.trending.chat.model.Role
 
 /**
@@ -145,6 +155,19 @@ private fun AssistantMessage(message: ChatMessage, onRetry: () -> Unit, modifier
     Column(modifier = modifier.fillMaxWidth()) {
         val error = message.error
         if (error == null) {
+            // 联网搜索瞬态指示（M3 Expressive LoadingIndicator，全 app 统一）
+            @OptIn(ExperimentalMaterial3ExpressiveApi::class)
+            if (message.searching) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    LoadingIndicator(modifier = Modifier.size(24.dp))
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text = stringResource(R.string.chat_searching),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
             var viewerUrl by remember { mutableStateOf<String?>(null) }
             SelectionContainer {
                 MarkdownText(
@@ -155,6 +178,9 @@ private fun AssistantMessage(message: ChatMessage, onRetry: () -> Unit, modifier
             }
             viewerUrl?.let { url ->
                 ImageViewerDialog(model = url, onDismiss = { viewerUrl = null })
+            }
+            if (message.sources.isNotEmpty()) {
+                SourcesRow(message.sources)
             }
             Row {
                 val clipboard = LocalClipboard.current
@@ -258,6 +284,24 @@ private fun MessageItemPreview() {
                         "- 平均时间复杂度 `O(n log n)`\n- 最坏 `O(n²)`",
                 ),
                 onRetry = {},
+            )
+        }
+    }
+}
+
+
+/** 引用来源行：可点击 chip 流式排布（点击经全局 UriHandler 统一出口打开） */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun SourcesRow(sources: List<SourceRef>) {
+    val uriHandler = LocalUriHandler.current
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        sources.forEach { source ->
+            SuggestionChip(
+                onClick = { runCatching { uriHandler.openUri(source.url) } },
+                label = {
+                    Text(source.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                },
             )
         }
     }

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -69,4 +69,7 @@
     <string name="chat_thread_delete_text">该会话中的消息将被永久删除。</string>
     <string name="chat_dialog_cancel">取消</string>
     <string name="chat_dialog_confirm">确定</string>
+    <!-- P2 联网搜索 -->
+    <string name="chat_web_search">联网搜索</string>
+    <string name="chat_searching">正在搜索网络…</string>
 </resources>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -69,4 +69,7 @@
     <string name="chat_thread_delete_text">Messages in this conversation will be permanently removed.</string>
     <string name="chat_dialog_cancel">Cancel</string>
     <string name="chat_dialog_confirm">OK</string>
+    <!-- P2 联网搜索 -->
+    <string name="chat_web_search">Web search</string>
+    <string name="chat_searching">Searching the web…</string>
 </resources>

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
@@ -57,6 +57,8 @@ class ChatViewModelPersistenceTest {
             history: List<ChatMessage>,
             context: ChatContext?,
             onDelta: (String) -> Unit,
+            search: Boolean,
+            onSearch: (whl.trending.chat.model.SearchEvent) -> Unit,
         ): String {
             failWith?.let { throw ChatException(it) }
             onDelta(reply)
@@ -224,4 +226,71 @@ class ChatViewModelPersistenceTest {
         assertTrue(store.threads().first().isEmpty())
         assertTrue(v.uiState.value.messages.isEmpty())
     }
+
+    // ---- P2 web search ----
+
+    /** 带搜索事件的假引擎 */
+    private class SearchEngine(var reply: String = "答案") : ChatEngine {
+        var lastSearchFlag = false
+        override suspend fun send(
+            history: List<ChatMessage>,
+            context: ChatContext?,
+            onDelta: (String) -> Unit,
+            search: Boolean,
+            onSearch: (whl.trending.chat.model.SearchEvent) -> Unit,
+        ): String {
+            lastSearchFlag = search
+            if (search) {
+                onSearch(whl.trending.chat.model.SearchEvent.Started)
+                onSearch(whl.trending.chat.model.SearchEvent.Done("q"))
+                onSearch(whl.trending.chat.model.SearchEvent.Source("Kotlin", "https://kotlinlang.org"))
+            }
+            onDelta(reply)
+            return reply
+        }
+        override suspend fun sendDetailSummary(context: ChatContext, onDelta: (String) -> Unit) =
+            DetailSummaryResult(reply, cached = false)
+    }
+
+    @Test
+    fun `搜索模式：引擎收到 search=true，来源落到消息并随消息持久化`() = runTest(dispatcher) {
+        val engine = SearchEngine()
+        val v = vm(engine)
+        advanceUntilIdle()
+        v.toggleWebSearch()
+        v.updateInput("查一下")
+        v.send()
+        advanceUntilIdle()
+
+        assertTrue(engine.lastSearchFlag)
+        val msg = v.uiState.value.messages.last()
+        assertEquals(listOf("https://kotlinlang.org"), msg.sources.map { it.url })
+        assertEquals(false, msg.searching)
+
+        // 持久化往返：重新加载后 sources 还在（segmentsJson v1 信封）
+        val threadId = store.threads().first()[0].id
+        val loaded = store.loadMessages(threadId)
+        assertEquals(listOf("https://kotlinlang.org"), loaded.last().sources.map { it.url })
+    }
+
+    @Test
+    fun `未开搜索模式：引擎收到 search=false`() = runTest(dispatcher) {
+        val engine = SearchEngine()
+        val v = vm(engine)
+        advanceUntilIdle()
+        v.updateInput("普通问题")
+        v.send()
+        advanceUntilIdle()
+        assertEquals(false, engine.lastSearchFlag)
+    }
+
+    @Test
+    fun `toggle 两次回到 Normal（单选互斥范式）`() = runTest(dispatcher) {
+        val v = vm(SearchEngine())
+        v.toggleWebSearch()
+        assertEquals(whl.trending.chat.model.ChatMode.WebSearch, v.chatMode.value)
+        v.toggleWebSearch()
+        assertEquals(whl.trending.chat.model.ChatMode.Normal, v.chatMode.value)
+    }
+
 }

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelStreamingTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelStreamingTest.kt
@@ -56,6 +56,8 @@ class ChatViewModelStreamingTest {
             history: List<ChatMessage>,
             context: ChatContext?,
             onDelta: (String) -> Unit,
+            search: Boolean,
+            onSearch: (whl.trending.chat.model.SearchEvent) -> Unit,
         ): String {
             chatCalls++
             failWith?.let { throw ChatException(it) }

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatSseTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatSseTest.kt
@@ -44,3 +44,39 @@ class ChatSseTest {
         assertEquals(ChatSse.Event.Delta("a\nb \"c\""), event)
     }
 }
+
+// ---------------------------------------------------------------------------
+// P2 web search：服务端 sse.js 新增的搜索事件行
+// ---------------------------------------------------------------------------
+
+class ChatSseSearchTest {
+
+    @Test
+    fun `search started 行`() {
+        val e = ChatSse.parseLine("""data: {"search":{"state":"started"}}""")
+        assertEquals(ChatSse.Event.SearchStarted, e)
+    }
+
+    @Test
+    fun `search done 行带 query`() {
+        val e = ChatSse.parseLine("""data: {"search":{"state":"done","query":"kotlin 2.4"}}""")
+        assertEquals(ChatSse.Event.SearchDone("kotlin 2.4"), e)
+    }
+
+    @Test
+    fun `search done 行无 query`() {
+        val e = ChatSse.parseLine("""data: {"search":{"state":"done"}}""")
+        assertEquals(ChatSse.Event.SearchDone(null), e)
+    }
+
+    @Test
+    fun `source 行`() {
+        val e = ChatSse.parseLine("""data: {"source":{"title":"Kotlin","url":"https://kotlinlang.org"}}""")
+        assertEquals(ChatSse.Event.Source("Kotlin", "https://kotlinlang.org"), e)
+    }
+
+    @Test
+    fun `未知 search state 返回 null（向前兼容）`() {
+        assertNull(ChatSse.parseLine("""data: {"search":{"state":"future"}}"""))
+    }
+}


### PR DESCRIPTION
## 概要

Chat 改造 v2 方案 P2 客户端侧：联网搜索能力（配套后端 github-ai-trending-api#22，需其先部署，端到端才生效；旧后端对 search 字段静默忽略、自动降级普通对话）。

## 变更

- **ChatMode 框架**（EchoFlow 单选互斥范式）：`+` 菜单开启 → 输入框上方 chip 回显可撤 → 粘滞对后续消息生效；P3 加 DeepResearch 只增枚举值
- **`+` 菜单门控理顺**：菜单常开，图片两项的登录闸下移到点击时——搜索对匿名开放，原按钮级闸会挡住搜索入口
- **引擎协议**：`ChatRequest.search`（默认省略，旧服务端零感知）；ChatSse 解析 search/source 事件 → SearchEvent 回调
- **消息模型与 UI**：sources 随消息持久化（segmentsJson v1 信封首次启用，带版本字段）+ searching 瞬态；「正在搜索网络…」指示（M3 Expressive LoadingIndicator）+ 可点 SourcesRow（经全局 UriHandler 统一出口）
- FakeChatEngine 模拟搜索事件供 Demo 全链路演示

## 测试

模块 83 全绿（+8：SSE 事件解析 ×5、VM 搜索流转与持久化往返 ×3）。真机端到端验证待后端 #22 部署后补做。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7b1EyajFyydKthdYtfiCV

## Summary by Sourcery

引入一种网页搜索聊天模式，将后端的搜索事件以流式方式引入聊天体验，并将被引用的来源与消息一同持久化存储。

New Features:
- 添加 WebSearch 聊天模式，通过输入栏周围的 + 菜单和 chip UI 提供可固定、可切换的交互行为。
- 在助手消息中展示网页搜索状态，包含短暂的“searching”指示器，以及可点击的来源 chip，通过全局 URI 处理器打开链接。

Enhancements:
- 扩展聊天引擎和 API，以支持搜索标志，并从 SSE 中解析流式搜索事件，将其映射到视图模型状态。
- 在聊天存储中使用带版本的 `segmentsJson` 封装，将网页搜索来源与助手消息一起持久化，为前向兼容的演进做好准备。

Tests:
- 添加单元测试，覆盖 SSE 搜索事件解析、聊天模式切换、搜索标志向引擎的传播，以及视图模型中端到端的来源持久化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a web search chat mode that streams search events from the backend into the chat experience and persists cited sources with messages.

New Features:
- Add a WebSearch chat mode with sticky toggleable behavior via the + menu and chip UI around the input bar.
- Surface web search status in assistant messages with a transient "searching" indicator and clickable source chips that open links via the global URI handler.

Enhancements:
- Extend the chat engine and API to support a search flag and streaming search events parsed from SSE, mapping them into view model state.
- Persist web search sources alongside assistant messages using a versioned segmentsJson envelope in chat storage for forward-compatible evolution.

Tests:
- Add unit tests covering SSE search event parsing, chat mode toggling, search flag propagation to the engine, and end-to-end source persistence in the view model.

</details>