### PR TITLE
feat: 邮箱验证码登录 + 账户页配额展示

### DIFF
--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -13,6 +13,7 @@ import java.io.IOException
 import java.lang.ref.WeakReference
 import java.net.ConnectException
 import java.net.HttpURLConnection
+import java.net.ProtocolException
 import java.net.SocketTimeoutException
 import java.net.URL
 import java.net.UnknownHostException
@@ -247,46 +248,51 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         }
     }
 
-    private fun measureClockOffsetMs(): Long? = runCatching {
+    /**
+     * HEAD 探测 Logto 端点：一次请求同时产出可达性分类与服务器时间，供 auth_probe（可达性）与
+     * 时钟偏移探测（Date 头）复用，避免两处几乎相同的样板各自漂移。
+     *
+     * 可达性分类刻意区分「链路可达」与「真不可达」：任意 HTTP 状态码（含 4xx/5xx）说明服务器
+     * 响应了 → ok；服务器/代理拒绝 HEAD 方法本身（ProtocolException）也说明链路是通的 → ok，
+     * 不算可达性失败（否则 auth_probe 失败率虚高，误导 Logto vs 自研的决策）；仅连接层失败
+     * （超时 / DNS / 连接重置等 IOException）才是真正不可达。
+     */
+    private fun probeEndpoint(timeoutMs: Int): EndpointProbe {
         val connection = URL(LOGTO_ENDPOINT).openConnection() as HttpURLConnection
-        try {
+        return try {
             connection.requestMethod = "HEAD"
-            connection.connectTimeout = CLOCK_PROBE_TIMEOUT_MS
-            connection.readTimeout = CLOCK_PROBE_TIMEOUT_MS
-            val serverDate = connection.getHeaderFieldDate("Date", 0L)
-            if (serverDate == 0L) null else serverDate - System.currentTimeMillis()
+            connection.connectTimeout = timeoutMs
+            connection.readTimeout = timeoutMs
+            connection.responseCode // 任意 HTTP 状态码都代表链路可达
+            EndpointProbe("ok", connection.getHeaderFieldDate("Date", 0L).takeIf { it != 0L })
+        } catch (_: SocketTimeoutException) {
+            EndpointProbe("timeout", null)
+        } catch (_: ProtocolException) {
+            EndpointProbe("ok", null) // HEAD 方法被拒 = 可达但方法不受支持，非可达性失败
+        } catch (_: Exception) {
+            EndpointProbe("fail", null) // 连接层失败：真正不可达
         } finally {
             connection.disconnect()
         }
-    }.getOrNull()
+    }
+
+    private class EndpointProbe(val result: String, val serverDate: Long?)
+
+    private fun measureClockOffsetMs(): Long? {
+        val serverDate = probeEndpoint(CLOCK_PROBE_TIMEOUT_MS).serverDate ?: return null
+        return serverDate - System.currentTimeMillis()
+    }
 
     /**
      * 登录发起时的 Logto 端点可达性探测（异步 fire-and-forget）：托管页/授权端点在 Custom Tab 里
      * 加载失败时 SDK 收不到任何回调，只会表现为「用户取消」——可达性失败被系统性伪装成取消，
      * 76% 取消率只能靠推测归因大陆可达性就是这个盲区造成的。
      * 分析口径：可达性失败占比 ≈ auth_probe 失败率，用「probe 失败 × cancel_kind=wait」交叉验证。
-     *
-     * 任何 HTTP 状态码（含 4xx/5xx）都算 ok——只测「链路能不能通」，不测服务对错。
      */
     private fun trackAuthProbe(method: String) {
         thread(isDaemon = true, name = "auth-probe") {
             val startedAt = SystemClock.elapsedRealtime()
-            val result = try {
-                val connection = URL(LOGTO_ENDPOINT).openConnection() as HttpURLConnection
-                try {
-                    connection.requestMethod = "HEAD"
-                    connection.connectTimeout = AUTH_PROBE_TIMEOUT_MS
-                    connection.readTimeout = AUTH_PROBE_TIMEOUT_MS
-                    connection.responseCode
-                    "ok"
-                } finally {
-                    connection.disconnect()
-                }
-            } catch (_: SocketTimeoutException) {
-                "timeout"
-            } catch (_: Exception) {
-                "fail"
-            }
+            val result = probeEndpoint(AUTH_PROBE_TIMEOUT_MS).result
             val latencyMs = SystemClock.elapsedRealtime() - startedAt
             trackEvent(
                 "auth_probe",

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -49,7 +49,8 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         LogtoConfig(
             endpoint = LOGTO_ENDPOINT,
             appId = LOGTO_APP_ID,
-            scopes = listOf("identities"),
+            // email：邮箱验证码登录的 email claim；对存量会话不追溯（老 token 无此授权，重登后才有）
+            scopes = listOf("identities", "email"),
             resources = null,
             usingPersistStorage = true,
         ),
@@ -63,30 +64,55 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
     override val isSupported: Boolean = true
 
     override fun signIn(source: String) {
+        // 不直接拉起授权：发布待选请求，App 根部 SignInMethodChooserHost 弹选择器后回调双参重载。
+        // 不在此置 LoggingIn / 上报 start——选择器被划掉不产生任何漏斗事件，start 仍指「浏览器流程已拉起」。
+        SignInChooserBus.request(source)
+    }
+
+    override fun signIn(source: String, method: SignInMethod) {
         val activity = activityRef.get() ?: return
         _authState.value = AuthState.LoggingIn
         // 漏斗起点事件：start 数减去 success/canceled/error 终态数 = 无终态的静默流失
         // （典型如用户停在授权页直接杀进程，SDK 回调永远不会到达）。
-        trackEvent("sign_in_start", mapOf("source" to source))
+        val methodProp = method.name.lowercase()
+        trackEvent("sign_in_start", mapOf("source" to source, "method" to methodProp))
+        // 可达性探测（异步、不阻塞）：托管页在 Custom Tab 里加载失败时 SDK 收不到回调、只会表现为
+        // 用户取消——auth_probe 把这个观测盲区显性化，是「继续 Logto vs 自研」决策的直接判据。
+        trackAuthProbe(methodProp)
         // 登录耗时起点：单调时钟，不受系统时间/时区调整影响；source 同理用局部变量随闭包捕获，
         // 配置变更重建 Activity 后回调即便落在旧实例也仍读到本次登录的起点（见 SignInFailureBus）。
         val signInStartedAt = SystemClock.elapsedRealtime()
-        // directSignIn：授权端点直接 302 到 GitHub，跳过 Logto 托管登录页（海外 Cloudflare 边缘
-        // 无境内节点，SPA ~490KB、大陆单请求 ~1s，是登录取消漏斗的主要嫌疑）。target 需与
-        // Logto 控制台 GitHub connector 的 target 一致；不匹配时 Logto 回落到普通登录页，不会报错。
-        val signInOptions = SignInOptions(
-            redirectUri = REDIRECT_URI,
-            directSignIn = DirectSignInOptions(method = DirectSignInMethod.SOCIAL, target = "github"),
-        )
+        val signInOptions = when (method) {
+            // directSignIn：授权端点直接 302 到 GitHub，跳过 Logto 托管登录页（海外 Cloudflare 边缘
+            // 无境内节点，SPA ~490KB、大陆单请求 ~1s，是登录取消漏斗的主要嫌疑）。target 需与
+            // Logto 控制台 GitHub connector 的 target 一致；不匹配时 Logto 回落到普通登录页，不会报错。
+            SignInMethod.GITHUB -> SignInOptions(
+                redirectUri = REDIRECT_URI,
+                directSignIn = DirectSignInOptions(method = DirectSignInMethod.SOCIAL, target = "github"),
+            )
+            // 邮箱验证码：无 directSignIn 等价物，必须经托管页；first_screen + identifier 让托管页
+            // 直接落在邮箱输入屏，跳过页内的方式选择步骤。
+            SignInMethod.EMAIL -> SignInOptions(
+                redirectUri = REDIRECT_URI,
+                firstScreen = FIRST_SCREEN_IDENTIFIER_SIGN_IN,
+                identifiers = listOf(IDENTIFIER_EMAIL),
+            )
+        }
         logtoClient.signIn(activity, signInOptions) { logtoException ->
             // 从登录进入到本次回调的耗时：成功=登录总时长，失败=到失败的时长（取消即用户在授权页停留时长）。
             // 需结合事件/reason 解读：config/no_browser 等快失败耗时接近 0 属正常。
             val durationMs = SystemClock.elapsedRealtime() - signInStartedAt
             if (logtoException == null && logtoClient.isAuthenticated) {
                 _authState.value = AuthState.LoggedIn
+                // method 为选择器意图；托管页内切换方式的边角（邮箱屏仍可能展示社交按钮）不在客户端识别
                 trackEvent(
                     "sign_in_success",
-                    mapOf("source" to source, "duration_ms" to durationMs, "duration_bucket" to durationBucket(durationMs)),
+                    mapOf(
+                        "source" to source,
+                        "method" to methodProp,
+                        "duration_ms" to durationMs,
+                        "duration_bucket" to durationBucket(durationMs),
+                    ),
                 )
             } else {
                 _authState.value = AuthState.LoggedOut
@@ -99,13 +125,14 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
                             "sign_in_canceled",
                             mapOf(
                                 "source" to source,
+                                "method" to methodProp,
                                 "duration_ms" to durationMs,
                                 "duration_bucket" to durationBucket(durationMs),
                                 "cancel_kind" to if (durationMs < CANCEL_KIND_QUICK_THRESHOLD_MS) "quick" else "wait",
                             ),
                         )
                     } else {
-                        trackSignInError(props + ("source" to source) + ("duration_ms" to durationMs))
+                        trackSignInError(props + ("source" to source) + ("method" to methodProp) + ("duration_ms" to durationMs))
                     }
                     if (BuildConfig.DEBUG) {
                         Log.w(TAG, "sign_in failed: reason=$reason props=$props", logtoException)
@@ -163,6 +190,7 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         }
         globalSettingsManager.setUserAvatarUrl(null)
         globalSettingsManager.setGithubIdentity(null, null)
+        globalSettingsManager.setUserEmail(null)
         globalSettingsManager.setIsPro(false)
         globalSettingsManager.clearSelectedChatModel()
         GithubTokenProvider.shared.clear()
@@ -232,10 +260,63 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         }
     }.getOrNull()
 
+    /**
+     * 登录发起时的 Logto 端点可达性探测（异步 fire-and-forget）：托管页/授权端点在 Custom Tab 里
+     * 加载失败时 SDK 收不到任何回调，只会表现为「用户取消」——可达性失败被系统性伪装成取消，
+     * 76% 取消率只能靠推测归因大陆可达性就是这个盲区造成的。
+     * 分析口径：可达性失败占比 ≈ auth_probe 失败率，用「probe 失败 × cancel_kind=wait」交叉验证。
+     *
+     * 任何 HTTP 状态码（含 4xx/5xx）都算 ok——只测「链路能不能通」，不测服务对错。
+     */
+    private fun trackAuthProbe(method: String) {
+        thread(isDaemon = true, name = "auth-probe") {
+            val startedAt = SystemClock.elapsedRealtime()
+            val result = try {
+                val connection = URL(LOGTO_ENDPOINT).openConnection() as HttpURLConnection
+                try {
+                    connection.requestMethod = "HEAD"
+                    connection.connectTimeout = AUTH_PROBE_TIMEOUT_MS
+                    connection.readTimeout = AUTH_PROBE_TIMEOUT_MS
+                    connection.responseCode
+                    "ok"
+                } finally {
+                    connection.disconnect()
+                }
+            } catch (_: SocketTimeoutException) {
+                "timeout"
+            } catch (_: Exception) {
+                "fail"
+            }
+            val latencyMs = SystemClock.elapsedRealtime() - startedAt
+            trackEvent(
+                "auth_probe",
+                mapOf(
+                    "result" to result,
+                    "method" to method,
+                    "latency_bucket" to probeLatencyBucket(latencyMs),
+                ),
+            )
+        }
+    }
+
     companion object {
         private const val TAG = "LogtoAuth"
         private const val LOGTO_APP_ID = "lasqslwwdjbim73vgkapj"
         private const val CLOCK_PROBE_TIMEOUT_MS = 3_000
+        private const val AUTH_PROBE_TIMEOUT_MS = 5_000
+
+        /** 托管页 first_screen / identifier 参数值（Logto OIDC 授权端点约定） */
+        private const val FIRST_SCREEN_IDENTIFIER_SIGN_IN = "identifier:sign_in"
+        private const val IDENTIFIER_EMAIL = "email"
+
+        /** auth_probe 延迟分桶：粒度比登录耗时桶细——探测本身 5s 超时，关注的是「页面级资源会不会太慢」 */
+        private fun probeLatencyBucket(latencyMs: Long): String = when {
+            latencyMs < 300 -> "lt_300ms"
+            latencyMs < 1_000 -> "300_1000ms"
+            latencyMs < 2_500 -> "1000_2500ms"
+            latencyMs < 5_000 -> "2500_5000ms"
+            else -> "gte_5s"
+        }
 
         /**
          * 长短取消的分界：短于此为 `quick`（授权页正常加载后主动拒绝），长于此为 `wait`

--- a/docs/superpowers/specs/2026-07-22-email-login-account-page-design.md
+++ b/docs/superpowers/specs/2026-07-22-email-login-account-page-design.md
@@ -9,7 +9,7 @@
 1. **登录可达性**：埋点显示 GitHub 登录取消率 76%，结构性原因是大陆 GitHub 可达性差；Google 同样不可达，只有邮箱验证码能真正解决。
 2. **余额可见性**：后端 `GET /api/quota` 已上线（balance / dailyGrant / resetAt / tier），但客户端从未调用，用户只能在 429 触顶后被动看到额度卡片。
 
-本期范围：**保留 Logto，新增邮箱验证码登录（Logto 托管登录页）；Profile 页重构为账户页，展示账户信息与配额**。仅 Android。
+本期范围：**保留 Logto，新增邮箱验证码登录（Logto 托管登录页）；Profile 页重构为账户页，展示账户信息与配额；登录链路补可达性埋点**（为未来 Logto vs 自研决策积累数据，见 3.1）。仅 Android。
 
 ## 已确认的决策
 
@@ -60,6 +60,17 @@
 - `SettingsManager` 持久化 email，登出清空；`setGithubIdentity` 接受 null。
 - 邮箱用户调 `LogtoAccountApi` 取 GitHub token 会失败——确认该路径静默降级、不弹错。
 - iOS `NoopAuthManager` 不变。
+
+### 3.1 登录可达性埋点
+
+目的：为未来「继续 Logto vs 自研登录」的决策积累判据——区分登录失败到底是**链路可达性问题**（托管页打不开/超时/网络错误，指向 Logto Cloud 在大陆不可达）还是**用户主动取消**（Custom Tab 被关掉）。该决策的失效条件之一就是「可达性失败占登录失败的大头」，没有这份数据，将来只能拍脑袋。
+
+现状盘点：`sign_in_error` 已带 `reason` 归因（`analyzeSignInFailure`：clock_skew / timeout / network / no_browser / config / other）+ `logto_type` + `cause`，`sign_in_canceled` 已带时长分桶与 `cancel_kind`（quick/wait）。**但存在一个结构性观测盲区：托管页在 Custom Tab 里加载失败（auth.trendingai.cn 不可达/超时）时，SDK 收不到任何回调，不会走 error 路径**——用户只能手动关掉 Custom Tab，被计入 `sign_in_canceled`。「可达性失败」被系统性伪装成「用户取消」，这正是取消率（76% 基线）只能靠推测归因大陆可达性的原因。本期补两点：
+
+- **登录发起时的可达性探测**：`signIn()` 触发时后台异步对 `auth.trendingai.cn` 发一个轻量探测请求（HEAD/GET，超时 5s，不阻塞登录流程），上报 `auth_probe` 事件（属性：`result` ok/timeout/fail + 延迟分桶）。与同一会话的登录结果交叉：probe 失败 + wait 型取消 ≈ 可达性失败——把盲区显性化；
+- **成功事件增加 `method` 属性**（`github` / `email`）：托管页内用户选了哪种方式客户端事前不可见，回调成功后从 claims 的 `identities` 有无 github 判断；同时作为邮箱登录渗透率的观测口径。
+
+分析口径：可达性失败占比 ≈ `auth_probe` 失败率，并用「probe 失败 × cancel_kind=wait」交叉验证；对照取消率基线，判断邮箱登录上线后失败结构的变化。这份数据是「继续 Logto vs 自研」失效条件第 1 条的直接判据。
 
 ### 4. 账户页重构（原 ProfileScreen）
 

--- a/docs/superpowers/specs/2026-07-22-email-login-account-page-design.md
+++ b/docs/superpowers/specs/2026-07-22-email-login-account-page-design.md
@@ -9,7 +9,7 @@
 1. **登录可达性**：埋点显示 GitHub 登录取消率 76%，结构性原因是大陆 GitHub 可达性差；Google 同样不可达，只有邮箱验证码能真正解决。
 2. **余额可见性**：后端 `GET /api/quota` 已上线（balance / dailyGrant / resetAt / tier），但客户端从未调用，用户只能在 429 触顶后被动看到额度卡片。
 
-本期范围：**保留 Logto，新增邮箱验证码登录（Logto 托管登录页）；Profile 页重构为账户页，展示账户信息与配额；登录链路补可达性埋点**（为未来 Logto vs 自研决策积累数据，见 3.1）。仅 Android。
+本期范围：**保留 Logto，新增邮箱验证码登录（原生选择器分流，邮箱走 Logto 托管页）；Profile 页重构为账户页，展示账户信息与配额；登录链路补可达性埋点**（为未来 Logto vs 自研决策积累数据，见 3.1）。仅 Android。
 
 ## 已确认的决策
 
@@ -17,7 +17,7 @@
 |---|---|
 | 方向 | 保留 Logto，增加登录方式（非替换、非纯展示） |
 | 新增登录方式 | 仅邮箱验证码（Google/微信/手机号不做） |
-| 登录交互 | Logto 托管登录页（signIn 去掉 directSignIn，页内同时提供邮箱与 GitHub） |
+| 登录交互 | 原生选择器分流：app 内底部选择（GitHub / 邮箱）；GitHub 保留 directSignIn 直达授权页（大陆存量路径零回退），邮箱经 firstScreen 直达托管页邮箱屏 |
 | Profile 形态 | 整体重构为账户页，GitHub 档案降为可选模块 |
 | 配额展示位置 | 仅账户页（chat 界面维持现状：触顶弹卡） |
 | 账户页数据获取 | 并行调 `GET /api/me` + `GET /api/quota` 两个现成端点，不新增聚合端点 |
@@ -39,7 +39,7 @@
 - **Email connector**：复用 Resend 通道——优先原生 Resend connector，没有则 SMTP connector 指向 `smtp.resend.com`（同一 API key 域名体系，发件人如 `noreply@trendingai.cn`），配中英验证码模板。
 - **登录体验**：identifier 增加 Email + 验证码（无密码）；GitHub 社交登录保留。
 - **账户自动关联**：若控制台提供「社交账号邮箱与已有邮箱账户相同则关联」选项则开启，堵住同一人先邮箱后 GitHub 登录产生双账户的分裂；没有该选项就接受双账户现状，不自建合并。
-- **配置时机**：Logto 只有生产实例，托管页配置即时生效；老版本客户端 directSignIn 直跳 GitHub 不经过托管页，开启 Email identifier 对存量用户无感。
+- **配置时机**：Logto 只有生产实例，托管页配置即时生效；新老客户端的 GitHub 路径都走 directSignIn 直跳、不经过托管页，开启 Email identifier 对存量用户无感，可先配后发版。
 
 ### 2. 后端改动（github-ai-trending-api，小改）
 
@@ -47,15 +47,17 @@
 - `me.js`：
   - `extractProfile` 提取 `claims.email`；
   - INSERT / UPDATE（github_user_id 对回原行路径）/ RETURNING 三处带上 email；
+  - upsert 的 email 更新用 `COALESCE(excluded.email, email)` 防 null 覆盖——存量会话的 token 无 email scope（scope 变更不追溯），多设备场景下老会话调 `/api/me` 会用 null 冲掉新登录设备已写入的 email；
   - `displayName` 兜底链改为 `claims.name ?? githubLogin ?? email 前缀`。
 - `pro.js`：`isProUser` 对 `githubUserId == null` 短路返回 false。
 - `/api/quota` 原样复用，零改动。
 
 ### 3. 客户端登录链路（Android）
 
-- `LogtoAuthManager`：
-  - scope 增加 `email`；
-  - `signIn()` 去掉 directSignIn 参数，改走 Logto 托管登录页。
+- 登录入口改为**原生底部选择器**（GitHub / 邮箱验证码），一次实现、各登录入口共用：
+  - GitHub → 沿用现有 directSignIn 直达授权页。**存量路径零回退**——directSignIn 当初就是为绕开托管页大陆加载慢（~490KB SPA、Cloudflare 边缘无境内节点，见 `LogtoAuthManager.kt:74-76` 注释）而加的优化，本方案保留它；
+  - 邮箱 → `SignInOptions` 带 `firstScreen`/`identifiers`（SDK 3.0.0-beta 已支持）打开托管页并直达邮箱输入屏，不经过托管页的方式选择步骤；
+- `LogtoAuthManager` scope 增加 `email`（两条路径同一配置）。
 - `MeResponse`/`MeUser` 增加可空 `email` 字段。
 - `SettingsManager` 持久化 email，登出清空；`setGithubIdentity` 接受 null。
 - 邮箱用户调 `LogtoAccountApi` 取 GitHub token 会失败——确认该路径静默降级、不弹错。
@@ -68,7 +70,7 @@
 现状盘点：`sign_in_error` 已带 `reason` 归因（`analyzeSignInFailure`：clock_skew / timeout / network / no_browser / config / other）+ `logto_type` + `cause`，`sign_in_canceled` 已带时长分桶与 `cancel_kind`（quick/wait）。**但存在一个结构性观测盲区：托管页在 Custom Tab 里加载失败（auth.trendingai.cn 不可达/超时）时，SDK 收不到任何回调，不会走 error 路径**——用户只能手动关掉 Custom Tab，被计入 `sign_in_canceled`。「可达性失败」被系统性伪装成「用户取消」，这正是取消率（76% 基线）只能靠推测归因大陆可达性的原因。本期补两点：
 
 - **登录发起时的可达性探测**：`signIn()` 触发时后台异步对 `auth.trendingai.cn` 发一个轻量探测请求（HEAD/GET，超时 5s，不阻塞登录流程），上报 `auth_probe` 事件（属性：`result` ok/timeout/fail + 延迟分桶）。与同一会话的登录结果交叉：probe 失败 + wait 型取消 ≈ 可达性失败——把盲区显性化；
-- **成功事件增加 `method` 属性**（`github` / `email`）：托管页内用户选了哪种方式客户端事前不可见，回调成功后从 claims 的 `identities` 有无 github 判断；同时作为邮箱登录渗透率的观测口径。
+- **登录事件全链路带 `method` 属性**（`github` / `email`）：原生选择器让用户意图在点击时即可见——`sign_in_start` / `sign_in_canceled` / `sign_in_error` 都带上选择器选中的 method（失败漏斗可按方式分段，这是选择器方案的附带收益）；`sign_in_success` 的 method 以 claims 的 `identities` 实判为准（意图与实际以实际为准）。method 同时作为邮箱登录渗透率的观测口径。
 
 分析口径：可达性失败占比 ≈ `auth_probe` 失败率，并用「probe 失败 × cancel_kind=wait」交叉验证；对照取消率基线，判断邮箱登录上线后失败结构的变化。这份数据是「继续 Logto vs 自研」失效条件第 1 条的直接判据。
 
@@ -84,6 +86,7 @@
 
 ### 5. 错误处理与兼容
 
+- **存量已登录用户完全无感**：Logto SDK 持久化存储的会话不受任何改动影响（控制台加登录方式不触碰已有会话，`signIn()` 改造只在主动登录时执行），不强制登出、不要求重登；Logto sub 不变，档案/额度/Pro 全部连续。唯一边角：存量会话 token 无 email scope，账户页邮箱行对他们暂空（null 即隐藏），自然重登后补齐。
 - quota 与 me 并行请求，各自独立错误态；me 失败沿用现有 Profile 错误处理。
 - 邮箱用户无 GitHub token：GitHub 模块隐藏，不弹错误。
 - 老客户端不受影响：登录链路只是托管页多了选项；旧版本 directSignIn 仍直跳 GitHub 可继续用。
@@ -97,7 +100,7 @@
 ### 7. 规模与提交策略
 
 - 后端 ~60 行 + 1 迁移，独立小 PR。
-- 客户端登录链路 ~30 行、账户页重构 ~400–600 行，属大改动，本分支（`feat/email-login-account-page`）走 PR。
+- 客户端登录链路（原生选择器 + 分流 + 埋点扩展）~150–250 行、账户页重构 ~400–600 行，属大改动，本分支（`feat/email-login-account-page`）走 PR。
 
 ## 明确不做
 

--- a/docs/superpowers/specs/2026-07-22-email-login-account-page-design.md
+++ b/docs/superpowers/specs/2026-07-22-email-login-account-page-design.md
@@ -1,0 +1,97 @@
+# 邮箱验证码登录 + 账户页重构 设计方案
+
+2026-07-22 · 状态：已评审通过，待实施
+
+## 背景与目标
+
+额度体系（账本 + 授予模型）与 Deep Research 上线后，登录体系需要从「解锁更高限额的开关」升级为可感知的账户体系。两个痛点：
+
+1. **登录可达性**：埋点显示 GitHub 登录取消率 76%，结构性原因是大陆 GitHub 可达性差；Google 同样不可达，只有邮箱验证码能真正解决。
+2. **余额可见性**：后端 `GET /api/quota` 已上线（balance / dailyGrant / resetAt / tier），但客户端从未调用，用户只能在 429 触顶后被动看到额度卡片。
+
+本期范围：**保留 Logto，新增邮箱验证码登录（Logto 托管登录页）；Profile 页重构为账户页，展示账户信息与配额**。仅 Android。
+
+## 已确认的决策
+
+| 决策点 | 结论 |
+|---|---|
+| 方向 | 保留 Logto，增加登录方式（非替换、非纯展示） |
+| 新增登录方式 | 仅邮箱验证码（Google/微信/手机号不做） |
+| 登录交互 | Logto 托管登录页（signIn 去掉 directSignIn，页内同时提供邮箱与 GitHub） |
+| Profile 形态 | 整体重构为账户页，GitHub 档案降为可选模块 |
+| 配额展示位置 | 仅账户页（chat 界面维持现状：触顶弹卡） |
+| 账户页数据获取 | 并行调 `GET /api/me` + `GET /api/quota` 两个现成端点，不新增聚合端点 |
+
+## 现状关键事实（探索结论）
+
+- 后端鉴权：Logto opaque token 在线校验（`src/lib/logto-auth.js` `requireAuth`，userinfo 结果按 token 哈希缓存 10 分钟）。
+- 计费身份：`identities` 表按 `user:{Logto sub}` 记账，与登录方式无关——邮箱用户自动进登录档（10 credits/天），**计费侧零改动**。
+- `app_users.github_user_id` 允许 NULL（SQLite UNIQUE 不限制多个 NULL），邮箱用户走 `me.js` INSERT upsert 路径结构上兼容；但表无 `email` 列，`extractProfile` 不提取 email。
+- Pro 权益按 `github_user_id` 挂靠（GitHub Sponsors webhook），邮箱用户天然非 Pro，逻辑自洽。
+- 客户端 Logto scope 目前仅 `identities`，拿 email claim 需加 `email` scope。
+- newsletter 已在用 Resend（`src/newsletter/index.js`），域名邮件通道现成。
+- 客户端 ProfileScreen 现定位「GitHub 开发者档案」（头像/资料/贡献热力图/活动流），无任何配额展示。
+
+## 设计
+
+### 1. Logto 控制台配置（不产代码）
+
+- **Email connector**：复用 Resend 通道——优先原生 Resend connector，没有则 SMTP connector 指向 `smtp.resend.com`（同一 API key 域名体系，发件人如 `noreply@trendingai.cn`），配中英验证码模板。
+- **登录体验**：identifier 增加 Email + 验证码（无密码）；GitHub 社交登录保留。
+- **账户自动关联**：若控制台提供「社交账号邮箱与已有邮箱账户相同则关联」选项则开启，堵住同一人先邮箱后 GitHub 登录产生双账户的分裂；没有该选项就接受双账户现状，不自建合并。
+- **配置时机**：Logto 只有生产实例，托管页配置即时生效；老版本客户端 directSignIn 直跳 GitHub 不经过托管页，开启 Email identifier 对存量用户无感。
+
+### 2. 后端改动（github-ai-trending-api，小改）
+
+- 迁移 030：`app_users` 加 `email TEXT` 列。**不加 UNIQUE**——Logto 是身份权威，email 仅为展示字段，避免重演删号重注册撞 UNIQUE 约束的老坑（见 me.js Fix 1 注释）。
+- `me.js`：
+  - `extractProfile` 提取 `claims.email`；
+  - INSERT / UPDATE（github_user_id 对回原行路径）/ RETURNING 三处带上 email；
+  - `displayName` 兜底链改为 `claims.name ?? githubLogin ?? email 前缀`。
+- `pro.js`：`isProUser` 对 `githubUserId == null` 短路返回 false。
+- `/api/quota` 原样复用，零改动。
+
+### 3. 客户端登录链路（Android）
+
+- `LogtoAuthManager`：
+  - scope 增加 `email`；
+  - `signIn()` 去掉 directSignIn 参数，改走 Logto 托管登录页。
+- `MeResponse`/`MeUser` 增加可空 `email` 字段。
+- `SettingsManager` 持久化 email，登出清空；`setGithubIdentity` 接受 null。
+- 邮箱用户调 `LogtoAccountApi` 取 GitHub token 会失败——确认该路径静默降级、不弹错。
+- iOS `NoopAuthManager` 不变。
+
+### 4. 账户页重构（原 ProfileScreen）
+
+信息架构从「GitHub 开发者档案」改为「账户页」，三段式：
+
+- **账户区**（所有登录用户）：头像（无头像用邮箱/名称首字母圆形占位）、显示名、邮箱行、档位徽章（Free / Pro）。
+- **配额卡**：新增 `TrendingApi.fetchQuota()` 调 `GET /api/quota`（带 `X-Install-Id` + Bearer），展示余额 / 每日额度进度、UTC 重置倒计时、档位。每次进入页面实时拉取不走缓存（余额要新鲜），下拉刷新一并刷新；quota 请求失败只降级这张卡（占位/错误态），不阻塞账户区。
+- **GitHub 模块**：有 GitHub 身份 → 现有内容（计数行、贡献热力图、活动流）整体收进模块，行为不变；无 GitHub 身份 → 整块隐藏。
+- 未登录态引导不变。
+- UI 遵循项目规范：加载态一律 M3 Expressive `LoadingIndicator`，下拉刷新显式传 `indicator`。
+
+### 5. 错误处理与兼容
+
+- quota 与 me 并行请求，各自独立错误态；me 失败沿用现有 Profile 错误处理。
+- 邮箱用户无 GitHub token：GitHub 模块隐藏，不弹错误。
+- 老客户端不受影响：登录链路只是托管页多了选项；旧版本 directSignIn 仍直跳 GitHub 可继续用。
+- 计费/额度语义不变，`QuotaLimitCard` 触顶体系维持现状。
+
+### 6. 测试与验收
+
+- 后端：`tests/api/` 补 `me` 的「无 GitHub identity claims」用例（email 用户建档、pro=false、null 字段兜底）。
+- 客户端：debug 包 Pixel_9_2 冒烟——邮箱验证码登录 → 账户页显示邮箱 + 配额卡；GitHub 登录全量回归（档案模块、贡献图、活动流）；发版前照常跑 `scripts/release-smoke.sh`。
+
+### 7. 规模与提交策略
+
+- 后端 ~60 行 + 1 迁移，独立小 PR。
+- 客户端登录链路 ~30 行、账户页重构 ~400–600 行，属大改动，本分支（`feat/email-login-account-page`）走 PR。
+
+## 明确不做
+
+- 应用内绑定/解绑 GitHub（靠 Logto 自动关联部分覆盖，后续再议）
+- Google / 微信 / 手机号登录
+- chat 界面常驻配额展示
+- me + quota 聚合端点
+- iOS 登录接入

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -161,7 +161,12 @@
     <string name="sign_in_value_star">一键 Star 喜欢的仓库</string>
     <string name="sign_in_value_chat">更多 AI 对话额度与深度解读</string>
     <string name="sign_in_value_profile">查看你的 GitHub 主页与关注动态</string>
-    <string name="sign_in_value_footer">将跳转浏览器完成 GitHub 授权，只需片刻。</string>
+    <string name="sign_in_value_footer">将跳转浏览器完成登录，只需片刻。</string>
+    <string name="sign_in_method_title">登录 TrendingAI</string>
+    <string name="sign_in_method_github">使用 GitHub 登录</string>
+    <string name="sign_in_method_github_desc">跳转浏览器完成授权</string>
+    <string name="sign_in_method_email">使用邮箱验证码登录</string>
+    <string name="sign_in_method_email_desc">验证码将发送至你的邮箱，无需密码</string>
     <string name="sign_in_value_dismiss">暂不</string>
     <string name="sign_in_hint_title">登录未完成</string>
     <string name="sign_in_hint_connectivity">GitHub 登录需要能正常访问 github.com，请检查网络后重试。</string>
@@ -174,6 +179,12 @@
     <string name="profile_repos">仓库</string>
     <string name="profile_pro_badge">PRO</string>
     <string name="profile_pro_badge_desc">Pro 会员</string>
+    <string name="profile_quota_title">AI 额度</string>
+    <string name="profile_quota_remaining">今日剩余 %1$d / %2$d</string>
+    <string name="profile_quota_reset_hours">约 %1$d 小时后重置</string>
+    <string name="profile_quota_reset_soon">1 小时内重置</string>
+    <string name="profile_quota_rates">对话 1 · 搜索 3 · 研究 10</string>
+    <string name="profile_quota_error">额度信息暂时无法获取</string>
     <string name="contrib_total">最近一年 %1$s 次贡献</string>
     <string name="contrib_less">少</string>
     <string name="contrib_more">多</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -161,7 +161,12 @@
     <string name="sign_in_value_star">Star repos you like with one tap</string>
     <string name="sign_in_value_chat">More AI chats a day, plus in-depth overviews</string>
     <string name="sign_in_value_profile">Your GitHub profile and network activity</string>
-    <string name="sign_in_value_footer">You&apos;ll be taken to your browser to sign in with GitHub — it only takes a moment.</string>
+    <string name="sign_in_value_footer">You&apos;ll be taken to your browser to sign in — it only takes a moment.</string>
+    <string name="sign_in_method_title">Sign in to TrendingAI</string>
+    <string name="sign_in_method_github">Continue with GitHub</string>
+    <string name="sign_in_method_github_desc">Authorize in your browser</string>
+    <string name="sign_in_method_email">Continue with email</string>
+    <string name="sign_in_method_email_desc">We&apos;ll send a verification code — no password needed</string>
     <string name="sign_in_value_dismiss">Not now</string>
     <string name="sign_in_hint_title">Sign-in not completed</string>
     <string name="sign_in_hint_connectivity">GitHub sign-in needs to reach github.com. Please check your connection and try again.</string>
@@ -173,6 +178,12 @@
     <string name="profile_following">Following</string>
     <string name="profile_repos">Repos</string>
     <string name="profile_pro_badge">PRO</string>
+    <string name="profile_quota_title">AI credits</string>
+    <string name="profile_quota_remaining">%1$d of %2$d credits left today</string>
+    <string name="profile_quota_reset_hours">Resets in ~%1$d h</string>
+    <string name="profile_quota_reset_soon">Resets within an hour</string>
+    <string name="profile_quota_rates">Chat 1 · Search 3 · Research 10</string>
+    <string name="profile_quota_error">Couldn&apos;t load credits right now</string>
     <string name="profile_pro_badge_desc">Pro member</string>
     <string name="contrib_total">%1$s contributions in the last year</string>
     <string name="contrib_less">Less</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/auth/AuthManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/auth/AuthManager.kt
@@ -46,6 +46,32 @@ object SignInFailureBus {
     }
 }
 
+/** 登录方式：GitHub 走 directSignIn 直达授权页；邮箱走托管页验证码（first_screen 直达邮箱输入屏） */
+enum class SignInMethod { GITHUB, EMAIL }
+
+/**
+ * 登录方式选择请求总线：`signIn(source)` 不再直接拉起授权，而是发布一个「待选择」请求，
+ * 由 App 根部的 SignInMethodChooserHost 弹底部选择器，选中后回调 `signIn(source, method)`。
+ * 好处：6 个登录入口零改动，选择器 UI 只实现一次（同 [SignInFailureBus] 的根部宿主思路）。
+ *
+ * 用 StateFlow 而非 SharedFlow：选择器是「当前是否有待选请求」的状态而非事件流，
+ * 配置变更重建后收集者能立刻恢复弹窗（replay 语义天然成立）。
+ */
+object SignInChooserBus {
+    private val _request = MutableStateFlow<String?>(null)
+
+    /** 当前待选择的登录来源（null = 无待选请求） */
+    val request: StateFlow<String?> = _request
+
+    fun request(source: String) {
+        _request.value = source
+    }
+
+    fun clear() {
+        _request.value = null
+    }
+}
+
 /**
  * 登录态抽象：shared/UI 只依赖本接口，Logto SDK 只存在于 androidApp。
  * iOS 未接入前使用 NoopAuthManager（isSupported=false，UI 隐藏登录入口）。
@@ -55,8 +81,15 @@ interface AuthManager {
     val isSupported: Boolean
     val authState: StateFlow<AuthState>
 
-    /** @param source 登录入口标识（如 "home_avatar"），随 sign_in_start/success/canceled/error 埋点上报做入口归因 */
+    /**
+     * 请求登录：发布到 [SignInChooserBus]，待用户在根部选择器里选定方式后进入 [signIn] 双参重载。
+     * @param source 登录入口标识（如 "home_avatar"），随 sign_in_* 埋点上报做入口归因
+     */
     fun signIn(source: String)
+
+    /** 以指定方式拉起授权流程（选择器回调；亦可跳过选择器直接指定方式） */
+    fun signIn(source: String, method: SignInMethod)
+
     fun signOut()
     suspend fun getAccessToken(): String?
 }
@@ -65,6 +98,7 @@ object NoopAuthManager : AuthManager {
     override val isSupported: Boolean = false
     override val authState: StateFlow<AuthState> = MutableStateFlow(AuthState.LoggedOut)
     override fun signIn(source: String) {}
+    override fun signIn(source: String, method: SignInMethod) {}
     override fun signOut() {}
     override suspend fun getAccessToken(): String? = null
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
@@ -33,6 +33,7 @@ import whl.trending.ai.chat.globalChatScreen
 import whl.trending.ai.core.platform.openUrl
 import whl.trending.ai.ui.common.ForceUpdateGate
 import whl.trending.ai.ui.common.SignInHintHost
+import whl.trending.ai.ui.common.SignInMethodChooserHost
 import whl.trending.ai.ui.common.WhatsNewHost
 
 data object Home
@@ -85,6 +86,7 @@ fun App() {
             ForceUpdateGate {
                 WhatsNewHost()
                 SignInHintHost()
+                SignInMethodChooserHost()
                 NavDisplay(
                     backStack = backStack,
                     onBack = { backStack.safePop() },

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/DateTimeUtils.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/DateTimeUtils.kt
@@ -35,6 +35,18 @@ object DateTimeUtils {
         }
     }
 
+    /**
+     * 距未来时刻的剩余整小时数（向上取整；已过期返回 0）。解析失败返回 null。
+     * 用于配额卡「约 N 小时后重置」——分钟级精度对每日重置没有意义，不做倒计时刷新。
+     */
+    fun hoursUntil(utcString: String, now: Instant = Clock.System.now()): Int? {
+        val instant = parseInstantOrNull(utcString) ?: return null
+        val diff = instant - now
+        if (diff.isNegative()) return 0
+        val whole = diff.inWholeHours
+        return if (diff - whole.hours > kotlin.time.Duration.ZERO) (whole + 1).toInt() else whole.toInt()
+    }
+
     private fun parseInstantOrNull(utcString: String): Instant? {
         if (utcString.isEmpty()) return null
         return try {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -72,6 +72,7 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val USER_AVATAR_KEY = "prefs_user_avatar_url"
     private val USER_GITHUB_LOGIN_KEY = "prefs_user_github_login"
     private val USER_GITHUB_USER_ID_KEY = "prefs_user_github_user_id"
+    private val USER_EMAIL_KEY = "prefs_user_email"
     private val FEED_HIGHLIGHTS_ONLY_KEY = "prefs_feed_filter_highlights"
     private val IS_PRO_KEY = "prefs_is_pro"
     private val SPONSOR_PAGE_OPENED_AT_KEY = "prefs_sponsor_page_opened_at"
@@ -244,6 +245,17 @@ class SettingsManager(private val settings: ObservableSettings) {
             settings.remove(USER_GITHUB_USER_ID_KEY)
         } else {
             settings.putLong(USER_GITHUB_USER_ID_KEY, userId)
+        }
+    }
+
+    /** 已登录用户邮箱缓存：/api/me 写入、登出清除。存量会话的 token 无 email scope 时为 null（不追溯）。 */
+    val userEmail: Flow<String?> = settings.getStringOrNullFlow(USER_EMAIL_KEY)
+
+    fun setUserEmail(email: String?) {
+        if (email.isNullOrBlank()) {
+            settings.remove(USER_EMAIL_KEY)
+        } else {
+            settings.putString(USER_EMAIL_KEY, email)
         }
     }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/Me.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/Me.kt
@@ -23,5 +23,23 @@ data class MeUser(
     @SerialName("avatar_url") val avatarUrl: String? = null,
     val bio: String? = null,
     @SerialName("html_url") val htmlUrl: String? = null,
+    /** 登录邮箱；存量会话的 token 无 email scope 时为 null（重登后补齐），GitHub 用户亦可能无 */
+    val email: String? = null,
     @SerialName("created_at") val createdAt: String? = null,
+)
+
+/**
+ * GET /api/quota 响应：credits 余额可见性（查询顺带完成当日懒授予，返回即真实余额）。
+ * 消耗参考费率：普通对话 1 / 联网搜索 3 / Deep Research 10 credits。
+ */
+@Serializable
+data class QuotaResponse(
+    /** 当前 credits 余额 */
+    val balance: Int,
+    /** 当前档位的每日授予额（anonymous 5 / user 10 / pro 100） */
+    val dailyGrant: Int,
+    /** 下次授予（UTC 零点重置）时间，ISO-8601 */
+    val resetAt: String,
+    /** 档位：anonymous / user / pro */
+    val tier: String,
 )

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -8,6 +8,7 @@ import whl.trending.ai.data.model.ChatModelsResponse
 import whl.trending.ai.data.model.MeResponse
 import whl.trending.ai.data.model.ProRefreshResponse
 import whl.trending.ai.data.model.PicksResponse
+import whl.trending.ai.data.model.QuotaResponse
 import whl.trending.ai.data.model.ReadmeResponse
 import whl.trending.ai.data.model.SubscribeResponse
 import whl.trending.ai.data.model.TrendingResponse
@@ -154,6 +155,21 @@ open class TrendingApi {
             throw ApiException(response.status.value, response.bodyAsText())
         }
         return response.body<MeResponse>()
+    }
+
+    /**
+     * credits 余额查询（账户页配额卡）。X-Install-Id 必传（匿名记账主体）；
+     * 已登录再带 Bearer——服务端按 user 主体与档位返回。响应服务端禁缓存，每次都是实时余额。
+     */
+    open suspend fun fetchQuota(installId: String, accessToken: String?): QuotaResponse {
+        val response = client.get("$baseHost/api/quota") {
+            header("X-Install-Id", installId)
+            accessToken?.let { header(HttpHeaders.Authorization, "Bearer $it") }
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<QuotaResponse>()
     }
 
     /** 即时激活/对账：后端权威核对赞助并 upsert，返回最新 Pro 态。用户从 Sponsors 返回时调用。 */

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
@@ -3,6 +3,7 @@ package whl.trending.ai.data.repository
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.MeResponse
 import whl.trending.ai.data.model.MeUser
+import whl.trending.ai.data.model.QuotaResponse
 import whl.trending.ai.data.remote.TrendingApi
 
 // open：便于测试以子类替身注入（保持手动 DI，不引入 mock 框架）
@@ -15,6 +16,13 @@ open class UserRepository(private val api: TrendingApi = TrendingApi()) {
     open suspend fun fetchMe(accessToken: String): MeUser = fetchMeResponse(accessToken).user
 
     /**
+     * credits 余额（账户页配额卡）。X-Install-Id 恒传（匿名记账主体）；token 可空——
+     * 服务端据此定档。不做缓存：余额是每次请求都在变的个人数据，进页即拉实时值。
+     */
+    open suspend fun fetchQuota(accessToken: String?): QuotaResponse =
+        api.fetchQuota(globalSettingsManager.getOrCreateInstallId(), accessToken)
+
+    /**
      * 登录成功/应用启动（已登录）时调用：服务端建档 + 刷新 last_login_at，并缓存头像与 Pro 权益态。
      * 失败静默——下次打开 Profile 仍会重试，不阻塞登录主流程。
      */
@@ -24,6 +32,7 @@ open class UserRepository(private val api: TrendingApi = TrendingApi()) {
             val me = fetchMeResponse(accessToken)
             globalSettingsManager.setUserAvatarUrl(me.user.avatarUrl)
             globalSettingsManager.setGithubIdentity(me.user.githubLogin, me.user.githubUserId)
+            globalSettingsManager.setUserEmail(me.user.email)
             globalSettingsManager.setIsPro(me.pro)
             me.user
         } catch (e: Exception) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SignInMethodChooserHost.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SignInMethodChooserHost.kt
@@ -1,0 +1,104 @@
+package whl.trending.ai.ui.common
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Email
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.sign_in_method_email
+import trendingai.shared.generated.resources.sign_in_method_email_desc
+import trendingai.shared.generated.resources.sign_in_method_github
+import trendingai.shared.generated.resources.sign_in_method_github_desc
+import trendingai.shared.generated.resources.sign_in_method_title
+import whl.trending.ai.auth.SignInChooserBus
+import whl.trending.ai.auth.SignInMethod
+import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.ui.home.githubLogoPainter
+
+/**
+ * 登录方式选择器宿主：收集 [SignInChooserBus] 的待选请求弹底部选择（GitHub / 邮箱验证码），
+ * 选中后回调 `signIn(source, method)` 拉起对应授权流程。
+ *
+ * 放在 App 根部（与 SignInHintHost 平级）：登录入口有 6 处（首页头像 / star Snackbar ×2 /
+ * chat 配额卡 ×2 / 图片理解弹窗），总线 + 根部宿主让所有入口零改动共享同一选择器。
+ *
+ * 埋点：shown/dismiss 记录选择器层的流失；方式一经选中，后续 sign_in_start/success/canceled/error
+ * 全部带 method 属性（见 LogtoAuthManager）——失败漏斗从此可按登录方式分段。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SignInMethodChooserHost() {
+    val source by SignInChooserBus.request.collectAsState()
+    val pendingSource = source ?: return
+
+    LaunchedEffect(pendingSource) {
+        trackEvent("sign_in_method_shown", mapOf("source" to pendingSource))
+    }
+
+    val choose = { method: SignInMethod ->
+        SignInChooserBus.clear()
+        globalAuthManager.signIn(pendingSource, method)
+    }
+    ModalBottomSheet(
+        onDismissRequest = {
+            trackEvent("sign_in_method_dismiss", mapOf("source" to pendingSource))
+            SignInChooserBus.clear()
+        },
+    ) {
+        Column(Modifier.navigationBarsPadding().padding(bottom = 16.dp)) {
+            Text(
+                text = stringResource(Res.string.sign_in_method_title),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+            )
+            ListItem(
+                headlineContent = { Text(stringResource(Res.string.sign_in_method_github)) },
+                supportingContent = { Text(stringResource(Res.string.sign_in_method_github_desc)) },
+                leadingContent = {
+                    Icon(
+                        painter = githubLogoPainter(),
+                        contentDescription = null,
+                        tint = Color.Unspecified,
+                        modifier = Modifier.size(24.dp),
+                    )
+                },
+                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                modifier = Modifier.fillMaxWidth().clickable { choose(SignInMethod.GITHUB) },
+            )
+            ListItem(
+                headlineContent = { Text(stringResource(Res.string.sign_in_method_email)) },
+                supportingContent = { Text(stringResource(Res.string.sign_in_method_email_desc)) },
+                leadingContent = {
+                    Icon(
+                        imageVector = Icons.Outlined.Email,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(24.dp),
+                    )
+                },
+                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                modifier = Modifier.fillMaxWidth().clickable { choose(SignInMethod.EMAIL) },
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -1,5 +1,6 @@
 package whl.trending.ai.ui.profile
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -25,7 +26,9 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -96,6 +99,12 @@ import trendingai.shared.generated.resources.feed_unavailable
 import trendingai.shared.generated.resources.profile_followers
 import trendingai.shared.generated.resources.profile_following
 import trendingai.shared.generated.resources.profile_load_failed
+import trendingai.shared.generated.resources.profile_quota_error
+import trendingai.shared.generated.resources.profile_quota_rates
+import trendingai.shared.generated.resources.profile_quota_remaining
+import trendingai.shared.generated.resources.profile_quota_reset_hours
+import trendingai.shared.generated.resources.profile_quota_reset_soon
+import trendingai.shared.generated.resources.profile_quota_title
 import trendingai.shared.generated.resources.profile_repos
 import trendingai.shared.generated.resources.profile_retry
 import trendingai.shared.generated.resources.profile_title
@@ -107,6 +116,7 @@ import trendingai.shared.generated.resources.time_just_now
 import trendingai.shared.generated.resources.time_minutes_ago
 import whl.trending.ai.core.DateTimeUtils
 import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.model.QuotaResponse
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -208,60 +218,70 @@ fun ProfileScreen(
                         onOpenRepos = onOpenRepos,
                     )
                 }
+                if (uiState.quota != null || uiState.quotaError) {
+                    item(key = "quota") {
+                        QuotaCard(quota = uiState.quota, quotaError = uiState.quotaError)
+                    }
+                }
+                // GitHub 档案模块（计数行在 header 内、热力图、动态流）整体只对有 GitHub 身份的
+                // 用户呈现；邮箱登录用户无 GitHub 身份，整块隐藏而非展示「动态不可用」占位
+                val hasGithub = uiState.user?.githubLogin != null
                 uiState.contributions?.let { calendar ->
                     item(key = "contributions") {
                         ContributionGraph(calendar, scrollState = contributionScrollState)
                         HorizontalDivider(thickness = 0.5.dp)
                     }
                 }
-                item(key = "feed_filter") {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        FilterChip(
-                            selected = uiState.highlightsOnly,
-                            onClick = { if (!uiState.highlightsOnly) viewModel.setFeedFilter(true) },
-                            label = { Text(stringResource(Res.string.feed_filter_highlights)) }
-                        )
-                        FilterChip(
-                            selected = !uiState.highlightsOnly,
-                            onClick = { if (uiState.highlightsOnly) viewModel.setFeedFilter(false) },
-                            label = { Text(stringResource(Res.string.feed_filter_all)) }
-                        )
-                        Spacer(Modifier.weight(1f))
-                        IconButton(onClick = { showRulesSheet = true }) {
-                            Icon(
-                                Icons.Outlined.Info,
-                                contentDescription = stringResource(Res.string.feed_rules_title),
+                if (hasGithub) {
+                    item(key = "feed_filter") {
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            FilterChip(
+                                selected = uiState.highlightsOnly,
+                                onClick = { if (!uiState.highlightsOnly) viewModel.setFeedFilter(true) },
+                                label = { Text(stringResource(Res.string.feed_filter_highlights)) }
                             )
+                            FilterChip(
+                                selected = !uiState.highlightsOnly,
+                                onClick = { if (uiState.highlightsOnly) viewModel.setFeedFilter(false) },
+                                label = { Text(stringResource(Res.string.feed_filter_all)) }
+                            )
+                            Spacer(Modifier.weight(1f))
+                            IconButton(onClick = { showRulesSheet = true }) {
+                                Icon(
+                                    Icons.Outlined.Info,
+                                    contentDescription = stringResource(Res.string.feed_rules_title),
+                                )
+                            }
                         }
                     }
-                }
-                if (uiState.feedUnavailable && uiState.feedItems.isEmpty()) {
-                    item(key = "feed_unavailable") {
-                        FeedNotice(stringResource(Res.string.feed_unavailable))
-                    }
-                } else if (uiState.feedItems.isEmpty() && uiState.feedEndReached) {
-                    item(key = "feed_empty") {
-                        FeedNotice(stringResource(Res.string.feed_empty))
-                    }
-                }
-                items(uiState.feedItems, key = { it.id }) { item ->
-                    GithubFeedRow(item = item, onClick = { uriHandler.openUri(item.targetUrl) })
-                    HorizontalDivider(thickness = 0.5.dp)
-                }
-                if (uiState.isFeedLoadingVisible) {
-                    item(key = "feed_loading") {
-                        Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
-                            LoadingIndicator(modifier = Modifier.size(32.dp))
+                    if (uiState.feedUnavailable && uiState.feedItems.isEmpty()) {
+                        item(key = "feed_unavailable") {
+                            FeedNotice(stringResource(Res.string.feed_unavailable))
+                        }
+                    } else if (uiState.feedItems.isEmpty() && uiState.feedEndReached) {
+                        item(key = "feed_empty") {
+                            FeedNotice(stringResource(Res.string.feed_empty))
                         }
                     }
-                }
-                if (uiState.feedEndReached && uiState.feedItems.isNotEmpty()) {
-                    item(key = "feed_end") {
-                        FeedNotice(stringResource(Res.string.feed_end_notice))
+                    items(uiState.feedItems, key = { it.id }) { item ->
+                        GithubFeedRow(item = item, onClick = { uriHandler.openUri(item.targetUrl) })
+                        HorizontalDivider(thickness = 0.5.dp)
+                    }
+                    if (uiState.isFeedLoadingVisible) {
+                        item(key = "feed_loading") {
+                            Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                                LoadingIndicator(modifier = Modifier.size(32.dp))
+                            }
+                        }
+                    }
+                    if (uiState.feedEndReached && uiState.feedItems.isNotEmpty()) {
+                        item(key = "feed_end") {
+                            FeedNotice(stringResource(Res.string.feed_end_notice))
+                        }
                     }
                 }
             }
@@ -356,11 +376,30 @@ private fun ProfileHeader(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        AsyncImage(
-            model = user.avatarUrl,
-            contentDescription = null,
-            modifier = Modifier.size(96.dp).clip(CircleShape)
-        )
+        if (user.avatarUrl != null) {
+            AsyncImage(
+                model = user.avatarUrl,
+                contentDescription = null,
+                modifier = Modifier.size(96.dp).clip(CircleShape)
+            )
+        } else {
+            // 邮箱登录用户无头像：显示名/邮箱首字母的圆形占位
+            val initial = (user.displayName ?: user.email ?: "?")
+                .firstOrNull()?.uppercase() ?: "?"
+            Box(
+                modifier = Modifier
+                    .size(96.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    initial,
+                    style = MaterialTheme.typography.displaySmall,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
+        }
         val isPro by globalSettingsManager.isPro.collectAsState(
             initial = globalSettingsManager.currentIsPro()
         )
@@ -370,7 +409,7 @@ private fun ProfileHeader(
             horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
         ) {
             Text(
-                user.displayName ?: user.githubLogin.orEmpty(),
+                user.displayName ?: user.githubLogin ?: user.email.orEmpty(),
                 style = MaterialTheme.typography.titleLarge,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
@@ -385,6 +424,14 @@ private fun ProfileHeader(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+        // 登录邮箱：与显示名不同时才展示（displayName 兜底到邮箱时避免同串重复）
+        user.email?.takeIf { it.isNotBlank() && it != user.displayName }?.let {
+            Text(
+                it,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
         user.bio?.takeIf { it.isNotBlank() }?.let {
             Text(it, style = MaterialTheme.typography.bodyMedium, textAlign = TextAlign.Center)
         }
@@ -394,6 +441,62 @@ private fun ProfileHeader(
                 CountCell(gh.following, stringResource(Res.string.profile_following), onClick = onOpenFollowing)
                 CountCell(gh.publicRepos, stringResource(Res.string.profile_repos), onClick = onOpenRepos)
             }
+        }
+    }
+}
+
+/**
+ * 配额卡：credits 余额可见性（余额/每日额度/重置时间/费率说明）。
+ * quota 为 null 且 quotaError 时展示错误占位；数据加载由 ViewModel 与整页解耦，失败不影响其余部分。
+ */
+@Composable
+private fun QuotaCard(quota: QuotaResponse?, quotaError: Boolean) {
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                stringResource(Res.string.profile_quota_title),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            if (quota == null) {
+                if (quotaError) {
+                    Text(
+                        stringResource(Res.string.profile_quota_error),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                return@Column
+            }
+            Text(
+                stringResource(Res.string.profile_quota_remaining, quota.balance, quota.dailyGrant),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            LinearProgressIndicator(
+                progress = {
+                    if (quota.dailyGrant <= 0) 0f
+                    else (quota.balance.toFloat() / quota.dailyGrant).coerceIn(0f, 1f)
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            val resetHours = remember(quota.resetAt) { DateTimeUtils.hoursUntil(quota.resetAt) }
+            val resetText = when {
+                resetHours == null -> null
+                resetHours <= 1 -> stringResource(Res.string.profile_quota_reset_soon)
+                else -> stringResource(Res.string.profile_quota_reset_hours, resetHours)
+            }
+            Text(
+                listOfNotNull(resetText, stringResource(Res.string.profile_quota_rates))
+                    .joinToString(" · "),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -403,13 +403,15 @@ private fun ProfileHeader(
         val isPro by globalSettingsManager.isPro.collectAsState(
             initial = globalSettingsManager.currentIsPro()
         )
+        // 标题回落链：显示名 → GitHub 用户名 → 邮箱。抽成变量供下方邮箱行去重复用。
+        val titleText = user.displayName ?: user.githubLogin ?: user.email.orEmpty()
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
         ) {
             Text(
-                user.displayName ?: user.githubLogin ?: user.email.orEmpty(),
+                titleText,
                 style = MaterialTheme.typography.titleLarge,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
@@ -424,8 +426,9 @@ private fun ProfileHeader(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        // 登录邮箱：与显示名不同时才展示（displayName 兜底到邮箱时避免同串重复）
-        user.email?.takeIf { it.isNotBlank() && it != user.displayName }?.let {
+        // 登录邮箱：仅当标题没有回落到邮箱时才单独展示——displayName 与 githubLogin 均缺失
+        // （如后端 displayName 回填部署前建的老会话）时标题已是邮箱，避免头部重复两遍
+        user.email?.takeIf { it.isNotBlank() && it != titleText }?.let {
             Text(
                 it,
                 style = MaterialTheme.typography.bodyMedium,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -226,13 +226,13 @@ fun ProfileScreen(
                 // GitHub 档案模块（计数行在 header 内、热力图、动态流）整体只对有 GitHub 身份的
                 // 用户呈现；邮箱登录用户无 GitHub 身份，整块隐藏而非展示「动态不可用」占位
                 val hasGithub = uiState.user?.githubLogin != null
-                uiState.contributions?.let { calendar ->
-                    item(key = "contributions") {
-                        ContributionGraph(calendar, scrollState = contributionScrollState)
-                        HorizontalDivider(thickness = 0.5.dp)
-                    }
-                }
                 if (hasGithub) {
+                    uiState.contributions?.let { calendar ->
+                        item(key = "contributions") {
+                            ContributionGraph(calendar, scrollState = contributionScrollState)
+                            HorizontalDivider(thickness = 0.5.dp)
+                        }
+                    }
                     item(key = "feed_filter") {
                         Row(
                             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -21,6 +21,7 @@ import whl.trending.ai.data.local.globalLastDataCache
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.ContributionCalendar
 import whl.trending.ai.data.model.MeUser
+import whl.trending.ai.data.model.QuotaResponse
 import whl.trending.ai.data.remote.GithubApi
 import whl.trending.ai.data.remote.GithubUser
 import whl.trending.ai.data.repository.UserRepository
@@ -36,6 +37,10 @@ data class ProfileUiState(
     val isRefreshing: Boolean = false,
     val user: MeUser? = null,
     val isError: Boolean = false,
+    /** credits 余额（账户页配额卡）；加载中/失败为 null，失败态由 [quotaError] 区分 */
+    val quota: QuotaResponse? = null,
+    /** quota 拉取失败且无旧值可展示：配额卡显示错误占位，不影响页面其余部分 */
+    val quotaError: Boolean = false,
     /** GitHub 实时计数；token 不可用或请求失败时为 null（UI 隐藏计数行） */
     val githubUser: GithubUser? = null,
     /** 最近一年贡献日历；加载中或不可用时为 null（UI 隐藏热力图） */
@@ -116,6 +121,9 @@ class ProfileViewModel(
     }
 
     fun load() {
+        // 余额每次进页都拉实时值（独立协程，不受下方跳过逻辑影响）：
+        // 聊天消耗发生在页面之外，跳过整页重载时余额仍需刷新
+        viewModelScope.launch { loadQuota() }
         // 已加载过且数据健在（非错误态）则跳过：用于从子页返回时不重拉
         val current = _uiState.value
         if (hasLoaded && current.user != null && !current.isError) return
@@ -291,8 +299,24 @@ class ProfileViewModel(
     fun refresh() {
         loadJob?.cancel()
         feedLoadJob?.cancel()
+        viewModelScope.launch { loadQuota() }
         loadJob = viewModelScope.launch {
             refreshInternal()
+        }
+    }
+
+    /**
+     * 拉取 credits 余额：与整页加载解耦，失败只降级配额卡（保留旧值时不置错误态），
+     * 不影响档案与 feed。quota 不进 ProfileCache——余额要新鲜，SWR 快照对它是误导。
+     */
+    private suspend fun loadQuota() {
+        val token = authManager().getAccessToken()
+        try {
+            val quota = repository.fetchQuota(token)
+            _uiState.value = _uiState.value.copy(quota = quota, quotaError = false)
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            _uiState.value = _uiState.value.copy(quotaError = _uiState.value.quota == null)
         }
     }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -132,41 +132,61 @@ class ProfileViewModel(
         loadJob = viewModelScope.launch {
             val highlightsOnly = settingsManager.currentFeedHighlightsOnly()
 
+            // 整页重建期间保留 quota 字段：loadQuota 与本协程并行，quota 先到时若被下面的
+            // 整对象重建抹掉，配额卡会静默消失（登出重登后首次进页必现的竞态）。
+            // 读取放在写入时刻而非提前快照，尽量窄化与 loadQuota 写入交错的窗口。
+            fun freshState(build: (quota: QuotaResponse?, quotaError: Boolean) -> ProfileUiState) {
+                val s = _uiState.value
+                _uiState.value = build(s.quota, s.quotaError)
+            }
+
             // SWR：有缓存整页秒出（header/计数/热力图/feed）+ 顶部指示器自动刷新
             val cached = cache.get<ProfileCache>(ProfileCache.KEY)
             if (cached != null) {
-                _uiState.value = ProfileUiState(
-                    isLoading = false,
-                    user = cached.user,
-                    githubUser = cached.githubUser,
-                    contributions = cached.contributions,
-                    // feed 与档位绑定，档位不一致时不复用（只用 header 部分，feed 走加载态）
-                    feedItems = if (cached.highlightsOnly == highlightsOnly) cached.feedItems else emptyList(),
-                    highlightsOnly = highlightsOnly,
-                )
+                freshState { quota, quotaError ->
+                    ProfileUiState(
+                        isLoading = false,
+                        user = cached.user,
+                        githubUser = cached.githubUser,
+                        contributions = cached.contributions,
+                        // feed 与档位绑定，档位不一致时不复用（只用 header 部分，feed 走加载态）
+                        feedItems = if (cached.highlightsOnly == highlightsOnly) cached.feedItems else emptyList(),
+                        highlightsOnly = highlightsOnly,
+                        quota = quota,
+                        quotaError = quotaError,
+                    )
+                }
                 hasLoaded = true
                 refreshInternal()
                 return@launch
             }
 
-            _uiState.value = ProfileUiState(isLoading = true, highlightsOnly = highlightsOnly)
+            freshState { quota, quotaError ->
+                ProfileUiState(isLoading = true, highlightsOnly = highlightsOnly, quota = quota, quotaError = quotaError)
+            }
             nextFeedPage = 1
             consumedRawCount = 0
             followingInfo = null
             ownRepoItems = emptyList()
             val token = authManager().getAccessToken()
             if (token == null) {
-                _uiState.value = ProfileUiState(isLoading = false, isError = true, highlightsOnly = highlightsOnly)
+                freshState { quota, quotaError ->
+                    ProfileUiState(isLoading = false, isError = true, highlightsOnly = highlightsOnly, quota = quota, quotaError = quotaError)
+                }
                 return@launch
             }
             val user = try {
                 repository.fetchMe(token)
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
-                _uiState.value = ProfileUiState(isLoading = false, isError = true, highlightsOnly = highlightsOnly)
+                freshState { quota, quotaError ->
+                    ProfileUiState(isLoading = false, isError = true, highlightsOnly = highlightsOnly, quota = quota, quotaError = quotaError)
+                }
                 return@launch
             }
-            _uiState.value = ProfileUiState(isLoading = false, user = user, highlightsOnly = highlightsOnly)
+            freshState { quota, quotaError ->
+                ProfileUiState(isLoading = false, user = user, highlightsOnly = highlightsOnly, quota = quota, quotaError = quotaError)
+            }
             hasLoaded = true
             persistSnapshot()
             loadGithubData(user)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -83,6 +83,8 @@ class ProfileViewModel(
     private var feedLoadJob: Job? = null
     /** 进行中的整页加载协程；重复进入页面时先取消，避免两个 load 并发交叉写 state 与分页游标 */
     private var loadJob: Job? = null
+    /** 进行中的余额拉取协程；每次重拉先取消在途请求，避免两次调用乱序返回时旧值覆盖新值 */
+    private var quotaJob: Job? = null
 
     /** 缓存当次会话的关注列表（load() 时重置） */
     private var followingInfo: FollowingInfo? = null
@@ -123,7 +125,7 @@ class ProfileViewModel(
     fun load() {
         // 余额每次进页都拉实时值（独立协程，不受下方跳过逻辑影响）：
         // 聊天消耗发生在页面之外，跳过整页重载时余额仍需刷新
-        viewModelScope.launch { loadQuota() }
+        reloadQuota()
         // 已加载过且数据健在（非错误态）则跳过：用于从子页返回时不重拉
         val current = _uiState.value
         if (hasLoaded && current.user != null && !current.isError) return
@@ -319,7 +321,7 @@ class ProfileViewModel(
     fun refresh() {
         loadJob?.cancel()
         feedLoadJob?.cancel()
-        viewModelScope.launch { loadQuota() }
+        reloadQuota()
         loadJob = viewModelScope.launch {
             refreshInternal()
         }
@@ -328,14 +330,23 @@ class ProfileViewModel(
     /**
      * 拉取 credits 余额：与整页加载解耦，失败只降级配额卡（保留旧值时不置错误态），
      * 不影响档案与 feed。quota 不进 ProfileCache——余额要新鲜，SWR 快照对它是误导。
+     * 自身串行：新请求先取消在途旧请求，避免两次调用乱序返回时旧值覆盖新值。
      */
+    private fun reloadQuota() {
+        quotaJob?.cancel()
+        quotaJob = viewModelScope.launch { loadQuota() }
+    }
+
     private suspend fun loadQuota() {
-        val token = authManager().getAccessToken()
+        // 账户页只在登录态可达；token 在刷新瞬态可能为 null，此时不请求——不带 Bearer 的
+        // /api/quota 会回落匿名档，用 5/5 覆盖登录/Pro 用户真实的 10/100。保留旧值等下次刷新。
+        val token = authManager().getAccessToken() ?: return
         try {
             val quota = repository.fetchQuota(token)
             _uiState.value = _uiState.value.copy(quota = quota, quotaError = false)
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
+            // 已有旧值时保留（stale-while-error），仅首次加载失败才显示错误占位
             _uiState.value = _uiState.value.copy(quotaError = _uiState.value.quota == null)
         }
     }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
@@ -30,6 +30,7 @@ import whl.trending.ai.data.local.LastDataCache
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.model.ContributionCalendar
 import whl.trending.ai.data.model.MeUser
+import whl.trending.ai.data.model.QuotaResponse
 import whl.trending.ai.data.remote.GithubApi
 import whl.trending.ai.data.remote.GithubEventDto
 import whl.trending.ai.data.remote.GithubUser
@@ -50,8 +51,12 @@ class ProfileViewModelTest {
 
     private class FakeUserRepository(
         val onFetchMe: suspend () -> MeUser = { profileMeUser() },
+        val onFetchQuota: suspend () -> QuotaResponse = {
+            QuotaResponse(balance = 8, dailyGrant = 10, resetAt = "2026-07-24T00:00:00.000Z", tier = "user")
+        },
     ) : UserRepository() {
         override suspend fun fetchMe(accessToken: String): MeUser = onFetchMe()
+        override suspend fun fetchQuota(accessToken: String?): QuotaResponse = onFetchQuota()
     }
 
     private class FakeGithubApi : GithubApi() {
@@ -124,7 +129,7 @@ class ProfileViewModelTest {
         cache.put(ProfileCache.KEY, cachedSnapshot())
         val gate = CompletableDeferred<MeUser>()
 
-        val vm = viewModel(cache, repository = FakeUserRepository { gate.await() })
+        val vm = viewModel(cache, repository = FakeUserRepository(onFetchMe = { gate.await() }))
         vm.load()
         advanceUntilIdle()
 
@@ -172,7 +177,7 @@ class ProfileViewModelTest {
 
         val vm = viewModel(
             cache,
-            repository = FakeUserRepository { gate.await() },
+            repository = FakeUserRepository(onFetchMe = { gate.await() }),
             settingsManager = settings(highlightsOnly = false),
         )
         vm.load()
@@ -184,6 +189,29 @@ class ProfileViewModelTest {
         assertEquals(99, mid.contributions?.total)
         assertEquals(emptyList(), mid.feedItems)
         assertFalse(mid.highlightsOnly)
+    }
+
+    // 回归：登出重登后首次进页（无缓存路径），quota 先于 fetchMe 到达时，
+    // 整页状态重建不得把已写入的 quota 抹掉（否则配额卡静默消失，返回再进才出现）
+    @Test
+    fun quotaSurvivesFullPageLoadRace() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val cache = cache() // 无缓存：登出已清 ProfileCache
+        val gate = CompletableDeferred<MeUser>()
+
+        val vm = viewModel(cache, repository = FakeUserRepository(onFetchMe = { gate.await() }))
+        vm.load()
+        advanceUntilIdle() // quota 已返回，fetchMe 仍挂起
+
+        assertEquals(8, vm.uiState.value.quota?.balance)
+
+        gate.complete(profileMeUser())
+        advanceUntilIdle()
+
+        val end = vm.uiState.value
+        assertEquals("octo", end.user?.githubLogin)
+        assertEquals(8, end.quota?.balance)
+        assertFalse(end.quotaError)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
@@ -41,12 +41,13 @@ class ProfileViewModelTest {
 
     private class FakeAuthManager : AuthManager {
         val state = MutableStateFlow<AuthState>(AuthState.LoggedIn)
+        @Volatile var token: String? = "token"
         override val isSupported: Boolean = true
         override val authState: StateFlow<AuthState> = state
         override fun signIn(source: String) {}
         override fun signIn(source: String, method: whl.trending.ai.auth.SignInMethod) {}
         override fun signOut() {}
-        override suspend fun getAccessToken(): String? = "token"
+        override suspend fun getAccessToken(): String? = token
     }
 
     private class FakeUserRepository(
@@ -212,6 +213,26 @@ class ProfileViewModelTest {
         assertEquals("octo", end.user?.githubLogin)
         assertEquals(8, end.quota?.balance)
         assertFalse(end.quotaError)
+    }
+
+    // 回归：token 刷新瞬态为 null 时，loadQuota 不得请求匿名档覆盖登录/Pro 用户已有的真实余额
+    @Test
+    fun quotaNotOverwrittenWhenTokenNull() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val cache = cache()
+        val auth = FakeAuthManager()
+
+        val vm = viewModel(cache, auth = auth)
+        vm.load()
+        advanceUntilIdle()
+        assertEquals(8, vm.uiState.value.quota?.balance) // 登录档余额
+
+        // 模拟刷新瞬态：token 变 null。此时重拉余额不应退到匿名档（5/5）覆盖登录档
+        auth.token = null
+        vm.refresh()
+        advanceUntilIdle()
+
+        assertEquals(8, vm.uiState.value.quota?.balance) // 旧登录档保留，未被匿名覆盖
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
@@ -43,6 +43,7 @@ class ProfileViewModelTest {
         override val isSupported: Boolean = true
         override val authState: StateFlow<AuthState> = state
         override fun signIn(source: String) {}
+        override fun signIn(source: String, method: whl.trending.ai.auth.SignInMethod) {}
         override fun signOut() {}
         override suspend fun getAccessToken(): String? = "token"
     }


### PR DESCRIPTION
## 背景

额度体系（账本+授予）与 Deep Research 上线后，把登录从「解锁更高限额的开关」升级为可感知的账户体系。两个动机：GitHub 登录取消率 76%（大陆可达性结构性问题，邮箱是唯一解），以及后端 `GET /api/quota` 已上线但客户端从未展示余额。

设计方案见 `docs/superpowers/specs/2026-07-22-email-login-account-page-design.md`。

## 改动

**登录方式（原生选择器分流）**
- 登录入口改为 app 内底部选择器（GitHub / 邮箱验证码），`SignInChooserBus` + 根部宿主，6 个登录入口零改动共用
- GitHub 保留 `directSignIn` 直达授权页（存量大陆路径零回退——directSignIn 本就是为绕开托管页大陆加载慢而加）；邮箱经 `firstScreen`/`identifiers` 直达 Logto 托管页邮箱输入屏
- scope 增加 `email`

**账户页重构（原 ProfileScreen）**
- 账户区支持无头像首字母占位、邮箱行
- 新增 `QuotaCard`：调 `GET /api/quota` 展示 credits 余额 / 每日额度进度 / 重置倒计时 / 费率说明；每次进页实时拉取，失败只降级卡片不阻塞页面
- GitHub 档案模块（计数行/贡献热力图/动态流）仅对有 GitHub 身份的用户呈现

**埋点**
- 登录事件全链路带 `method` 属性（github/email），失败漏斗可按方式分段
- 新增 `auth_probe` 可达性探测：托管页在 Custom Tab 加载失败时 SDK 收不到回调、只会表现为「用户取消」——把这个观测盲区显性化，作为未来「继续 Logto vs 自研」决策的判据

**修复**
- 修 `ProfileViewModel` 整页加载抹掉并行到达 quota 导致的配额卡消失（登出重登后首现的竞态），补回归测试

## 配套（已独立发布）

- 后端 `github-ai-trending-api`：迁移 030 给 `app_users` 加 email 列 + `me.js` 提取 email/COALESCE 防 null 覆盖（405 测试全绿，迁移已 apply --remote，Worker 已部署，`/api/me` 冒烟 401 正常）
- Logto 控制台：SMTP connector（Resend）+ 登录体验加邮箱验证码 identifier + 同标识符账户自动关联；测试邮件 Delivered 实证

## 验证

- shared 单测全绿；github 渠道 debug 包 Pixel_9_2 冒烟
- 登录选择器 / 邮箱回落 / 取消路径 / 账户页 QuotaCard 实机渲染（10/10 credits、~13h 重置、费率行）均通过
- 邮箱验证码端到端由用户真机走通

## 不做（本期范围外）

应用内绑定/解绑 GitHub、Google/微信/手机号登录、chat 界面常驻配额展示、me+quota 聚合端点、iOS 登录

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

通过在 GitHub 登录之外引入邮箱验证登录，并重新设计账号/个人资料体验以展示 AI 额度配额，同时提升登录可观测性并修复额度加载竞态问题。

新功能：
- 添加应用内登录方式选择器，让用户可以选择 GitHub 或邮箱验证登录，并在分析中按登录方式扩展追踪和连接性探测。
- 通过 Logto 引入基于邮箱的登录，更新作用域以获取用户邮箱，并将邮箱作为账号数据的一部分进行持久化存储。
- 在账号页面添加 AI 配额卡片，展示每日额度余额、重置时间点和使用速率，由新的配额 API 客户端和模型提供支持。

缺陷修复：
- 修复个人资料页面中的竞态条件问题：在页面与配额并发加载时配额数据可能丢失，确保重新登录后配额卡片仍然可见。

增强改进：
- 将个人资料页面重构为以账号为中心的视图，支持没有 GitHub 身份的用户，包括头像回退策略和邮箱展示，并对非 GitHub 账号隐藏 GitHub 特定模块。
- 扩展设置和用户仓库逻辑，在现有身份字段之外同时存储和清除用户邮箱。
- 更新登录文案，使其与登录方式无关，并为新的登录方式选择器和配额卡片 UI 添加本地化字符串。
- 添加测试覆盖配额加载行为以及与整页加载并发相关的场景。

文档：
- 添加详细的设计说明，记录邮箱验证登录流程、账号页面配额展示，以及相关的行为和数据追踪决策。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce email verification login alongside GitHub sign-in and redesign the account/profile experience to surface AI credit quotas, while improving login observability and fixing quota loading races.

New Features:
- Add an in-app sign-in method chooser that lets users select GitHub or email verification login and extends analytics with per-method tracking and connectivity probing.
- Introduce email-based login via Logto with updated scopes to retrieve user email, and persist email as part of account data.
- Add an AI quota card on the account page that shows daily credits balance, reset timing, and usage rates, backed by a new quota API client and model.

Bug Fixes:
- Fix a race condition in the profile screen where quota data could be lost during concurrent page and quota loads, ensuring the quota card remains visible after re-login.

Enhancements:
- Refactor the profile screen into an account-centric view that supports users without GitHub identities, including avatar fallbacks and email display, while hiding GitHub-specific modules for non-GitHub accounts.
- Extend settings and user repository logic to store and clear user email alongside existing identity fields.
- Update sign-in copy to be method-agnostic and add localized strings for the new sign-in chooser and quota card UI.
- Add tests covering the quota loading behavior and concurrency with full page loading.

Documentation:
- Add a detailed design spec documenting the email verification login flow, account page quota display, and associated behavioral and tracking decisions.

</details>