### PR TITLE
P3：Deep Research 客户端——提交/轮询/占位恢复全链路

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -2,6 +2,7 @@ package whl.trending.chat
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -92,6 +93,14 @@ class ChatViewModel(
 
     // 每线在途流（切走后后台继续）
     private val streams = mutableMapOf<Long?, Job>()
+
+    // research 轮询任务，按占位消息 id 分键——不与 streams（threadId 键）共用一张表：
+    // 两者都是从 1 起的自增序列，键空间重叠会互相顶掉 / 误取消 / 误判 isSending
+    private val researchJobs = mutableMapOf<Long, Job>()
+
+    // research 占位行：缓冲内消息 id → Room 行 id。error 消息占内存 id 但不落库，两套自增
+    // 序列会错位；Room id 直接混进缓冲会与已有消息重号（LazyColumn 按 id 作 key 时崩溃）
+    private val researchRowIds = mutableMapOf<Long, Long>()
 
     init {
         viewModelScope.launch {
@@ -202,6 +211,11 @@ class ChatViewModel(
         val passthrough = error.code == ChatError.CODE_QUOTA_DEVICE ||
             error.code == ChatError.CODE_LOGIN_REQUIRED
         if (!error.category.retryable && !passthrough) return
+        if (message.kind == MessageKind.DEEP_RESEARCH) {
+            // research 不进流式管线（launchRequest 对该 kind 直接 error()），单独路由
+            retryResearch(message)
+            return
+        }
         val threadId = _currentThreadId.value
         updateThreadMessages(threadId) { list -> list.filterNot { it.id == message.id } }
         _uiState.update { it.copy(isSending = true) }
@@ -231,8 +245,9 @@ class ChatViewModel(
 
     fun deleteThread(id: Long) {
         viewModelScope.launch {
-            // 在途流一并取消：线程行将消失，终局落库会撞外键
+            // 在途流一并取消：线程行将消失，终局落库会撞外键；research 轮询同理
             streams.remove(id)?.cancel()
+            messagesByThread[id]?.forEach { researchJobs.remove(it.id)?.cancel() }
             messagesByThread.remove(id)
             store?.deleteThread(id)
             if (_currentThreadId.value == id) startNewThread()
@@ -292,8 +307,12 @@ class ChatViewModel(
             val result = runCatching {
                 when (kind) {
                     MessageKind.CHAT -> {
+                        // 空 assistant 行（research 占位 / 错误条）不进 history：对模型无信息量，
+                        // 且上游可能拒空 content
                         val history = (messagesByThread[threadId] ?: emptyList())
-                            .filterNot { it.id == placeholderId }
+                            .filterNot {
+                                it.id == placeholderId || (it.role == Role.ASSISTANT && it.content.isBlank())
+                            }
                         val useSearch = _chatMode.value == ChatMode.WebSearch
                         engine.send(
                             history,
@@ -354,39 +373,78 @@ class ChatViewModel(
         viewModelScope.launch {
             val threadId = ensureThreadForSend(topic)
             appendAndPersistUser(threadId, ChatMessage(nextId(), Role.USER, topic, kind = MessageKind.DEEP_RESEARCH))
-            val runId = try {
-                engine.createResearch(topic)
-            } catch (e: ChatException) {
-                trackFailure(MessageKind.DEEP_RESEARCH, e.error)
-                updateThreadMessages(threadId) {
-                    it + ChatMessage(nextId(), Role.ASSISTANT, "", error = e.error, kind = MessageKind.DEEP_RESEARCH)
-                }
-                if (threadId == _currentThreadId.value) _uiState.update { it.copy(isSending = false) }
-                return@launch
-            }
-            // 占位行即恢复载体：提交成功立即落库（store 缺席时用内存 id）
-            val messageId = if (store != null && threadId != null) {
-                store.persistResearchPlaceholder(threadId, runId).also { idSeq = maxOf(idSeq, it) }
-            } else nextId()
-            updateThreadMessages(threadId) {
-                it + ChatMessage(messageId, Role.ASSISTANT, "", kind = MessageKind.DEEP_RESEARCH, searching = true, researchRunId = runId)
-            }
-            launchResearchPolling(threadId, messageId, runId)
+            startResearch(threadId, topic)
         }
     }
 
-    /** 轮询任务（约 8s 间隔）；running 达上限静默停轮，占位行保留 → 下次打开会话续轮 */
+    /** 提交 research 任务并启动轮询；提交失败挂错误条（重试经 [retryResearch] 重新提交） */
+    private suspend fun startResearch(threadId: Long?, topic: String) {
+        val runId = try {
+            engine.createResearch(topic)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // 不只 catch ChatException：Demo/预览引擎的默认实现抛 UnsupportedOperationException，逃逸即崩
+            val error = (e as? ChatException)?.error
+                ?: ChatError(ChatErrorCategory.UNKNOWN, detail = e.toString())
+            trackFailure(MessageKind.DEEP_RESEARCH, error)
+            updateThreadMessages(threadId) {
+                it + ChatMessage(nextId(), Role.ASSISTANT, "", error = error, kind = MessageKind.DEEP_RESEARCH)
+            }
+            if (threadId == _currentThreadId.value) _uiState.update { it.copy(isSending = false) }
+            return
+        }
+        // 占位行即恢复载体：提交成功立即落库。缓冲内一律用内存 id，Room 行 id 另记映射
+        // 供终局写库（见 researchRowIds 的重号说明）
+        val messageId = nextId()
+        if (store != null && threadId != null) {
+            researchRowIds[messageId] = store.persistResearchPlaceholder(threadId, runId)
+        }
+        updateThreadMessages(threadId) {
+            it + ChatMessage(messageId, Role.ASSISTANT, "", kind = MessageKind.DEEP_RESEARCH, searching = true, researchRunId = runId)
+        }
+        launchResearchPolling(threadId, messageId, runId)
+    }
+
+    /** research 错误条的重试：任务已在服务端存在则恢复轮询同一 runId（绝不重复建任务——
+     *  会重复扣费）；任务未建立（提交失败 / 已判死删行）则取相邻提问重新提交 */
+    private fun retryResearch(message: ChatMessage) {
+        val threadId = _currentThreadId.value
+        val runId = message.researchRunId
+        if (runId != null) {
+            updateThreadMessages(threadId) { list ->
+                list.map { if (it.id == message.id) it.copy(error = null, searching = true) else it }
+            }
+            _uiState.update { it.copy(isSending = true) }
+            launchResearchPolling(threadId, message.id, runId)
+            return
+        }
+        val messages = messagesByThread[threadId] ?: emptyList()
+        val index = messages.indexOfFirst { it.id == message.id }
+        val topic = messages.take(index.coerceAtLeast(0))
+            .lastOrNull { it.role == Role.USER && it.kind == MessageKind.DEEP_RESEARCH }
+            ?.content ?: return
+        updateThreadMessages(threadId) { list -> list.filterNot { it.id == message.id } }
+        _uiState.update { it.copy(isSending = true) }
+        viewModelScope.launch { startResearch(threadId, topic) }
+    }
+
+    /**
+     * 轮询任务：快轮 8s 覆盖正常时长，转慢轮 60s 直到盖过服务端 2h 超龄判死闸——服务端
+     * 保证死任务终会转 failed，客户端跟到那个终态为止，不留「静默停轮永远转圈」的僵尸态。
+     * 绝对上限仍无终态（异常情况）→ 呈现可重试错误，runId 保留（重试恢复轮询，不重复扣费）。
+     */
     private fun launchResearchPolling(threadId: Long?, messageId: Long, runId: String) {
-        if (streams[messageId]?.isActive == true) return
+        if (researchJobs[messageId]?.isActive == true) return
         val job = viewModelScope.launch {
-            repeat(MAX_RESEARCH_POLLS) {
-                delay(RESEARCH_POLL_MS)
+            repeat(MAX_RESEARCH_POLLS + MAX_RESEARCH_SLOW_POLLS) { attempt ->
+                delay(if (attempt < MAX_RESEARCH_POLLS) RESEARCH_POLL_MS else RESEARCH_SLOW_POLL_MS)
                 val run = try {
                     engine.pollResearch(runId)
                 } catch (e: ChatException) {
                     // 瞬态（网络/超时/5xx）继续轮；永久错误（鉴权/配额/非法请求）终局呈现——
                     // 否则用户只看到转圈直到静默停轮（Sourcery 审查确认的 bug）。
-                    // 占位行不删：任务可能仍在服务端跑完，重登后重开会话可恢复
+                    // 占位行不删：任务可能仍在服务端跑完，重登后重试/重开会话可恢复
                     if (e.error.category.retryable) return@repeat
                     trackFailure(MessageKind.DEEP_RESEARCH, e.error)
                     updateThreadMessages(threadId) { list ->
@@ -398,18 +456,29 @@ class ChatViewModel(
                 when (run.status) {
                     "completed" -> {
                         val report = run.report.orEmpty()
-                        if (store != null && threadId != null) {
-                            store.completeResearchMessage(threadId, messageId, report, runId)
+                        if (report.isBlank()) {
+                            // 空报告视同失败（服务端已按失败退款）：直接写回空串会留下一个
+                            // 永远满足恢复哨兵的空占位——每次开会话闪一次、清不掉
+                            store?.deleteMessage(researchRowId(messageId))
+                            val error = ChatError(ChatErrorCategory.SERVER, detail = "empty report")
+                            track("research_fail", mapOf("reason" to "empty_report"))
+                            updateThreadMessages(threadId) { list ->
+                                list.map { if (it.id == messageId) it.copy(searching = false, error = error, researchRunId = null) else it }
+                            }
+                        } else {
+                            if (store != null && threadId != null) {
+                                store.completeResearchMessage(threadId, researchRowId(messageId), report, runId)
+                            }
+                            updateThreadMessages(threadId) { list ->
+                                list.map { if (it.id == messageId) it.copy(content = report, searching = false) else it }
+                            }
+                            track("research_done", emptyMap())
                         }
-                        updateThreadMessages(threadId) { list ->
-                            list.map { if (it.id == messageId) it.copy(content = report, searching = false) else it }
-                        }
-                        track("research_done", emptyMap())
                         finishResearch(threadId, messageId)
                         return@launch
                     }
                     "failed" -> {
-                        store?.deleteMessage(messageId)
+                        store?.deleteMessage(researchRowId(messageId))
                         val error = ChatError(ChatErrorCategory.SERVER, detail = run.error ?: "research failed")
                         track("research_fail", mapOf("reason" to (run.error ?: "unknown")))
                         updateThreadMessages(threadId) { list ->
@@ -421,13 +490,23 @@ class ChatViewModel(
                     else -> Unit // running：继续
                 }
             }
-            finishResearch(threadId, messageId) // 达上限：停轮不判死，恢复机制兜底
+            // 绝对上限：已超过服务端判死闸仍无终态，属异常。呈现可重试错误（runId 保留 →
+            // 重试恢复轮询同一任务；库中占位行保留 → 跨进程仍可恢复），不再无限转圈
+            val error = ChatError(ChatErrorCategory.TIMEOUT, detail = "research polling exhausted")
+            trackFailure(MessageKind.DEEP_RESEARCH, error)
+            updateThreadMessages(threadId) { list ->
+                list.map { if (it.id == messageId) it.copy(searching = false, error = error) else it }
+            }
+            finishResearch(threadId, messageId)
         }
-        streams[messageId] = job
+        researchJobs[messageId] = job
     }
 
+    /** 占位行的 Room 行 id：同会话建的走映射，重启后从库载入的消息 id 本身就是行 id */
+    private fun researchRowId(messageId: Long): Long = researchRowIds[messageId] ?: messageId
+
     private fun finishResearch(threadId: Long?, messageId: Long) {
-        streams.remove(messageId)
+        researchJobs.remove(messageId)
         if (threadId == _currentThreadId.value) _uiState.update { it.copy(isSending = false) }
     }
 
@@ -473,6 +552,10 @@ class ChatViewModel(
     }
 
     private fun trackFailure(kind: MessageKind, error: ChatError) {
+        // research 失败漏斗：提交失败 / 轮询永久错误 / 轮询耗尽都计数（status=failed 在轮询处单独上报）
+        if (kind == MessageKind.DEEP_RESEARCH) {
+            track("research_fail", mapOf("reason" to (error.code ?: error.category.name.lowercase())))
+        }
         when {
             // 付费意愿漏斗第一级：个人配额触顶（在 VM 记一次，避免 UI 重组重复上报）
             error.code == ChatError.CODE_QUOTA_DEVICE -> {
@@ -490,8 +573,11 @@ class ChatViewModel(
         /** 单条消息图片数上限，与服务端及 [whl.trending.chat.engine.ChatWire] 对齐 */
         const val MAX_IMAGES_PER_MESSAGE = 4
 
-        /** research 轮询间隔与上限：8s × 90 ≈ 12 分钟；达上限停轮不判死（恢复机制兜底续轮） */
+        /** research 轮询节奏：快轮 8s×90（≈12 分钟）覆盖正常任务时长，慢轮 60s×110（≈110 分钟）
+         *  盖过服务端 2h 超龄判死闸——每个任务都能等到服务端终态，不留僵尸占位 */
         private const val RESEARCH_POLL_MS = 8_000L
         private const val MAX_RESEARCH_POLLS = 90
+        private const val RESEARCH_SLOW_POLL_MS = 60_000L
+        private const val MAX_RESEARCH_SLOW_POLLS = 110
     }
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import whl.trending.ai.chat.ChatContext
 import whl.trending.ai.core.platform.trackEvent
@@ -26,6 +27,7 @@ import whl.trending.chat.model.ChatMode
 import whl.trending.chat.model.ChatUiState
 import whl.trending.chat.model.MessageKind
 import whl.trending.chat.model.Role
+import whl.trending.chat.model.ResearchRun
 import whl.trending.chat.model.SearchEvent
 import whl.trending.chat.model.SourceRef
 import whl.trending.chat.store.ChatStore
@@ -75,8 +77,11 @@ class ChatViewModel(
     val chatMode: StateFlow<ChatMode> = _chatMode.asStateFlow()
 
     /** EchoFlow 单选互斥范式：再点同项回 Normal，点别项自动顶掉 */
-    fun toggleWebSearch() {
-        _chatMode.value = if (_chatMode.value == ChatMode.WebSearch) ChatMode.Normal else ChatMode.WebSearch
+    fun toggleWebSearch() = toggleMode(ChatMode.WebSearch)
+    fun toggleDeepResearch() = toggleMode(ChatMode.DeepResearch)
+
+    private fun toggleMode(mode: ChatMode) {
+        _chatMode.value = if (_chatMode.value == mode) ChatMode.Normal else mode
     }
 
     /** 当前会话的 ChatContext（解读 chip / 服务端 context 注入）；随切换/恢复而变 */
@@ -166,6 +171,10 @@ class ChatViewModel(
 
     private fun sendMessage(text: String, images: List<String>) {
         if (_uiState.value.isSending || (text.isBlank() && images.isEmpty())) return
+        if (_chatMode.value == ChatMode.DeepResearch) {
+            sendResearch(text)
+            return
+        }
         if (images.isNotEmpty()) {
             track("chat_send_with_images", mapOf("image_count" to images.size.toString()))
         }
@@ -237,6 +246,7 @@ class ChatViewModel(
                 pendingImages = emptyList(),
             )
         }
+        resumeResearchIfAny(id, messages)
     }
 
     /** 首条消息才建线（懒建）；当前线已存在则直接复用。内存模式恒为 null 键。 */
@@ -292,6 +302,7 @@ class ChatViewModel(
                         if (detail.cached) track("detail_summary_cache_hit", mapOf("from" to "chat"))
                         detail.content
                     }
+                    MessageKind.DEEP_RESEARCH -> error("research 走 launchResearch，不进流式管线")
                 }
             }
             result.fold(
@@ -325,6 +336,93 @@ class ChatViewModel(
             }
         }
         streams[threadId] = job
+    }
+
+    // ---- Deep Research（P3）----
+
+    private fun sendResearch(topic: String) {
+        track("research_start", mapOf("from" to "chat"))
+        _uiState.update { it.copy(isSending = true) }
+        viewModelScope.launch {
+            val threadId = ensureThreadForSend(topic)
+            appendAndPersistUser(threadId, ChatMessage(nextId(), Role.USER, topic, kind = MessageKind.DEEP_RESEARCH))
+            val runId = try {
+                engine.createResearch(topic)
+            } catch (e: ChatException) {
+                trackFailure(MessageKind.DEEP_RESEARCH, e.error)
+                updateThreadMessages(threadId) {
+                    it + ChatMessage(nextId(), Role.ASSISTANT, "", error = e.error, kind = MessageKind.DEEP_RESEARCH)
+                }
+                if (threadId == _currentThreadId.value) _uiState.update { it.copy(isSending = false) }
+                return@launch
+            }
+            // 占位行即恢复载体：提交成功立即落库（store 缺席时用内存 id）
+            val messageId = if (store != null && threadId != null) {
+                store.persistResearchPlaceholder(threadId, runId).also { idSeq = maxOf(idSeq, it) }
+            } else nextId()
+            updateThreadMessages(threadId) {
+                it + ChatMessage(messageId, Role.ASSISTANT, "", kind = MessageKind.DEEP_RESEARCH, searching = true, researchRunId = runId)
+            }
+            launchResearchPolling(threadId, messageId, runId)
+        }
+    }
+
+    /** 轮询任务（约 8s 间隔）；running 达上限静默停轮，占位行保留 → 下次打开会话续轮 */
+    private fun launchResearchPolling(threadId: Long?, messageId: Long, runId: String) {
+        if (streams[messageId]?.isActive == true) return
+        val job = viewModelScope.launch {
+            repeat(MAX_RESEARCH_POLLS) {
+                delay(RESEARCH_POLL_MS)
+                val run = try {
+                    engine.pollResearch(runId)
+                } catch (e: ChatException) {
+                    return@repeat // 瞬态失败：下轮再试
+                }
+                when (run.status) {
+                    "completed" -> {
+                        val report = run.report.orEmpty()
+                        if (store != null && threadId != null) {
+                            store.completeResearchMessage(threadId, messageId, report, runId)
+                        }
+                        updateThreadMessages(threadId) { list ->
+                            list.map { if (it.id == messageId) it.copy(content = report, searching = false) else it }
+                        }
+                        track("research_done", emptyMap())
+                        finishResearch(threadId, messageId)
+                        return@launch
+                    }
+                    "failed" -> {
+                        store?.deleteMessage(messageId)
+                        val error = ChatError(ChatErrorCategory.SERVER, detail = run.error ?: "research failed")
+                        track("research_fail", mapOf("reason" to (run.error ?: "unknown")))
+                        updateThreadMessages(threadId) { list ->
+                            list.map { if (it.id == messageId) it.copy(searching = false, error = error, researchRunId = null) else it }
+                        }
+                        finishResearch(threadId, messageId)
+                        return@launch
+                    }
+                    else -> Unit // running：继续
+                }
+            }
+            finishResearch(threadId, messageId) // 达上限：停轮不判死，恢复机制兜底
+        }
+        streams[messageId] = job
+    }
+
+    private fun finishResearch(threadId: Long?, messageId: Long) {
+        streams.remove(messageId)
+        if (threadId == _currentThreadId.value) _uiState.update { it.copy(isSending = false) }
+    }
+
+    /** 恢复：打开会话时发现「空内容 + runId」的 research 占位 → 续轮询 */
+    private fun resumeResearchIfAny(threadId: Long?, messages: List<ChatMessage>) {
+        messages.filter { it.kind == MessageKind.DEEP_RESEARCH && it.content.isBlank() && it.researchRunId != null && it.error == null }
+            .forEach { placeholder ->
+                updateThreadMessages(threadId) { list ->
+                    list.map { if (it.id == placeholder.id) it.copy(searching = true) else it }
+                }
+                launchResearchPolling(threadId, placeholder.id, placeholder.researchRunId!!)
+            }
     }
 
     /** 搜索事件落到占位消息：searching 瞬态 + sources 累积（服务端已按 url 去重，客户端再防御一层） */
@@ -374,5 +472,9 @@ class ChatViewModel(
     companion object {
         /** 单条消息图片数上限，与服务端及 [whl.trending.chat.engine.ChatWire] 对齐 */
         const val MAX_IMAGES_PER_MESSAGE = 4
+
+        /** research 轮询间隔与上限：8s × 90 ≈ 12 分钟；达上限停轮不判死（恢复机制兜底续轮） */
+        private const val RESEARCH_POLL_MS = 8_000L
+        private const val MAX_RESEARCH_POLLS = 90
     }
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -144,6 +144,14 @@ class ChatViewModel(
         val state = _uiState.value
         if (!state.canSend) return
         val text = state.input.trim()
+        // research 仅支持文本：不消费待发图片（保留在输入区，用户可换模式再发或移除），
+        // 避免静默丢弃（Sourcery 审查建议）
+        if (_chatMode.value == ChatMode.DeepResearch) {
+            if (text.isBlank()) return
+            _uiState.update { it.copy(input = "") }
+            sendResearch(text)
+            return
+        }
         val images = state.pendingImages
         _uiState.update { it.copy(input = "", pendingImages = emptyList()) }
         sendMessage(text, images)
@@ -376,7 +384,16 @@ class ChatViewModel(
                 val run = try {
                     engine.pollResearch(runId)
                 } catch (e: ChatException) {
-                    return@repeat // 瞬态失败：下轮再试
+                    // 瞬态（网络/超时/5xx）继续轮；永久错误（鉴权/配额/非法请求）终局呈现——
+                    // 否则用户只看到转圈直到静默停轮（Sourcery 审查确认的 bug）。
+                    // 占位行不删：任务可能仍在服务端跑完，重登后重开会话可恢复
+                    if (e.error.category.retryable) return@repeat
+                    trackFailure(MessageKind.DEEP_RESEARCH, e.error)
+                    updateThreadMessages(threadId) { list ->
+                        list.map { if (it.id == messageId) it.copy(searching = false, error = e.error) else it }
+                    }
+                    finishResearch(threadId, messageId)
+                    return@launch
                 }
                 when (run.status) {
                     "completed" -> {

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/db/ChatDatabase.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/db/ChatDatabase.kt
@@ -102,6 +102,13 @@ interface MessageDao {
     /** 删线程前收集待删的图片文件路径（行删除交给 CASCADE） */
     @Query("SELECT imagesJson FROM chat_messages WHERE threadId = :threadId AND imagesJson IS NOT NULL")
     suspend fun imagesJsonFor(threadId: Long): List<String>
+
+    /** research 占位 → 终局报告（P3：占位行是跨进程恢复轮询的载体） */
+    @Query("UPDATE chat_messages SET content = :content, segmentsJson = :segmentsJson WHERE id = :id")
+    suspend fun updateContent(id: Long, content: String, segmentsJson: String?)
+
+    @Query("DELETE FROM chat_messages WHERE id = :id")
+    suspend fun deleteById(id: Long)
 }
 
 @Database(entities = [ThreadEntity::class, MessageEntity::class], version = 1, exportSchema = true)

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -196,7 +196,7 @@ class ChatApi(
     }
 
     override suspend fun pollResearch(id: String): whl.trending.chat.model.ResearchRun {
-        val r = researchJson(HttpMethod.Get, "research/${'$'}id") {}
+        val r = researchJson(HttpMethod.Get, "research/$id") {}
         return whl.trending.chat.model.ResearchRun(r.id, r.status, r.report, r.error)
     }
 
@@ -208,10 +208,10 @@ class ChatApi(
     ): ResearchRunResponse {
         try {
             val sentAsLoggedIn = globalAuthManager.authState.value is AuthState.LoggedIn
-            val response = client.request("${'$'}baseUrl/${'$'}path") {
+            val response = client.request("$baseUrl/$path") {
                 this.method = method
                 header("X-Install-Id", globalSettingsManager.getOrCreateInstallId())
-                globalAuthManager.getAccessToken()?.let { header("Authorization", "Bearer ${'$'}it") }
+                globalAuthManager.getAccessToken()?.let { header("Authorization", "Bearer $it") }
                 timeout { requestTimeoutMillis = 30_000 }
                 configure()
             }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -7,6 +7,8 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.timeout
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
+import io.ktor.client.request.request
+import io.ktor.http.HttpMethod
 import io.ktor.client.request.preparePost
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
@@ -99,6 +101,17 @@ class ChatApi(
     private data class ChatResponse(val content: String)
 
     @Serializable
+    private data class ResearchCreateRequest(val topic: String, val lang: String)
+
+    @Serializable
+    private data class ResearchRunResponse(
+        val id: String,
+        val status: String,
+        val report: String? = null,
+        val error: String? = null,
+    )
+
+    @Serializable
     private data class ErrorResponse(
         val error: String? = null,
         val code: String? = null,
@@ -171,6 +184,50 @@ class ChatApi(
         val lang = resolveLang()
         return executeStreaming(path = "detail-summary", onDelta = onDelta) {
             setBody(DetailSummaryRequest(source = source, externalId = externalId, lang = lang))
+        }
+    }
+
+    override suspend fun createResearch(topic: String): String {
+        val lang = resolveLang()
+        return researchJson(HttpMethod.Post, "research") {
+            contentType(ContentType.Application.Json)
+            setBody(ResearchCreateRequest(topic = topic, lang = lang))
+        }.id
+    }
+
+    override suspend fun pollResearch(id: String): whl.trending.chat.model.ResearchRun {
+        val r = researchJson(HttpMethod.Get, "research/${'$'}id") {}
+        return whl.trending.chat.model.ResearchRun(r.id, r.status, r.report, r.error)
+    }
+
+    /** research 的非流式 JSON 路径：错误分类与流式路径同一套（含 login_required/quota 语义） */
+    private suspend fun researchJson(
+        method: HttpMethod,
+        path: String,
+        configure: HttpRequestBuilder.() -> Unit,
+    ): ResearchRunResponse {
+        try {
+            val sentAsLoggedIn = globalAuthManager.authState.value is AuthState.LoggedIn
+            val response = client.request("${'$'}baseUrl/${'$'}path") {
+                this.method = method
+                header("X-Install-Id", globalSettingsManager.getOrCreateInstallId())
+                globalAuthManager.getAccessToken()?.let { header("Authorization", "Bearer ${'$'}it") }
+                timeout { requestTimeoutMillis = 30_000 }
+                configure()
+            }
+            if (response.status != HttpStatusCode.OK) {
+                throw toChatException(response, sentAsLoggedIn)
+            }
+            return json.decodeFromString<ResearchRunResponse>(response.bodyAsText())
+        } catch (e: ChatException) {
+            logFailure(path, e.error)
+            throw e
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            val error = ChatErrors.forThrowable(e)
+            logFailure(path, error)
+            throw ChatException(error)
         }
     }
 

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatEngine.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatEngine.kt
@@ -40,4 +40,12 @@ interface ChatEngine {
         context: ChatContext,
         onDelta: (String) -> Unit = {},
     ): DetailSummaryResult
+
+    /** 提交 Deep Research（POST /api/research）→ 服务端 run id；403 login_required 为登录闸 */
+    suspend fun createResearch(topic: String): String =
+        throw UnsupportedOperationException("research not supported by this engine")
+
+    /** 轮询任务状态（GET /api/research/{id}） */
+    suspend fun pollResearch(id: String): whl.trending.chat.model.ResearchRun =
+        throw UnsupportedOperationException("research not supported by this engine")
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatMessage.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/ChatMessage.kt
@@ -8,7 +8,7 @@ enum class Role { USER, ASSISTANT }
  * 若未来新增 kind 需要消息级再生成参数或差异化渲染，届时再升级为 sealed interface——
  * 会话仅内存存储，重构无兼容成本。
  */
-enum class MessageKind { CHAT, DETAIL_SUMMARY }
+enum class MessageKind { CHAT, DETAIL_SUMMARY, DEEP_RESEARCH }
 
 /**
  * 一条聊天消息。
@@ -30,4 +30,6 @@ data class ChatMessage(
     val kind: MessageKind = MessageKind.CHAT,
     val sources: List<SourceRef> = emptyList(),
     val searching: Boolean = false,
+    /** Deep Research 任务 id（随占位消息持久化——冷启动恢复轮询的载体） */
+    val researchRunId: String? = null,
 )

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/SearchModels.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/model/SearchModels.kt
@@ -7,7 +7,11 @@ package whl.trending.chat.model
 sealed interface ChatMode {
     data object Normal : ChatMode
     data object WebSearch : ChatMode
+    data object DeepResearch : ChatMode
 }
+
+/** Deep Research 任务状态（引擎轮询返回） */
+data class ResearchRun(val id: String, val status: String, val report: String?, val error: String?)
 
 /** 引用来源（服务端按 url 去重后下发；随 assistant 消息持久化） */
 data class SourceRef(val title: String, val url: String)

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
@@ -159,21 +159,22 @@ class ChatStore(
     private fun titleFrom(text: String): String =
         text.trim().take(MAX_TITLE_LENGTH).ifBlank { DEFAULT_TITLE }
 
-    private fun MessageEntity.toModel() = ChatMessage(
-        id = id,
-        role = if (role == ROLE_USER) Role.USER else Role.ASSISTANT,
-        content = content,
-        images = imagesJson?.let { runCatching { json.decodeFromString<List<String>>(it) }.getOrNull() }
-            ?: emptyList(),
-        kind = runCatching { MessageKind.valueOf(kind) }.getOrDefault(MessageKind.CHAT),
-        sources = segmentsJson?.let { raw ->
+    private fun MessageEntity.toModel(): ChatMessage {
+        // segments 信封热路径只解码一次（Sourcery 建议）
+        val segments = segmentsJson?.let { raw ->
             runCatching { json.decodeFromString<StoredSegments>(raw) }.getOrNull()
-                ?.sources?.map { SourceRef(it.title, it.url) }
-        } ?: emptyList(),
-        researchRunId = segmentsJson?.let { raw ->
-            runCatching { json.decodeFromString<StoredSegments>(raw) }.getOrNull()?.researchRunId
-        },
-    )
+        }
+        return ChatMessage(
+            id = id,
+            role = if (role == ROLE_USER) Role.USER else Role.ASSISTANT,
+            content = content,
+            images = imagesJson?.let { runCatching { json.decodeFromString<List<String>>(it) }.getOrNull() }
+                ?: emptyList(),
+            kind = runCatching { MessageKind.valueOf(kind) }.getOrDefault(MessageKind.CHAT),
+            sources = segments?.sources?.map { SourceRef(it.title, it.url) } ?: emptyList(),
+            researchRunId = segments?.researchRunId,
+        )
+    }
 
     private fun ChatMessage.toEntity(threadId: Long, now: Long) = MessageEntity(
         threadId = threadId,

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
@@ -98,6 +98,35 @@ class ChatStore(
     suspend fun loadMessages(threadId: Long): List<ChatMessage> =
         db.messageDao().messagesFor(threadId).map { it.toModel() }
 
+    /**
+     * Deep Research 占位行：提交成功即落库（content 空 + runId），是跨进程恢复轮询的
+     * 载体——进程死亡后重进，「空内容 + runId」的行触发续轮询，5 credits 不白花。
+     */
+    suspend fun persistResearchPlaceholder(threadId: Long, runId: String): Long {
+        val id = db.messageDao().insert(
+            MessageEntity(
+                threadId = threadId, role = ROLE_ASSISTANT, content = "",
+                imagesJson = null, kind = MessageKind.DEEP_RESEARCH.name, model = null,
+                segmentsJson = json.encodeToString(StoredSegments(researchRunId = runId)),
+                createdAt = clock(),
+            ),
+        )
+        db.threadDao().touch(threadId, clock())
+        return id
+    }
+
+    /** research 终局：占位行升级为报告全文（保留 runId 供追溯） */
+    suspend fun completeResearchMessage(threadId: Long, messageId: Long, report: String, runId: String) {
+        db.messageDao().updateContent(
+            messageId, report,
+            json.encodeToString(StoredSegments(researchRunId = runId)),
+        )
+        db.threadDao().touch(threadId, clock())
+    }
+
+    /** research 失败：删占位行（服务端已退款；留着会让重启误续轮询死任务） */
+    suspend fun deleteMessage(messageId: Long) = db.messageDao().deleteById(messageId)
+
     suspend fun renameThread(threadId: Long, title: String) =
         db.threadDao().rename(threadId, title.trim().take(MAX_TITLE_LENGTH))
 
@@ -141,6 +170,9 @@ class ChatStore(
             runCatching { json.decodeFromString<StoredSegments>(raw) }.getOrNull()
                 ?.sources?.map { SourceRef(it.title, it.url) }
         } ?: emptyList(),
+        researchRunId = segmentsJson?.let { raw ->
+            runCatching { json.decodeFromString<StoredSegments>(raw) }.getOrNull()?.researchRunId
+        },
     )
 
     private fun ChatMessage.toEntity(threadId: Long, now: Long) = MessageEntity(
@@ -159,7 +191,7 @@ class ChatStore(
      * 反序列化 ignoreUnknownKeys 保证老版本读新数据不崩（EchoFlow 教训的版本化版）
      */
     @Serializable
-    private data class StoredSegments(val v: Int = 1, val sources: List<StoredSource> = emptyList())
+    private data class StoredSegments(val v: Int = 1, val sources: List<StoredSource> = emptyList(), val researchRunId: String? = null)
 
     @Serializable
     private data class StoredSource(val title: String, val url: String)

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatInputBar.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatInputBar.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.PhotoCamera
+import androidx.compose.material.icons.outlined.Science
 import androidx.compose.material.icons.outlined.TravelExplore
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.AlertDialog
@@ -79,7 +80,9 @@ fun ChatInputBar(
     canSend: Boolean,
     pendingImages: List<String>,
     searchActive: Boolean = false,
+    researchActive: Boolean = false,
     onToggleSearch: () -> Unit = {},
+    onToggleResearch: () -> Unit = {},
     onInputChange: (String) -> Unit,
     onSend: () -> Unit,
     onAddImage: (String) -> Unit,
@@ -203,6 +206,17 @@ fun ChatInputBar(
                                 onClick = {
                                     menuExpanded = false
                                     onToggleSearch()
+                                },
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.chat_deep_research)) },
+                                leadingIcon = { Icon(Icons.Outlined.Science, contentDescription = null) },
+                                trailingIcon = {
+                                    if (researchActive) Icon(Icons.Filled.Check, contentDescription = null)
+                                },
+                                onClick = {
+                                    menuExpanded = false
+                                    onToggleResearch()
                                 },
                             )
                             if (globalAuthManager.isSupported) DropdownMenuItem(

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -200,12 +200,17 @@ fun ChatScreen(
                     }
                     // 能力 chip 回显区：开启的模式可见可撤（EchoFlow「菜单开启 + chip 回显」范式）
                     val mode by viewModel.chatMode.collectAsState()
-                    if (mode == whl.trending.chat.model.ChatMode.WebSearch) {
+                    if (mode != whl.trending.chat.model.ChatMode.Normal) {
+                        val isResearch = mode == whl.trending.chat.model.ChatMode.DeepResearch
                         Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 2.dp)) {
                             androidx.compose.material3.InputChip(
                                 selected = true,
-                                onClick = { viewModel.toggleWebSearch() },
-                                label = { Text(stringResource(R.string.chat_web_search)) },
+                                onClick = {
+                                    if (isResearch) viewModel.toggleDeepResearch() else viewModel.toggleWebSearch()
+                                },
+                                label = {
+                                    Text(stringResource(if (isResearch) R.string.chat_deep_research else R.string.chat_web_search))
+                                },
                                 trailingIcon = {
                                     Icon(
                                         Icons.Filled.Close,
@@ -227,7 +232,9 @@ fun ChatScreen(
                         canSend = state.canSend,
                         pendingImages = state.pendingImages,
                         searchActive = mode == whl.trending.chat.model.ChatMode.WebSearch,
+                        researchActive = mode == whl.trending.chat.model.ChatMode.DeepResearch,
                         onToggleSearch = viewModel::toggleWebSearch,
+                        onToggleResearch = viewModel::toggleDeepResearch,
                         onInputChange = viewModel::updateInput,
                         onSend = viewModel::send,
                         onAddImage = viewModel::addPendingImage,

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -229,7 +229,9 @@ fun ChatScreen(
                     )
                     ChatInputBar(
                         input = state.input,
-                        canSend = state.canSend,
+                        // research 仅支持文本：只有图片没文字时发送会被 VM 忽略，按钮同步禁用（不静默）
+                        canSend = state.canSend &&
+                            (mode != whl.trending.chat.model.ChatMode.DeepResearch || state.input.isNotBlank()),
                         pendingImages = state.pendingImages,
                         searchActive = mode == whl.trending.chat.model.ChatMode.WebSearch,
                         researchActive = mode == whl.trending.chat.model.ChatMode.DeepResearch,

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
@@ -162,7 +162,10 @@ private fun AssistantMessage(message: ChatMessage, onRetry: () -> Unit, modifier
                     LoadingIndicator(modifier = Modifier.size(24.dp))
                     Spacer(Modifier.width(6.dp))
                     Text(
-                        text = stringResource(R.string.chat_searching),
+                        text = stringResource(
+                            if (message.kind == whl.trending.chat.model.MessageKind.DEEP_RESEARCH) R.string.chat_researching
+                            else R.string.chat_searching,
+                        ),
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -72,4 +72,6 @@
     <!-- P2 联网搜索 -->
     <string name="chat_web_search">联网搜索</string>
     <string name="chat_searching">正在搜索网络…</string>
+    <string name="chat_deep_research">深入研究</string>
+    <string name="chat_researching">深入研究中，约需几分钟…</string>
 </resources>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -72,4 +72,6 @@
     <!-- P2 联网搜索 -->
     <string name="chat_web_search">Web search</string>
     <string name="chat_searching">Searching the web…</string>
+    <string name="chat_deep_research">Deep research</string>
+    <string name="chat_researching">Deep research in progress… this may take a few minutes</string>
 </resources>

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
@@ -296,16 +296,22 @@ class ChatViewModelPersistenceTest {
 
     // ---- P3 Deep Research ----
 
-    /** research 假引擎：脚本化状态序列 */
+    /** research 假引擎：脚本化状态序列 + 可编程失败 + history 捕获 */
     private class ResearchEngine(
         var statuses: MutableList<whl.trending.chat.model.ResearchRun> = mutableListOf(),
         var failCreate: ChatError? = null,
+        var failPoll: ChatError? = null,
     ) : ChatEngine {
         var created = 0
+        var polled = 0
+        var lastHistory: List<ChatMessage>? = null
         override suspend fun send(
             history: List<ChatMessage>, context: ChatContext?, onDelta: (String) -> Unit,
             search: Boolean, onSearch: (whl.trending.chat.model.SearchEvent) -> Unit,
-        ): String = "n/a"
+        ): String {
+            lastHistory = history
+            return "n/a"
+        }
         override suspend fun sendDetailSummary(context: ChatContext, onDelta: (String) -> Unit) =
             DetailSummaryResult("n/a", cached = false)
         override suspend fun createResearch(topic: String): String {
@@ -313,8 +319,11 @@ class ChatViewModelPersistenceTest {
             created++
             return "run-77"
         }
-        override suspend fun pollResearch(id: String): whl.trending.chat.model.ResearchRun =
-            if (statuses.size > 1) statuses.removeAt(0) else statuses[0]
+        override suspend fun pollResearch(id: String): whl.trending.chat.model.ResearchRun {
+            failPoll?.let { throw ChatException(it) }
+            polled++
+            return if (statuses.size > 1) statuses.removeAt(0) else statuses[0]
+        }
     }
 
     @Test
@@ -381,6 +390,159 @@ class ChatViewModelPersistenceTest {
         advanceUntilIdle()
 
         assertEquals("迟到的报告", v2.uiState.value.messages.last().content)
+    }
+
+    @Test
+    fun `research 空报告视同失败：删占位行、错误可重试、不留恢复哨兵`() = runTest(dispatcher) {
+        val engine = ResearchEngine(mutableListOf(
+            whl.trending.chat.model.ResearchRun("run-77", "completed", "", null),
+        ))
+        val v = vm(engine)
+        advanceUntilIdle()
+        v.toggleDeepResearch()
+        v.updateInput("空手而归")
+        v.send()
+        advanceUntilIdle()
+
+        val last = v.uiState.value.messages.last()
+        assertNotNull(last.error)
+        assertEquals(null, last.researchRunId)
+        // 占位行已删：库里只剩 user，重开会话不会再触发恢复轮询
+        val threadId = store.threads().first()[0].id
+        assertEquals(listOf("user"), db.messageDao().messagesFor(threadId).map { it.role })
+    }
+
+    @Test
+    fun `error 条占过内存 id 后，research 占位 id 不与已有消息重号`() = runTest(dispatcher) {
+        // 第一次提交失败：error 条占用内存 id 但不落库 → Room 自增从此落后于内存序列
+        val engine = ResearchEngine(
+            statuses = mutableListOf(whl.trending.chat.model.ResearchRun("run-77", "completed", "# 报告", null)),
+            failCreate = ChatError(ChatErrorCategory.SERVER),
+        )
+        val v = vm(engine)
+        advanceUntilIdle()
+        v.toggleDeepResearch()
+        v.updateInput("第一问")
+        v.send()
+        advanceUntilIdle()
+
+        engine.failCreate = null
+        v.updateInput("第二问")
+        v.send()
+        advanceUntilIdle()
+
+        val messages = v.uiState.value.messages
+        // id 全局唯一（重号会让 LazyColumn 的 key 崩溃、报告覆盖用户气泡）
+        assertEquals(messages.size, messages.map { it.id }.distinct().size)
+        // 用户自己的提问未被报告内容覆盖
+        assertEquals(listOf("第一问", "第二问"), messages.filter { it.role == Role.USER }.map { it.content })
+        assertEquals("# 报告", messages.last().content)
+    }
+
+    @Test
+    fun `retry research 提交失败条→重新提交而非撞流式管线`() = runTest(dispatcher) {
+        val engine = ResearchEngine(
+            statuses = mutableListOf(whl.trending.chat.model.ResearchRun("run-77", "completed", "# 报告", null)),
+            failCreate = ChatError(ChatErrorCategory.SERVER),
+        )
+        val v = vm(engine)
+        advanceUntilIdle()
+        v.toggleDeepResearch()
+        v.updateInput("研究题")
+        v.send()
+        advanceUntilIdle()
+        val errorRow = v.uiState.value.messages.last()
+        assertNotNull(errorRow.error)
+
+        engine.failCreate = null
+        v.retry(errorRow)
+        advanceUntilIdle()
+
+        assertEquals(1, engine.created)
+        assertEquals("# 报告", v.uiState.value.messages.last().content)
+        // user 提问只有一条，未被重试复制
+        val threadId = store.threads().first()[0].id
+        assertEquals(listOf("user", "assistant"), db.messageDao().messagesFor(threadId).map { it.role })
+    }
+
+    @Test
+    fun `retry research 轮询永久错误条→恢复轮询同一任务，不重复建任务`() = runTest(dispatcher) {
+        val engine = ResearchEngine(
+            statuses = mutableListOf(whl.trending.chat.model.ResearchRun("run-77", "completed", "# 报告", null)),
+            failPoll = ChatError(ChatErrorCategory.QUOTA, code = ChatError.CODE_QUOTA_DEVICE),
+        )
+        val v = vm(engine)
+        advanceUntilIdle()
+        v.toggleDeepResearch()
+        v.updateInput("配额题")
+        v.send()
+        advanceUntilIdle()
+        val errorRow = v.uiState.value.messages.last()
+        assertNotNull(errorRow.error)
+        assertEquals("run-77", errorRow.researchRunId) // runId 保留是恢复的前提
+
+        engine.failPoll = null
+        v.retry(errorRow)
+        advanceUntilIdle()
+
+        assertEquals(1, engine.created) // 没有重复建任务（重复扣费）
+        assertEquals("# 报告", v.uiState.value.messages.last().content)
+    }
+
+    @Test
+    fun `不支持 research 的引擎（Demo 默认实现）：不崩溃、呈现错误条`() = runTest(dispatcher) {
+        // GatedEngine 未覆写 createResearch → 默认实现抛 UnsupportedOperationException
+        val v = vm(GatedEngine())
+        advanceUntilIdle()
+        v.toggleDeepResearch()
+        v.updateInput("不支持")
+        v.send()
+        advanceUntilIdle()
+
+        assertNotNull(v.uiState.value.messages.last().error)
+        assertEquals(false, v.uiState.value.isSending)
+    }
+
+    @Test
+    fun `空 assistant 行（research 错误条）不进后续 chat history`() = runTest(dispatcher) {
+        val engine = ResearchEngine(failCreate = ChatError(ChatErrorCategory.SERVER))
+        val v = vm(engine)
+        advanceUntilIdle()
+        v.toggleDeepResearch()
+        v.updateInput("失败的研究")
+        v.send()
+        advanceUntilIdle()
+
+        v.toggleDeepResearch() // 回 Normal
+        v.updateInput("普通问题")
+        v.send()
+        advanceUntilIdle()
+
+        val history = engine.lastHistory
+        assertNotNull(history)
+        assertTrue(history.none { it.role == Role.ASSISTANT && it.content.isBlank() })
+    }
+
+    @Test
+    fun `deleteThread 取消 research 轮询任务`() = runTest(dispatcher) {
+        val engine = ResearchEngine(mutableListOf(
+            whl.trending.chat.model.ResearchRun("run-77", "running", null, null),
+        ))
+        val v = vm(engine)
+        advanceUntilIdle()
+        v.toggleDeepResearch()
+        v.updateInput("长任务")
+        v.send()
+        testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(20_000) // 快轮阶段推进两轮
+        val polledBefore = engine.polled
+        assertTrue(polledBefore > 0)
+
+        val threadId = store.threads().first()[0].id
+        v.deleteThread(threadId)
+        advanceUntilIdle()
+
+        assertEquals(polledBefore, engine.polled) // 轮询已随线程删除而取消
     }
 
 }

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
@@ -293,4 +293,94 @@ class ChatViewModelPersistenceTest {
         assertEquals(whl.trending.chat.model.ChatMode.Normal, v.chatMode.value)
     }
 
+
+    // ---- P3 Deep Research ----
+
+    /** research 假引擎：脚本化状态序列 */
+    private class ResearchEngine(
+        var statuses: MutableList<whl.trending.chat.model.ResearchRun> = mutableListOf(),
+        var failCreate: ChatError? = null,
+    ) : ChatEngine {
+        var created = 0
+        override suspend fun send(
+            history: List<ChatMessage>, context: ChatContext?, onDelta: (String) -> Unit,
+            search: Boolean, onSearch: (whl.trending.chat.model.SearchEvent) -> Unit,
+        ): String = "n/a"
+        override suspend fun sendDetailSummary(context: ChatContext, onDelta: (String) -> Unit) =
+            DetailSummaryResult("n/a", cached = false)
+        override suspend fun createResearch(topic: String): String {
+            failCreate?.let { throw ChatException(it) }
+            created++
+            return "run-77"
+        }
+        override suspend fun pollResearch(id: String): whl.trending.chat.model.ResearchRun =
+            if (statuses.size > 1) statuses.removeAt(0) else statuses[0]
+    }
+
+    @Test
+    fun `research 提交→占位落库→轮询完成→报告落库`() = runTest(dispatcher) {
+        val engine = ResearchEngine(mutableListOf(
+            whl.trending.chat.model.ResearchRun("run-77", "running", null, null),
+            whl.trending.chat.model.ResearchRun("run-77", "completed", "# 研究报告", null),
+        ))
+        val v = vm(engine)
+        advanceUntilIdle()
+        v.toggleDeepResearch()
+        v.updateInput("研究一下 KMP")
+        v.send()
+        advanceUntilIdle()
+
+        val msg = v.uiState.value.messages.last()
+        assertEquals("# 研究报告", msg.content)
+        assertEquals(false, msg.searching)
+
+        val threadId = store.threads().first()[0].id
+        val rows = db.messageDao().messagesFor(threadId)
+        assertEquals("DEEP_RESEARCH", rows.last().kind)
+        assertEquals("# 研究报告", rows.last().content)
+        assertTrue(rows.last().segmentsJson!!.contains("run-77"))
+    }
+
+    @Test
+    fun `research 失败→删占位行→错误条可见`() = runTest(dispatcher) {
+        val engine = ResearchEngine(mutableListOf(
+            whl.trending.chat.model.ResearchRun("run-77", "failed", null, "failed"),
+        ))
+        val v = vm(engine)
+        advanceUntilIdle()
+        v.toggleDeepResearch()
+        v.updateInput("x")
+        v.send()
+        advanceUntilIdle()
+
+        assertNotNull(v.uiState.value.messages.last().error)
+        val threadId = store.threads().first()[0].id
+        val rows = db.messageDao().messagesFor(threadId)
+        // 占位行已删，只剩 user 消息
+        assertEquals(listOf("user"), rows.map { it.role })
+    }
+
+    @Test
+    fun `重开会话发现未完成占位→恢复轮询直至完成`() = runTest(dispatcher) {
+        val engine = ResearchEngine(mutableListOf(
+            whl.trending.chat.model.ResearchRun("run-77", "running", null, null),
+        ))
+        val v = vm(engine)
+        advanceUntilIdle()
+        v.toggleDeepResearch()
+        v.updateInput("长任务")
+        v.send()
+        // 只让创建完成、不推进轮询到终局：先切走再回来模拟重开
+        advanceUntilIdle()
+
+        // 新 VM（模拟进程重启）：占位行在库里 → enterEntry 恢复轮询
+        val engine2 = ResearchEngine(mutableListOf(
+            whl.trending.chat.model.ResearchRun("run-77", "completed", "迟到的报告", null),
+        ))
+        val v2 = vm(engine2)
+        advanceUntilIdle()
+
+        assertEquals("迟到的报告", v2.uiState.value.messages.last().content)
+    }
+
 }


### PR DESCRIPTION
## 概要

Chat 改造 v2 方案 P3 客户端侧（配套后端 github-ai-trending-api#23，需其先迁移+部署）。

## 变更

- **ChatMode.DeepResearch**：入 `+` 菜单与 chip 回显——互斥框架零改动只增枚举（P2 框架设计的兑现）
- **research 流**：不走流式管线——POST 建任务 → 8s 轮询（90 次上限，达限停轮不判死）→ 报告以消息终局呈现
- **占位行即恢复载体**：提交成功立即落库（空内容 + runId），进程死亡后重开会话触发续轮询，5 credits 不白花；完成升级为报告全文，失败删行（服务端已退款）
- 引擎接口默认实现兜底，既有 fake 零改动；错误分类复用（login_required → 登录引导路径与解读一致）
- 埋点：research_start / research_done / research_fail

## 测试

模块 86 全绿（+3：提交→轮询→完成落库 / 失败删行 / 重开恢复轮询）。真机端到端待后端部署后补做（登录门所限 curl 冒烟只能覆盖 403）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7b1EyajFyydKthdYtfiCV

## Summary by Sourcery

添加 Deep Research 聊天模式，采用非流式的研究工作流，包括基于轮询的报告投递以及基于持久化存储的恢复（resume）行为。

New Features:
- 在现有网页搜索模式基础上引入 Deep Research 聊天模式，提供菜单入口，并通过 chip 式 UI 回显当前模式。
- 支持提交 Deep Research 任务并轮询其状态直至完成或失败，将最终报告作为一条聊天消息投递。

Enhancements:
- 持久化保存带有运行 ID 的 Deep Research 占位消息，以支持跨进程恢复轮询，并在任务完成后将其升级为完整报告。
- 扩展聊天消息、存储 schema 和 DAO，以存储 Deep Research 元数据，并处理占位消息的生命周期，包括在失败时删除占位消息。
- 更新聊天 UI 组件以反映 Deep Research 状态，包括专用标签、图标和进行中提示文案，同时保持与网页搜索模式的互斥选择。

Tests:
- 添加单元测试，覆盖 Deep Research 提交、占位消息持久化与完成、失败清理，以及会话重新打开后的轮询恢复行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Deep Research chat mode with non-streaming research workflow, including polling-based report delivery and persistence-backed resume behavior.

New Features:
- Introduce Deep Research chat mode alongside existing web search mode, with menu entry and chip-based UI echo.
- Support submitting Deep Research tasks and polling their status until completion or failure, delivering the final report as a chat message.

Enhancements:
- Persist Deep Research placeholder messages with run IDs to enable cross-process resume of polling and upgrade them to full reports on completion.
- Extend chat messages, storage schema, and DAO to store Deep Research metadata and handle placeholder lifecycle, including deletion on failure.
- Update chat UI components to reflect Deep Research state, including dedicated labels, icons, and in-progress text, while keeping mode selection mutually exclusive with web search.

Tests:
- Add unit tests covering Deep Research submission, placeholder persistence and completion, failure cleanup, and session-reopen polling resume behavior.

</details>