### PR TITLE
feat(chat): 解读与 research 入口整合——FAB 深度调研 + 解读卡升级漏斗 + topic 锚点

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -81,6 +81,11 @@ class ChatViewModel(
     fun toggleWebSearch() = toggleMode(ChatMode.WebSearch)
     fun toggleDeepResearch() = toggleMode(ChatMode.DeepResearch)
 
+    /** README 详情页「深度调研」入口：定向开启（非 toggle——重进已开启的会话不能反把模式关掉） */
+    fun enableDeepResearch() {
+        _chatMode.value = ChatMode.DeepResearch
+    }
+
     private fun toggleMode(mode: ChatMode) {
         _chatMode.value = if (_chatMode.value == mode) ChatMode.Normal else mode
     }
@@ -367,8 +372,14 @@ class ChatViewModel(
 
     // ---- Deep Research（P3）----
 
-    private fun sendResearch(topic: String) {
-        track("research_start", mapOf("from" to "chat"))
+    /** 解读卡尾部「深度调研此项目」升级入口：按 research 管线直发，不依赖模式开关 */
+    fun sendRepoResearch(promptText: String) {
+        if (_uiState.value.isSending || activeContext == null) return
+        sendResearch(promptText, from = "detail_summary_upsell")
+    }
+
+    private fun sendResearch(topic: String, from: String = "chat") {
+        track("research_start", mapOf("from" to from))
         _uiState.update { it.copy(isSending = true) }
         viewModelScope.launch {
             val threadId = ensureThreadForSend(topic)
@@ -380,7 +391,8 @@ class ChatViewModel(
     /** 提交 research 任务并启动轮询；提交失败挂错误条（重试经 [retryResearch] 重新提交） */
     private suspend fun startResearch(threadId: Long?, topic: String) {
         val runId = try {
-            engine.createResearch(topic)
+            // 条目会话附上标题/链接锚点（拼装收口在此：发送与重试都传原文，各自重拼保证同构）
+            engine.createResearch(ResearchTopics.compose(topic, activeContext))
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ResearchTopics.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ResearchTopics.kt
@@ -1,0 +1,28 @@
+package whl.trending.chat
+
+import whl.trending.ai.chat.ChatContext
+
+/**
+ * research 主题的条目锚点拼装（纯函数）。
+ *
+ * 条目会话里发起的 research 在主题尾部附上标题 + 链接，让联网检索锁定正确项目
+ * （同名项目/常见词主题极易漂移）。落库与气泡展示的仍是用户原文；拼装收口在
+ * 发送前最后一步（[whl.trending.chat.ChatViewModel] 的 startResearch），发送与
+ * 重试两条路径都传原文、各自重新拼装，保证同构。
+ */
+object ResearchTopics {
+
+    /** 与服务端 research 接口 MAX_TOPIC_LEN 同源约定 */
+    const val MAX_TOPIC_LEN = 500
+
+    fun compose(text: String, context: ChatContext?): String {
+        val anchor = listOfNotNull(
+            context?.title?.takeIf { it.isNotBlank() },
+            context?.sourceUrl?.takeIf { it.isNotBlank() },
+        ).joinToString(" ")
+        if (anchor.isBlank()) return text
+        val composed = "$text\n\nTarget: $anchor"
+        // 附加后超上限则回退原文：宁可丢锚点，不截用户内容、不让请求被 400 拒掉
+        return if (composed.length <= MAX_TOPIC_LEN) composed else text
+    }
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ResearchUpsellPolicy.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ResearchUpsellPolicy.kt
@@ -1,0 +1,27 @@
+package whl.trending.chat
+
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.MessageKind
+import whl.trending.chat.model.Role
+
+/**
+ * 解读卡尾部「深度调研此项目」升级入口的可见性策略（纯函数）。
+ *
+ * 挂在最后一条成功解读消息的尾部：解读（便宜、秒级）是漏斗上层，research
+ * （10 credits、分钟级）是升级动作。会话里一旦出现任何 research 消息——包括
+ * 在途占位与失败条——入口即隐藏：失败已有自己的重试路径，这里再放入口
+ * 等于诱导重复扣费。
+ */
+object ResearchUpsellPolicy {
+
+    /** 返回应挂升级入口的消息 id；无处可挂则 null */
+    fun upsellMessageId(messages: List<ChatMessage>): Long? {
+        if (messages.any { it.kind == MessageKind.DEEP_RESEARCH }) return null
+        return messages.lastOrNull {
+            it.kind == MessageKind.DETAIL_SUMMARY &&
+                it.role == Role.ASSISTANT &&
+                it.error == null &&
+                it.content.isNotBlank()
+        }?.id
+    }
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -264,12 +264,13 @@ fun ChatScreen(
                     // 自动切到 MessageList，与「介绍这个项目」chip 的隐藏时机一致。
                     ChatWelcome(hasContext = initialContext != null)
                 } else {
-                    val upsellPrompt = stringResource(R.string.chat_action_research_upsell)
+                    // topic 用预填调研主题而非按钮 CTA 文案：与 FAB 入口同构，后端拿到的是
+                    // 有内容的调研诉求（Sourcery 审查采纳）
                     MessageList(
                         messages = state.messages,
                         isSending = state.isSending,
                         onRetry = viewModel::retry,
-                        onResearchUpsell = { viewModel.sendRepoResearch(upsellPrompt) },
+                        onResearchUpsell = { viewModel.sendRepoResearch(researchPrefill) },
                     )
                 }
             }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -104,6 +104,16 @@ fun ChatScreen(
         }
     }
 
+    // README 详情页「深度调研」入口：只预选模式 + 预填主题，发送仍由用户确认——
+    // research 计价高（10 credits），不做自动触发（有别于解读入口的 auto 语义）
+    val researchPrefill = stringResource(R.string.chat_research_repo_prefill)
+    LaunchedEffect(entryKey) {
+        if (initialContext?.autoDeepResearch == true) {
+            viewModel.enableDeepResearch()
+            if (viewModel.uiState.value.input.isBlank()) viewModel.updateInput(researchPrefill)
+        }
+    }
+
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
     fun closeDrawer() = scope.launch { drawerState.close() }
@@ -254,10 +264,12 @@ fun ChatScreen(
                     // 自动切到 MessageList，与「介绍这个项目」chip 的隐藏时机一致。
                     ChatWelcome(hasContext = initialContext != null)
                 } else {
+                    val upsellPrompt = stringResource(R.string.chat_action_research_upsell)
                     MessageList(
                         messages = state.messages,
                         isSending = state.isSending,
                         onRetry = viewModel::retry,
+                        onResearchUpsell = { viewModel.sendRepoResearch(upsellPrompt) },
                     )
                 }
             }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageItem.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material.icons.outlined.TravelExplore
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -66,16 +68,20 @@ import whl.trending.chat.model.Role
  * - 用户：右侧气泡（primaryContainer）
  * - 助手：左侧全宽 Markdown 渲染（无气泡，贴近 Claude/ChatGPT 风格）
  * 均支持长按选中复制；助手出错时展示错误与重试按钮。
+ *
+ * @param onResearchUpsell 非 null 时在消息尾部挂「深度调研此项目」升级入口
+ *   （仅解读消息会收到，可见性由 [whl.trending.chat.ResearchUpsellPolicy] 决定）
  */
 @Composable
 fun MessageItem(
     message: ChatMessage,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
+    onResearchUpsell: (() -> Unit)? = null,
 ) {
     when (message.role) {
         Role.USER -> UserMessage(message, modifier)
-        Role.ASSISTANT -> AssistantMessage(message, onRetry, modifier)
+        Role.ASSISTANT -> AssistantMessage(message, onRetry, modifier, onResearchUpsell)
     }
 }
 
@@ -151,7 +157,12 @@ private fun UserImageThumb(path: String, onClick: () -> Unit, modifier: Modifier
 }
 
 @Composable
-private fun AssistantMessage(message: ChatMessage, onRetry: () -> Unit, modifier: Modifier) {
+private fun AssistantMessage(
+    message: ChatMessage,
+    onRetry: () -> Unit,
+    modifier: Modifier,
+    onResearchUpsell: (() -> Unit)? = null,
+) {
     Column(modifier = modifier.fillMaxWidth()) {
         val error = message.error
         if (error == null) {
@@ -240,6 +251,20 @@ private fun AssistantMessage(message: ChatMessage, onRetry: () -> Unit, modifier
                         modifier = Modifier.size(18.dp),
                     )
                 }
+            }
+            // 解读 → research 的升级漏斗：解读卡尾部一键发起对该项目的深度调研
+            if (onResearchUpsell != null) {
+                AssistChip(
+                    onClick = onResearchUpsell,
+                    label = { Text(stringResource(R.string.chat_action_research_upsell)) },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Outlined.TravelExplore,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    },
+                )
             }
         } else if (error.code == ChatError.CODE_QUOTA_DEVICE || error.code == ChatError.CODE_LOGIN_REQUIRED) {
             // 个人配额触顶 / 解读登录闸走专属卡片（登录 CTA / waitlist），全局熔断仍走普通错误文案

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageList.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/MessageList.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import whl.trending.chat.ResearchUpsellPolicy
 import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.Role
 
@@ -26,8 +27,13 @@ fun MessageList(
     isSending: Boolean,
     onRetry: (ChatMessage) -> Unit,
     modifier: Modifier = Modifier,
+    onResearchUpsell: (() -> Unit)? = null,
 ) {
     val listState = rememberLazyListState()
+    // 「深度调研此项目」升级入口挂载点（发送中不挂，防连点重复扣费）
+    val upsellId = if (onResearchUpsell != null && !isSending) {
+        ResearchUpsellPolicy.upsellMessageId(messages)
+    } else null
 
     // 仅离散事件（发送/回复到达/typing 项增删）时滚回底部；流式增量期间 size 不变、不触发
     LaunchedEffect(messages.size, isSending) {
@@ -51,7 +57,11 @@ fun MessageList(
             item(key = "typing") { TypingIndicator() }
         }
         items(messages.asReversed(), key = { it.id }) { message ->
-            MessageItem(message = message, onRetry = { onRetry(message) })
+            MessageItem(
+                message = message,
+                onRetry = { onRetry(message) },
+                onResearchUpsell = onResearchUpsell.takeIf { message.id == upsellId },
+            )
         }
     }
 }

--- a/androidLibrary/chat/src/main/res/values-zh/strings.xml
+++ b/androidLibrary/chat/src/main/res/values-zh/strings.xml
@@ -74,4 +74,6 @@
     <string name="chat_searching">正在搜索网络…</string>
     <string name="chat_deep_research">深入研究</string>
     <string name="chat_researching">深入研究中，约需几分钟…</string>
+    <string name="chat_action_research_upsell">深度调研此项目</string>
+    <string name="chat_research_repo_prefill">全面调研这个项目：技术定位与亮点、同类方案对比、社区口碑与采用情况</string>
 </resources>

--- a/androidLibrary/chat/src/main/res/values/strings.xml
+++ b/androidLibrary/chat/src/main/res/values/strings.xml
@@ -74,4 +74,6 @@
     <string name="chat_searching">Searching the web…</string>
     <string name="chat_deep_research">Deep research</string>
     <string name="chat_researching">Deep research in progress… this may take a few minutes</string>
+    <string name="chat_action_research_upsell">Deep research this project</string>
+    <string name="chat_research_repo_prefill">Research this project in depth: positioning and highlights, comparable alternatives, community feedback and adoption.</string>
 </resources>

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ResearchTopicsTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ResearchTopicsTest.kt
@@ -1,0 +1,47 @@
+package whl.trending.chat
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import whl.trending.ai.chat.ChatContext
+
+/** research 主题的条目锚点拼装（纯函数）。 */
+class ResearchTopicsTest {
+
+    private val repoContext = ChatContext(
+        title = "octo/demo",
+        sourceUrl = "https://github.com/octo/demo",
+        source = "github",
+        externalId = "octo/demo",
+    )
+
+    @Test
+    fun `无 context → 原文透传`() {
+        assertEquals("调研一下 KMP 生态", ResearchTopics.compose("调研一下 KMP 生态", null))
+    }
+
+    @Test
+    fun `条目会话 → 尾部附标题与链接锚点`() {
+        val composed = ResearchTopics.compose("这个项目值得投入吗", repoContext)
+        assertTrue(composed.startsWith("这个项目值得投入吗"))
+        assertTrue("octo/demo" in composed)
+        assertTrue("https://github.com/octo/demo" in composed)
+    }
+
+    @Test
+    fun `context 无标题无链接 → 原文透传`() {
+        assertEquals("hi", ResearchTopics.compose("hi", ChatContext(title = "")))
+    }
+
+    @Test
+    fun `附加后超服务端上限 → 回退原文，不截用户内容`() {
+        val longText = "调".repeat(ResearchTopics.MAX_TOPIC_LEN - 10)
+        assertEquals(longText, ResearchTopics.compose(longText, repoContext))
+    }
+
+    @Test
+    fun `拼装结果不超服务端上限`() {
+        val text = "调".repeat(400)
+        assertTrue(ResearchTopics.compose(text, repoContext).length <= ResearchTopics.MAX_TOPIC_LEN)
+    }
+}

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ResearchUpsellPolicyTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ResearchUpsellPolicyTest.kt
@@ -1,0 +1,52 @@
+package whl.trending.chat
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import whl.trending.chat.model.ChatError
+import whl.trending.chat.model.ChatErrorCategory
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.MessageKind
+import whl.trending.chat.model.Role
+
+/** 解读卡尾部「深度调研此项目」升级入口的可见性策略（纯函数）。 */
+class ResearchUpsellPolicyTest {
+
+    private val summaryUser = ChatMessage(1, Role.USER, "一键详细解读", kind = MessageKind.DETAIL_SUMMARY)
+    private val summaryOk = ChatMessage(2, Role.ASSISTANT, "解读全文", kind = MessageKind.DETAIL_SUMMARY)
+
+    @Test
+    fun `成功解读消息 → 挂在该消息上`() {
+        assertEquals(2L, ResearchUpsellPolicy.upsellMessageId(listOf(summaryUser, summaryOk)))
+    }
+
+    @Test
+    fun `无解读消息 → 不显示`() {
+        val chat = listOf(ChatMessage(1, Role.USER, "hi"), ChatMessage(2, Role.ASSISTANT, "hello"))
+        assertNull(ResearchUpsellPolicy.upsellMessageId(chat))
+    }
+
+    @Test
+    fun `解读失败或未出字 → 不显示`() {
+        val failed = ChatMessage(
+            2, Role.ASSISTANT, "",
+            error = ChatError(ChatErrorCategory.SERVER),
+            kind = MessageKind.DETAIL_SUMMARY,
+        )
+        assertNull(ResearchUpsellPolicy.upsellMessageId(listOf(summaryUser, failed)))
+        val blank = ChatMessage(3, Role.ASSISTANT, "", kind = MessageKind.DETAIL_SUMMARY)
+        assertNull(ResearchUpsellPolicy.upsellMessageId(listOf(summaryUser, blank)))
+    }
+
+    @Test
+    fun `会话已有任何 research 消息（含在途与失败）→ 隐藏，防重复扣费`() {
+        val researchUser = ChatMessage(3, Role.USER, "深度调研此项目", kind = MessageKind.DEEP_RESEARCH)
+        assertNull(ResearchUpsellPolicy.upsellMessageId(listOf(summaryUser, summaryOk, researchUser)))
+    }
+
+    @Test
+    fun `多条成功解读 → 挂在最后一条上`() {
+        val later = ChatMessage(5, Role.ASSISTANT, "新解读", kind = MessageKind.DETAIL_SUMMARY)
+        assertEquals(5L, ResearchUpsellPolicy.upsellMessageId(listOf(summaryUser, summaryOk, later)))
+    }
+}

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -109,6 +109,7 @@
     <string name="share_to_ai">分享</string>
     <string name="readme_fab_chat">AI 对话</string>
     <string name="readme_fab_detail_summary">一键解读</string>
+    <string name="readme_fab_deep_research">深度调研</string>
     <string name="share_ai_text_full">请帮我解读这条技术资讯并提炼核心要点：\n\n标题：%1$s\n\n摘要：%2$s\n\n原文：%3$s</string>
     <string name="share_ai_text_brief">请帮我解读这条技术资讯并提炼核心要点：\n\n标题：%1$s\n\n原文：%2$s</string>
     <string name="readme_no_content">该仓库暂无 README 文件。</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -109,6 +109,7 @@
     <string name="share_to_ai">Share</string>
     <string name="readme_fab_chat">AI Chat</string>
     <string name="readme_fab_detail_summary">In-depth read</string>
+    <string name="readme_fab_deep_research">Deep research</string>
     <string name="share_ai_text_full">Please help me read and summarize this tech update:\n\nTitle: %1$s\n\nSummary: %2$s\n\nSource: %3$s</string>
     <string name="share_ai_text_brief">Please help me read and summarize this tech update:\n\nTitle: %1$s\n\nSource: %2$s</string>
     <string name="readme_no_content">No README found for this repository.</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/chat/ChatIntegration.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/chat/ChatIntegration.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.Composable
  * @param externalId 条目在数据源内的 ID（GitHub 为 `owner/repo`），detail-summary API 入参
  * @param readmeLength README 正文长度估计（ReadmeScreen 进 chat 时填充；未加载完为 null → chip 不显示）
  * @param autoDetailSummary 进入 chat 后是否自动触发「一键详细解读」（README 详情页「一键解读」入口置 true）
+ * @param autoDeepResearch 进入 chat 后预选 Deep Research 模式并预填调研主题（README 详情页「深度调研」
+ *   入口置 true）；只预选不自动发送——research 计价高，发送必须由用户确认
  */
 data class ChatContext(
     val title: String,
@@ -19,6 +21,7 @@ data class ChatContext(
     val externalId: String? = null,
     val readmeLength: Int? = null,
     val autoDetailSummary: Boolean = false,
+    val autoDeepResearch: Boolean = false,
 )
 
 /**

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarBorder
+import androidx.compose.material.icons.outlined.TravelExplore
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -64,6 +65,7 @@ import trendingai.shared.generated.resources.action_star
 import trendingai.shared.generated.resources.action_unstar
 import trendingai.shared.generated.resources.back
 import trendingai.shared.generated.resources.readme_fab_chat
+import trendingai.shared.generated.resources.readme_fab_deep_research
 import trendingai.shared.generated.resources.readme_fab_detail_summary
 import trendingai.shared.generated.resources.readme_no_content
 import trendingai.shared.generated.resources.retry
@@ -109,8 +111,9 @@ fun ReadmeScreen(
             ?.replace(Regex("<[^>]+>"), "")
             ?.length
     }
-    // 构造进入 chat 的上下文；autoDetailSummary=true 时进 chat 自动触发「一键详细解读」
-    fun buildChatContext(autoDetailSummary: Boolean) = ChatContext(
+    // 构造进入 chat 的上下文；autoDetailSummary=true 时进 chat 自动触发「一键详细解读」，
+    // autoDeepResearch=true 时预选 Deep Research 模式 + 预填主题（发送由用户确认）
+    fun buildChatContext(autoDetailSummary: Boolean = false, autoDeepResearch: Boolean = false) = ChatContext(
         title = "$owner/$repo",
         // 带上 README 摘录作为依据，让 AI 能介绍冷门项目；未加载完为 null，退化为仅 title + url
         summary = summary,
@@ -120,6 +123,7 @@ fun ReadmeScreen(
         externalId = "$owner/$repo",
         readmeLength = readmeLength,
         autoDetailSummary = autoDetailSummary,
+        autoDeepResearch = autoDeepResearch,
     )
     // 与 chat 模块 DetailSummaryPolicy.MIN_README_CHARS 保持一致（shared 无法跨模块引用该常量）
     val detailSummaryAvailable = (readmeLength ?: 0) >= 1500
@@ -251,7 +255,7 @@ fun ReadmeScreen(
                     FloatingActionButtonMenuItem(
                         onClick = {
                             menuExpanded = false
-                            onNavigateToChat(buildChatContext(autoDetailSummary = false))
+                            onNavigateToChat(buildChatContext())
                         },
                         icon = {
                             Icon(Icons.AutoMirrored.Filled.Chat, contentDescription = null)
@@ -271,6 +275,17 @@ fun ReadmeScreen(
                             text = { Text(stringResource(Res.string.readme_fab_detail_summary)) },
                         )
                     }
+                    // 「深度调研」不受 README 长度限制：research 联网检索，不依赖 README 正文
+                    FloatingActionButtonMenuItem(
+                        onClick = {
+                            menuExpanded = false
+                            onNavigateToChat(buildChatContext(autoDeepResearch = true))
+                        },
+                        icon = {
+                            Icon(Icons.Outlined.TravelExplore, contentDescription = null)
+                        },
+                        text = { Text(stringResource(Res.string.readme_fab_deep_research)) },
+                    )
                 }
             }
         }


### PR DESCRIPTION
## 背景

一键解读（秒级、免费可缓存的精读卡）与 Deep Research（10 credits、分钟级的联网调研报告）是梯度关系而非替代关系。本 PR 做入口层整合，让两档形成「先看解读卡 → 值得深挖再升级 research」的递进漏斗，两条后端管线保持独立。

## 改动

1. **FAB 第三项「深度调研」**（ReadmeScreen）：进 chat 预选 Deep Research 模式并预填调研主题，发送由用户确认——research 计价高，有别于「一键解读」的自动触发语义；不受 README 长度门槛限制（research 联网检索，不依赖 README 正文）
2. **解读卡尾部「深度调研此项目」升级入口**（`ResearchUpsellPolicy`）：挂最后一条成功解读消息尾部；会话内已有任何 research 消息（含在途/失败）即隐藏，防重复扣费；发送中不挂，防连点
3. **research topic 条目锚点注入**（`ResearchTopics`）：条目会话发起的 research 在主题尾部附标题+链接，锁定联网检索目标（同名项目/常见词主题易漂移）。拼装收口在 `startResearch`——发送与重试两路都传原文、各自重拼保证同构；附加后超服务端 `MAX_TOPIC_LEN=500` 则回退原文
4. 埋点：升级入口以 `research_start from=detail_summary_upsell` 区分来源

## 验证

- 新增 `ResearchTopicsTest` / `ResearchUpsellPolicyTest`，chat 模块全量单测通过
- `:androidApp:assembleDebug` 构建通过
- Pixel_9_2 模拟器冒烟：FAB 三项正常展示；点「深度调研」进 chat 后模式 chip 选中、主题预填、未自动发送、模型选择器按规则隐藏

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXNd9VNRY4AeUfMFe9Xu7G

## Summary by Sourcery

在聊天中的 README 详情总结基础上集成深度研究作为升级路径，并改进研究主题与代码仓库上下文的关联方式。

New Features:
- 在 README FAB 菜单中新增独立的深度研究入口，打开聊天时预先选择深度研究模式并填充默认研究提示词。
- 在成功的详情总结消息末尾显示一个“深入研究此项目”的辅助按钮，在策略允许时作为引导用户进入深度研究的升级入口。
- 通过在研究请求中附加当前仓库的标题和 URL，将深度研究主题与当前仓库进行绑定，同时遵守后端对主题长度的限制。

Enhancements:
- 引入一个策略对象，用于控制何时显示深度研究升级入口，避免重复计费，并且只附加到合法的总结消息上。
- 添加分析事件，用于区分来自聊天直接发起的深度研究与通过详情总结升级入口发起的深度研究。

Tests:
- 为深度研究升级入口的可见性策略以及带有仓库锚点的研究主题构造逻辑添加单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate deep research as an upgrade path from README detail summaries in chat, and improve how research topics are anchored to repository context.

New Features:
- Add a dedicated deep research entry in the README FAB menu that opens chat with Deep Research mode preselected and a prefilled research prompt.
- Surface a "deep research this project" assist chip at the end of successful detail summary messages as an upsell into Deep Research, when allowed by policy.
- Anchor deep research topics to the current repository by appending title and URL to the research request, while respecting backend topic length limits.

Enhancements:
- Introduce a policy object to control when the deep research upsell is shown, avoiding duplicate charging and only attaching to valid summary messages.
- Add analytics to distinguish deep research starts coming from chat vs from the detail summary upsell entry.

Tests:
- Add unit tests for the deep research upsell visibility policy and for composing research topics with repository anchors.

</details>