### PR TITLE
feat(favorites): 收藏云同步客户端（本地缓存 + 幂等接口 + 打开全量拉取）

### DIFF
--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import whl.trending.ai.BuildConfig
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.repository.globalFavoriteRepository
 
 /**
  * Logto 实现：OIDC PKCE 登录，token 存储/刷新由 SDK 托管。
@@ -194,6 +195,7 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         globalSettingsManager.setUserEmail(null)
         globalSettingsManager.setIsPro(false)
         globalSettingsManager.clearSelectedChatModel()
+        globalFavoriteRepository.onSignOut()
         GithubTokenProvider.shared.clear()
         FollowingProvider.shared.clear()
         OwnRepoEventsProvider.shared.clear()

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -18,6 +18,7 @@ import whl.trending.ai.core.platform.getSystemLanguage
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.model.DEFAULT_CHAT_MODEL
 import whl.trending.ai.data.model.FavoriteItem
+import whl.trending.ai.data.model.PendingFavoriteOp
 
 enum class ThemeMode(val title: String) {
     FOLLOW_SYSTEM("跟随系统"),
@@ -67,6 +68,8 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val LAST_UPDATE_CHECK_KEY = "prefs_last_update_check"
     private val LAST_SEEN_WHATSNEW_KEY = "prefs_last_seen_whatsnew_version"
     private val FAVORITES_KEY = "prefs_favorites"
+    private val FAVORITES_PENDING_KEY = "prefs_favorites_pending"
+    private val FAVORITES_MERGED_KEY = "prefs_favorites_merged"
     private val SUBSCRIBED_EMAIL_KEY = "prefs_subscribed_email"
     private val INSTALL_ID_KEY = "prefs_install_id"
     private val USER_AVATAR_KEY = "prefs_user_avatar_url"
@@ -211,9 +214,49 @@ class SettingsManager(private val settings: ObservableSettings) {
         trackEvent("favorite_toggle", mapOf("on" to false))
     }
 
+    /** 当前收藏快照（同步引擎读本地态用）。 */
+    fun currentFavorites(): List<FavoriteItem> = getCurrentFavorites()
+
     private fun getCurrentFavorites(): List<FavoriteItem> {
         val json = settings.getStringOrNull(FAVORITES_KEY) ?: return emptyList()
         return runCatching { Json.decodeFromString<List<FavoriteItem>>(json) }.getOrElse { emptyList() }
+    }
+
+    /**
+     * 用服务端全量列表覆盖本地收藏缓存（云同步「打开时全量拉取」用）。
+     * 非用户手势，不埋点；与 [addFavorite]/[removeFavorite] 的手势写入区分。
+     */
+    fun replaceFavorites(items: List<FavoriteItem>) {
+        settings.putString(FAVORITES_KEY, Json.encodeToString(items))
+    }
+
+    // ---- 云同步状态：待同步 op 队列 + 首次登录合并标记 ----
+
+    fun getPendingFavoriteOps(): List<PendingFavoriteOp> {
+        val json = settings.getStringOrNull(FAVORITES_PENDING_KEY) ?: return emptyList()
+        return runCatching { Json.decodeFromString<List<PendingFavoriteOp>>(json) }.getOrElse { emptyList() }
+    }
+
+    fun setPendingFavoriteOps(ops: List<PendingFavoriteOp>) {
+        if (ops.isEmpty()) settings.remove(FAVORITES_PENDING_KEY)
+        else settings.putString(FAVORITES_PENDING_KEY, Json.encodeToString(ops))
+    }
+
+    /** 是否已完成本次登录的首次合并（true 后走增量 op flush，false 时走全量 batch 合并）。 */
+    fun favoritesMerged(): Boolean = settings.getBoolean(FAVORITES_MERGED_KEY, false)
+
+    fun setFavoritesMerged(value: Boolean) {
+        settings.putBoolean(FAVORITES_MERGED_KEY, value)
+    }
+
+    /**
+     * 登出时清空账号收藏与同步状态：收藏已安全存于该账号云端，清本地避免账号间数据串味
+     * （下个账号登录时不会把上一个账号的收藏 batch 合并上去）。匿名重新收藏从空开始。
+     */
+    fun clearFavoritesOnSignOut() {
+        settings.remove(FAVORITES_KEY)
+        settings.remove(FAVORITES_PENDING_KEY)
+        settings.remove(FAVORITES_MERGED_KEY)
     }
 
     /** 已登录用户头像 URL 缓存：TopBar 入口同步展示用；登出时清空 */

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/FavoriteItem.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/FavoriteItem.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class FavoriteItem(
-    /** 收藏主键，同时用于判重与去重；恒为条目原始 url，不随打开地址变化 */
+    /** 收藏主键，同时用于本地判重与去重；恒为条目原始 url，不随打开地址变化 */
     val url: String,
     val title: String,
     val source: String,
@@ -15,8 +15,37 @@ data class FavoriteItem(
      * 点击收藏时实际打开的地址（如 PH 条目的原帖链接）。
      * 与 [url] 一致或未记录时为 null；旧版本存的收藏均为 null，回退用 [url] 打开。
      */
-    val openUrl: String? = null
+    val openUrl: String? = null,
+    /**
+     * 与后端 contents 表对齐的内容标识（github=owner/repo、hn=story id、ph=node id），
+     * 云同步以 (source, externalId) 为唯一键。存量本地收藏 / 无法解析时为空串，
+     * 首次同步由 [resolvedExternalId] best-effort 回填（github 从 url 反解，其余用 url 派生）。
+     */
+    val externalId: String = ""
 ) {
     /** 打开收藏时应使用的地址 */
     val targetUrl: String get() = openUrl?.takeIf { it.isNotBlank() } ?: url
+
+    /**
+     * 云同步用的 external_id：优先用已有值；缺失时 best-effort 回填——
+     * github 从 url 反解 owner/repo，其余源用 url 派生合成键（`url:<url>`，仅保证用户内唯一，不与 contents join）。
+     */
+    val resolvedExternalId: String
+        get() = externalId.ifBlank {
+            if (source == "github") {
+                val path = url
+                    .removePrefix("https://github.com/")
+                    .removePrefix("http://github.com/")
+                    .trimEnd('/')
+                val parts = path.split("/")
+                if (parts.size >= 2 && parts[0].isNotBlank() && parts[1].isNotBlank()) {
+                    "${parts[0]}/${parts[1]}"
+                } else {
+                    "url:$url"
+                }
+            } else {
+                "url:$url"
+            }
+        }
 }
+

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/FavoritesResponse.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/FavoritesResponse.kt
@@ -1,0 +1,25 @@
+package whl.trending.ai.data.model
+
+import kotlinx.serialization.Serializable
+
+/** GET /api/favorites 响应：服务端返回的收藏全量列表（字段名与 [FavoriteItem] 对齐，可直接反序列化）。 */
+@Serializable
+data class FavoritesResponse(
+    val favorites: List<FavoriteItem> = emptyList()
+)
+
+/**
+ * 收藏本地待同步操作（pending op），登录且已完成首次合并后产生：
+ * 每次收藏/取消先落本地即时生效，再入队一条 op，后台 flush 到服务端；flush 失败留队列下次重试。
+ * delete 需 (source, externalId) 打服务端；[url] 供本地缓存合并（applyPending）按 url 定位。
+ */
+@Serializable
+data class PendingFavoriteOp(
+    /** "add" | "delete" */
+    val op: String,
+    val url: String,
+    val source: String,
+    val externalId: String,
+    /** add 时携带完整快照，供 flush 上云与在途合并回填 */
+    val item: FavoriteItem? = null
+)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/PicksResponse.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/PicksResponse.kt
@@ -22,6 +22,8 @@ data class PicksMetadata(
 data class PickItem(
     val rank: Int = 0,
     val source: String = "",
+    /** 与后端 contents 对齐的内容标识；供收藏云同步作唯一键 */
+    val externalId: String = "",
     val title: String = "",
     val url: String = "",
     val phUrl: String? = null,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -2,6 +2,8 @@ package whl.trending.ai.data.remote
 
 import whl.trending.ai.core.platform.getUserAgent
 import whl.trending.ai.data.model.AppConfigResponse
+import whl.trending.ai.data.model.FavoriteItem
+import whl.trending.ai.data.model.FavoritesResponse
 import whl.trending.ai.data.model.FeedResponse
 import whl.trending.ai.data.model.ChatModelOption
 import whl.trending.ai.data.model.ChatModelsResponse
@@ -18,10 +20,12 @@ import io.ktor.client.call.body
 import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
@@ -199,6 +203,50 @@ open class TrendingApi {
             throw ApiException(response.status.value, response.bodyAsText())
         }
         return response.body<ChatModelsResponse>().models
+    }
+
+    // ---- 收藏云同步（设计稿 2026-07-24-favorites-cloud-sync，B 档）----
+    // 全部经 Bearer 鉴权；调用方（FavoriteRepository）负责传入 externalId 已回填的条目。
+
+    /** 拉取该用户全量收藏。非 2xx 抛 [ApiException]，供调用方在失败时保留本地、不覆盖。 */
+    open suspend fun fetchFavorites(accessToken: String): List<FavoriteItem> {
+        val response = client.get("$baseHost/api/favorites") {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+        }
+        if (response.status.value !in 200..299) {
+            throw ApiException(response.status.value, response.bodyAsText())
+        }
+        return response.body<FavoritesResponse>().favorites
+    }
+
+    /** upsert 单条收藏（幂等）。返回是否成功，失败由调用方入队重试。 */
+    open suspend fun putFavorite(accessToken: String, item: FavoriteItem): Boolean {
+        val response = client.put("$baseHost/api/favorites") {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+            contentType(ContentType.Application.Json)
+            setBody(item)
+        }
+        return response.status.value in 200..299
+    }
+
+    /** 删一条收藏（幂等，服务端不存在也 200）。 */
+    open suspend fun deleteFavorite(accessToken: String, source: String, externalId: String): Boolean {
+        val response = client.delete("$baseHost/api/favorites") {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+            parameter("source", source)
+            parameter("external_id", externalId)
+        }
+        return response.status.value in 200..299
+    }
+
+    /** 批量 upsert（登录首次合并本地收藏）。 */
+    open suspend fun batchPutFavorites(accessToken: String, items: List<FavoriteItem>): Boolean {
+        val response = client.post("$baseHost/api/favorites/batch") {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+            contentType(ContentType.Application.Json)
+            setBody(FavoritesResponse(items))
+        }
+        return response.status.value in 200..299
     }
 
     open suspend fun cancelSubscribe(email: String): Result<SubscribeResponse> {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/FavoriteRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/FavoriteRepository.kt
@@ -37,8 +37,7 @@ class FavoriteRepository(
         val resolved = if (item.externalId.isBlank()) item.copy(externalId = item.resolvedExternalId) else item
         settings.addFavorite(resolved)
         if (canSyncOps()) {
-            enqueue(PendingFavoriteOp("add", resolved.url, resolved.source, resolved.externalId, resolved))
-            scope.launch { flushQuietly() }
+            scope.launch { pushOp(PendingFavoriteOp("add", resolved.url, resolved.source, resolved.externalId, resolved)) }
         }
     }
 
@@ -47,8 +46,7 @@ class FavoriteRepository(
         val existing = settings.currentFavorites().firstOrNull { it.url == url }
         settings.removeFavorite(url)
         if (existing != null && canSyncOps()) {
-            enqueue(PendingFavoriteOp("delete", url, existing.source, existing.resolvedExternalId, null))
-            scope.launch { flushQuietly() }
+            scope.launch { pushOp(PendingFavoriteOp("delete", url, existing.source, existing.resolvedExternalId, null)) }
         }
     }
 
@@ -79,7 +77,15 @@ class FavoriteRepository(
         }
     }
 
-    /** 登出清理：清空本地收藏 + 同步状态，避免账号间串味。由登出流程调用。 */
+    /**
+     * 登出清理：清空本地收藏 + 同步状态，避免账号间串味。由登出流程调用。
+     *
+     * 取舍：会一并清掉未 flush 成功的 pending op。极端场景「离线新增一条收藏（flush 失败留队列）
+     * → 立即登出」下，该条既未上云也被清除 → 丢失。不在此做 best-effort flush，因为：
+     * (1) 该场景前提是离线，flush 同样发不出去；(2) 登出流程开头已吊销凭证，此刻已无有效 token。
+     * 唯一能不丢的做法是「登出不清、留到下次登录再传」，但那会重开要防的账号串味。
+     * 详见设计稿 §6.2。
+     */
     fun onSignOut() {
         settings.clearFavoritesOnSignOut()
     }
@@ -93,18 +99,26 @@ class FavoriteRepository(
      */
     private fun canSyncOps(): Boolean = settings.favoritesMerged()
 
-    private fun enqueue(op: PendingFavoriteOp) {
-        // 同一 (op,url) 去重合并：保留最新一条，避免同键 op 堆积
+    /**
+     * 入队一条 op 并尝试 flush，全程持 [mutex]——与 [sync] 串行化。
+     * 关键：pending 键的读-改-写只允许在 mutex 内发生（enqueue/flush/sync 都在锁内），
+     * 否则主线程 enqueue 与后台 flush 并行 RMW 同一 prefs 键会 lost-update、静默丢一条收藏。
+     */
+    private suspend fun pushOp(op: PendingFavoriteOp) {
+        mutex.withLock {
+            enqueueLocked(op)
+            val token = tokenProvider() ?: return@withLock // 匿名/无 token：留队列，下次 sync 再推
+            runCatching { flushPending(token) }
+        }
+    }
+
+    /** 必须在 [mutex] 内调用。同一 (op,url) 去重合并：保留最新一条，避免同键 op 堆积。 */
+    private fun enqueueLocked(op: PendingFavoriteOp) {
         val kept = settings.getPendingFavoriteOps().filterNot { it.op == op.op && it.url == op.url }
         settings.setPendingFavoriteOps(kept + op)
     }
 
-    private suspend fun flushQuietly() {
-        val token = tokenProvider() ?: return
-        mutex.withLock { runCatching { flushPending(token) } }
-    }
-
-    /** 逐条推送队列；成功的移出队列，遇失败保留剩余（含当前）待下次重试。 */
+    /** 逐条推送队列；成功的移出队列，遇失败保留剩余（含当前）待下次重试。必须在 [mutex] 内调用。 */
     private suspend fun flushPending(token: String) {
         val ops = settings.getPendingFavoriteOps()
         if (ops.isEmpty()) return

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/FavoriteRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/FavoriteRepository.kt
@@ -1,0 +1,149 @@
+package whl.trending.ai.data.repository
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.model.FavoriteItem
+import whl.trending.ai.data.model.PendingFavoriteOp
+import whl.trending.ai.data.remote.TrendingApi
+
+/**
+ * 收藏云同步引擎（设计稿 2026-07-24-favorites-cloud-sync，B 档：本地缓存 + 幂等 CRUD + 打开时全量拉取覆盖）。
+ *
+ * - 本地缓存（[SettingsManager] 的 favorites）始终是 UI 即时真源，离线可用；网络在后台跑、失败不打断。
+ * - 收藏/取消：先落本地即时生效，登录且已完成首次合并后入队一条 op 并后台 flush；失败留队列下次重试。
+ * - [sync]（登录/启动触发）：首次登录把全部本地收藏 batch 上云合并，之后 flush 增量 op；随后全量 GET 覆盖本地。
+ * - 删除跨设备传播靠「打开时全量 GET 覆盖」完成，无墓碑。
+ *
+ * UI 只需把原先直调 SettingsManager 的收藏读写改为调本类；收藏列表流仍读 SettingsManager.favorites 不变。
+ */
+class FavoriteRepository(
+    private val settings: SettingsManager,
+    private val api: TrendingApi,
+    private val tokenProvider: suspend () -> String?,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) {
+    // 序列化所有网络同步，避免 flush 与全量覆盖交错导致缓存被旧快照回冲
+    private val mutex = Mutex()
+
+    /** 收藏：本地即时写入 + 埋点（沿用 SettingsManager 手势路径），随后后台推送。 */
+    fun add(item: FavoriteItem) {
+        val resolved = if (item.externalId.isBlank()) item.copy(externalId = item.resolvedExternalId) else item
+        settings.addFavorite(resolved)
+        if (canSyncOps()) {
+            enqueue(PendingFavoriteOp("add", resolved.url, resolved.source, resolved.externalId, resolved))
+            scope.launch { flushQuietly() }
+        }
+    }
+
+    /** 取消收藏：按 url 本地删除 + 埋点，随后后台推送删除。 */
+    fun remove(url: String) {
+        val existing = settings.currentFavorites().firstOrNull { it.url == url }
+        settings.removeFavorite(url)
+        if (existing != null && canSyncOps()) {
+            enqueue(PendingFavoriteOp("delete", url, existing.source, existing.resolvedExternalId, null))
+            scope.launch { flushQuietly() }
+        }
+    }
+
+    /**
+     * 登录 / 启动时的同步。传入 access token（null=匿名，直接返回，纯本地）。
+     * 内部吞掉网络异常：失败保留本地态，下次再试。
+     */
+    suspend fun sync(accessToken: String?) {
+        val token = accessToken ?: return
+        mutex.withLock {
+            runCatching {
+                if (!settings.favoritesMerged()) {
+                    // 首次登录合并：全部本地收藏（含匿名期 + 存量，externalId 回填）batch 上云
+                    val local = settings.currentFavorites().map { withResolvedId(it) }
+                    if (local.isNotEmpty() && !api.batchPutFavorites(token, local)) {
+                        return@runCatching // batch 失败：不置 merged、不覆盖本地，下次重试
+                    }
+                    settings.setPendingFavoriteOps(emptyList()) // batch 已全覆盖，清历史 op
+                    settings.setFavoritesMerged(true)
+                } else {
+                    flushPending(token)
+                }
+                // 全量拉取覆盖本地；叠加在途/未 flush 成功的 pending，避免刚发生的本地改动被旧快照冲掉
+                val server = api.fetchFavorites(token)
+                val merged = applyPending(server, settings.getPendingFavoriteOps())
+                settings.replaceFavorites(merged)
+            }
+        }
+    }
+
+    /** 登出清理：清空本地收藏 + 同步状态，避免账号间串味。由登出流程调用。 */
+    fun onSignOut() {
+        settings.clearFavoritesOnSignOut()
+    }
+
+    // ---- 内部 ----
+
+    /**
+     * 仅在已完成首次合并后才入队增量 op；否则本地改动由首次 batch 合并整体覆盖。
+     * merged 只有在带真实 token 的 [sync] 成功后才置 true，故匿名 / iOS(Noop 无 token) 恒为 false，
+     * 天然不入队、队列不膨胀，无需再看平台是否支持登录。
+     */
+    private fun canSyncOps(): Boolean = settings.favoritesMerged()
+
+    private fun enqueue(op: PendingFavoriteOp) {
+        // 同一 (op,url) 去重合并：保留最新一条，避免同键 op 堆积
+        val kept = settings.getPendingFavoriteOps().filterNot { it.op == op.op && it.url == op.url }
+        settings.setPendingFavoriteOps(kept + op)
+    }
+
+    private suspend fun flushQuietly() {
+        val token = tokenProvider() ?: return
+        mutex.withLock { runCatching { flushPending(token) } }
+    }
+
+    /** 逐条推送队列；成功的移出队列，遇失败保留剩余（含当前）待下次重试。 */
+    private suspend fun flushPending(token: String) {
+        val ops = settings.getPendingFavoriteOps()
+        if (ops.isEmpty()) return
+        val done = mutableListOf<PendingFavoriteOp>()
+        for (op in ops) {
+            val ok = when (op.op) {
+                "add" -> op.item?.let { api.putFavorite(token, withResolvedId(it)) } ?: true
+                "delete" -> api.deleteFavorite(token, op.source, op.externalId)
+                else -> true // 未知 op 直接丢弃
+            }
+            if (ok) done += op else break
+        }
+        if (done.isNotEmpty()) {
+            settings.setPendingFavoriteOps(settings.getPendingFavoriteOps().filterNot { it in done })
+        }
+    }
+
+    private fun withResolvedId(item: FavoriteItem): FavoriteItem =
+        if (item.externalId.isBlank()) item.copy(externalId = item.resolvedExternalId) else item
+
+    /** 服务端全量叠加本地 pending：add 覆盖入表、delete 移除，按 url 定位，收藏时刻倒序。 */
+    private fun applyPending(server: List<FavoriteItem>, pending: List<PendingFavoriteOp>): List<FavoriteItem> {
+        val map = LinkedHashMap<String, FavoriteItem>()
+        server.forEach { map[it.url] = it }
+        pending.forEach { op ->
+            when (op.op) {
+                "add" -> op.item?.let { map[it.url] = it }
+                "delete" -> map.remove(op.url)
+            }
+        }
+        return map.values.sortedByDescending { it.savedAt }
+    }
+}
+
+/** 全局单例：注入全局 SettingsManager / TrendingApi / 登录态 token。 */
+val globalFavoriteRepository by lazy {
+    FavoriteRepository(
+        settings = globalSettingsManager,
+        api = TrendingApi(),
+        tokenProvider = { globalAuthManager.getAccessToken() },
+    )
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/favorites/FavoriteListScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/favorites/FavoriteListScreen.kt
@@ -1,6 +1,7 @@
 package whl.trending.ai.ui.favorites
 
 import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.repository.globalFavoriteRepository
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.ui.common.AiSummaryBox
 import whl.trending.ai.ui.picks.SourceTag
@@ -121,7 +122,7 @@ fun FavoriteListScreen(
                     FavoriteCard(
                         item = item,
                         onClick = { handleFavoriteClick(item, onNavigateToDetail, onOpenUrl) },
-                        onRemove = { globalSettingsManager.removeFavorite(item.url) }
+                        onRemove = { globalFavoriteRepository.remove(item.url) }
                     )
                     if (index < favorites.lastIndex) {
                         HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
@@ -39,6 +39,7 @@ import trendingai.shared.generated.resources.no_data
 import trendingai.shared.generated.resources.retry
 import whl.trending.ai.core.platform.trackItemClick
 import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.repository.globalFavoriteRepository
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.data.model.FeedItem
 import whl.trending.ai.core.platform.shareText
@@ -120,9 +121,9 @@ fun FeedScreen(
                             onOpenUrl = onOpenUrl,
                             onToggleFavorite = {
                                 if (item.url in favoriteUrls) {
-                                    globalSettingsManager.removeFavorite(item.url)
+                                    globalFavoriteRepository.remove(item.url)
                                 } else {
-                                    globalSettingsManager.addFavorite(
+                                    globalFavoriteRepository.add(
                                         FavoriteItem(
                                             url = item.url,
                                             title = item.title,
@@ -130,7 +131,8 @@ fun FeedScreen(
                                             description = item.description,
                                             summary = item.summary,
                                             savedAt = Clock.System.now().toEpochMilliseconds(),
-                                            openUrl = item.openUrl
+                                            openUrl = item.openUrl,
+                                            externalId = item.externalId
                                         )
                                     )
                                 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -78,6 +78,7 @@ import whl.trending.ai.chat.globalChatScreen
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.ChatModelsProvider
 import whl.trending.ai.data.repository.UserRepository
+import whl.trending.ai.data.repository.globalFavoriteRepository
 import whl.trending.ai.ui.feed.FeedScreen
 import whl.trending.ai.ui.feed.FeedViewModel
 import whl.trending.ai.ui.picks.PicksScreen
@@ -146,11 +147,13 @@ fun HomeScreen(
     val userAvatarUrl by globalSettingsManager.userAvatarUrl.collectAsState(null)
     val userRepository = remember { UserRepository() }
 
-    // 应用启动且已登录：服务端建档/刷新 last_login_at + 同步头像（幂等，失败静默）
+    // 应用启动且已登录：服务端建档/刷新 last_login_at + 同步头像 + 同步收藏（幂等，失败静默）
     LaunchedEffect(authState) {
         val state = authState
         if (state is AuthState.LoggedIn) {
-            userRepository.syncMe(authManager.getAccessToken())
+            val token = authManager.getAccessToken()
+            userRepository.syncMe(token)
+            globalFavoriteRepository.sync(token)
         }
     }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
@@ -61,6 +61,7 @@ import trendingai.shared.generated.resources.retry
 import whl.trending.ai.core.DateTimeUtils
 import whl.trending.ai.core.platform.trackItemClick
 import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.repository.globalFavoriteRepository
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.core.platform.shareText
 import whl.trending.ai.core.platform.trackEvent
@@ -490,9 +491,9 @@ private fun DebutCard(
 
 private fun togglePickFavorite(item: PickItem, favoriteUrls: Set<String>) {
     if (item.url in favoriteUrls) {
-        globalSettingsManager.removeFavorite(item.url)
+        globalFavoriteRepository.remove(item.url)
     } else {
-        globalSettingsManager.addFavorite(
+        globalFavoriteRepository.add(
             FavoriteItem(
                 url = item.url,
                 title = item.title,
@@ -500,7 +501,8 @@ private fun togglePickFavorite(item: PickItem, favoriteUrls: Set<String>) {
                 description = item.analysis?.core ?: item.description,
                 summary = item.analysis?.whyImportant ?: item.summary,
                 savedAt = Clock.System.now().toEpochMilliseconds(),
-                openUrl = item.openUrl
+                openUrl = item.openUrl,
+                externalId = item.externalId
             )
         )
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
@@ -111,6 +111,7 @@ import whl.trending.ai.core.platform.shareText
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.core.platform.trackItemClick
 import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.repository.globalFavoriteRepository
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.data.model.TrendingContributor
 import whl.trending.ai.data.model.TrendingRepo
@@ -298,16 +299,17 @@ private fun RepoList(
                         onStar = onStarRepo?.let { star -> { star(repo) } },
                         onToggleFavorite = {
                             if (repo.url in favoriteUrls) {
-                                globalSettingsManager.removeFavorite(repo.url)
+                                globalFavoriteRepository.remove(repo.url)
                             } else {
-                                globalSettingsManager.addFavorite(
+                                globalFavoriteRepository.add(
                                     FavoriteItem(
                                         url = repo.url,
                                         title = "${repo.author}/${repo.repoName}",
                                         source = "github",
                                         description = repo.description.takeIf { it.isNotBlank() },
                                         summary = repo.aiSummaries.firstOrNull()?.content,
-                                        savedAt = Clock.System.now().toEpochMilliseconds()
+                                        savedAt = Clock.System.now().toEpochMilliseconds(),
+                                        externalId = "${repo.author}/${repo.repoName}"
                                     )
                                 )
                             }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/repository/FavoriteRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/repository/FavoriteRepositoryTest.kt
@@ -1,0 +1,183 @@
+package whl.trending.ai.data.repository
+
+import com.russhwolf.settings.MapSettings
+import com.russhwolf.settings.ObservableSettings
+import kotlinx.coroutines.test.runTest
+import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.model.FavoriteItem
+import whl.trending.ai.data.model.PendingFavoriteOp
+import whl.trending.ai.data.remote.TrendingApi
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** 内存版 TrendingApi：记录调用并维护一份「服务端」收藏，键为 source|externalId。 */
+private class FakeApi : TrendingApi() {
+    val server = LinkedHashMap<String, FavoriteItem>()
+    var getCount = 0
+    var batchCount = 0
+    val puts = mutableListOf<FavoriteItem>()
+    val deletes = mutableListOf<Pair<String, String>>()
+    var failNextBatch = false
+
+    private fun key(source: String, externalId: String) = "$source|$externalId"
+
+    fun seedServer(vararg items: FavoriteItem) {
+        items.forEach { server[key(it.source, it.externalId)] = it }
+    }
+
+    override suspend fun fetchFavorites(accessToken: String): List<FavoriteItem> {
+        getCount++
+        return server.values.toList()
+    }
+
+    override suspend fun putFavorite(accessToken: String, item: FavoriteItem): Boolean {
+        puts += item
+        server[key(item.source, item.externalId)] = item
+        return true
+    }
+
+    override suspend fun deleteFavorite(accessToken: String, source: String, externalId: String): Boolean {
+        deletes += source to externalId
+        server.remove(key(source, externalId))
+        return true
+    }
+
+    override suspend fun batchPutFavorites(accessToken: String, items: List<FavoriteItem>): Boolean {
+        if (failNextBatch) { failNextBatch = false; return false }
+        batchCount++
+        items.forEach { server[key(it.source, it.externalId)] = it }
+        return true
+    }
+}
+
+class FavoriteRepositoryTest {
+    private lateinit var settings: SettingsManager
+    private lateinit var api: FakeApi
+
+    private fun repo(token: String? = "tok") =
+        FavoriteRepository(settings, api, tokenProvider = { token })
+
+    private fun gh(name: String, ext: String = name) = FavoriteItem(
+        url = "https://github.com/$name",
+        title = name,
+        source = "github",
+        savedAt = 1000,
+        externalId = ext,
+    )
+
+    @BeforeTest
+    fun setup() {
+        settings = SettingsManager(MapSettings() as ObservableSettings)
+        api = FakeApi()
+    }
+
+    @Test
+    fun 首次登录合并_本地全部batch上云并用服务端覆盖本地() = runTest {
+        settings.replaceFavorites(listOf(gh("a/b"), gh("c/d")))
+        api.seedServer(gh("e/f")) // 云端已有的另一条
+
+        repo().sync("tok")
+
+        assertEquals(1, api.batchCount)
+        assertTrue(settings.favoritesMerged())
+        // 本地被服务端全量覆盖：合并后含云端已有 + 本地上推的三条
+        val local = settings.currentFavorites().map { it.externalId }.toSet()
+        assertEquals(setOf("a/b", "c/d", "e/f"), local)
+    }
+
+    @Test
+    fun 首次合并_存量收藏无externalId时github从url回填() = runTest {
+        // 存量本地收藏：externalId 为空
+        settings.replaceFavorites(listOf(FavoriteItem(url = "https://github.com/foo/bar", title = "foo/bar", source = "github")))
+
+        repo().sync("tok")
+
+        // batch 上推的条目 externalId 已回填为 owner/repo
+        assertEquals("foo/bar", api.server.keys.first().removePrefix("github|"))
+    }
+
+    @Test
+    fun batch失败_不置merged也不覆盖本地() = runTest {
+        settings.replaceFavorites(listOf(gh("a/b")))
+        api.failNextBatch = true
+
+        repo().sync("tok")
+
+        assertFalse(settings.favoritesMerged())
+        assertEquals(0, api.getCount) // 未走到 GET
+        assertEquals(listOf("a/b"), settings.currentFavorites().map { it.externalId }) // 本地保留
+    }
+
+    @Test
+    fun 已合并_删除跨设备传播_GET覆盖移除本地条目() = runTest {
+        // 已完成首次合并；本地有 X，云端已被别的设备删掉（服务端为空）
+        settings.setFavoritesMerged(true)
+        settings.replaceFavorites(listOf(gh("a/b")))
+        // api.server 为空
+
+        repo().sync("tok")
+
+        assertEquals(0, api.batchCount) // 已合并，不再 batch
+        assertTrue(settings.currentFavorites().isEmpty()) // X 被服务端全量覆盖移除
+    }
+
+    @Test
+    fun 已合并_在途pending的add在GET覆盖时被保留() = runTest {
+        settings.setFavoritesMerged(true)
+        // 服务端空，但本地有一条尚未 flush 成功的 add op
+        settings.setPendingFavoriteOps(
+            listOf(PendingFavoriteOp("add", "https://github.com/x/y", "github", "x/y", gh("x/y")))
+        )
+
+        repo().sync("tok")
+
+        // GET 返回空，但 pending add 叠加回来，本地仍含 x/y
+        assertEquals(listOf("x/y"), settings.currentFavorites().map { it.externalId })
+    }
+
+    @Test
+    fun 已合并_flush先推增量op再GET() = runTest {
+        settings.setFavoritesMerged(true)
+        settings.replaceFavorites(listOf(gh("a/b")))
+        settings.setPendingFavoriteOps(
+            listOf(PendingFavoriteOp("add", "https://github.com/a/b", "github", "a/b", gh("a/b")))
+        )
+
+        repo().sync("tok")
+
+        assertEquals(1, api.puts.size) // pending add 被 flush
+        assertTrue(settings.getPendingFavoriteOps().isEmpty()) // flush 成功后出队
+    }
+
+    @Test
+    fun 匿名_token为null时sync直接返回不动本地() = runTest {
+        settings.replaceFavorites(listOf(gh("a/b")))
+
+        repo(token = null).sync(null)
+
+        assertFalse(settings.favoritesMerged())
+        assertEquals(0, api.getCount)
+        assertEquals(0, api.batchCount)
+        assertEquals(listOf("a/b"), settings.currentFavorites().map { it.externalId })
+    }
+
+    // 注：add()/remove() 的手势路径会触发 favorite_toggle 埋点（Aptabase），
+    // 在纯 JVM host-test 中未初始化会 NPE，故不在此单测；其本地写入 + 入队逻辑
+    // 由上面的「在途 pending 保留」「flush 增量」用例间接覆盖（构造同一 PendingFavoriteOp 形态）。
+
+    @Test
+    fun onSignOut_清空收藏与同步状态() = runTest {
+        settings.setFavoritesMerged(true)
+        settings.replaceFavorites(listOf(gh("a/b")))
+        settings.setPendingFavoriteOps(listOf(PendingFavoriteOp("delete", "u", "github", "a/b", null)))
+
+        repo().onSignOut()
+
+        assertTrue(settings.currentFavorites().isEmpty())
+        assertTrue(settings.getPendingFavoriteOps().isEmpty())
+        assertFalse(settings.favoritesMerged())
+    }
+}


### PR DESCRIPTION
## 背景

把纯本地的收藏升级为登录用户可在 Cloudflare 端保存并跨设备同步。后端见 github-ai-trending-api#24；设计方案见父仓库 `docs/superpowers/specs/2026-07-24-favorites-cloud-sync-design.md`。

**架构（B 档）**：本地缓存仍是 UI 即时真源（离线可用）；每次收藏/取消先落本地即时生效，后台推幂等接口；打开 App / 登录时全量 GET 覆盖本地。**不引入游标/墓碑**，删除跨设备靠全量覆盖传播。

## 改动

- **`FavoriteRepository`（新）**：同步引擎
  - 首次登录：全部本地收藏（含匿名期 + 存量，externalId 回填）`POST /batch` 合并上云
  - 之后：增量 pending op flush（失败入队重试）
  - 每次同步末尾：全量 GET，叠加在途 pending 后覆盖本地缓存（避免刚发生的本地改动被旧快照冲掉）
- **`FavoriteItem`** 增 `externalId`（云同步唯一键）+ `resolvedExternalId`（存量/无 id 时 github 从 url 反解、其余用 url 派生）
- **`PickItem`** 增 `externalId`；**`TrendingApi`** 增 `get/put/delete/batch` 收藏接口
- **`SettingsManager`** 增 pending 队列 / merged 标记 / `replaceFavorites` / 登出清理
- 三源收藏入口（Feed / Picks / Trending / 收藏列表）改走 `globalFavoriteRepository` 并透传 `externalId`
- **`HomeScreen`** 登录/启动触发 `sync`；**`LogtoAuthManager.signOut`** 清空账号收藏，避免账号间串味
- **iOS**：无登录态（Noop）→ 自动保持纯本地，零改动

## 定位

所有**登录用户免费**同步；匿名/未登录用户行为与现状完全一致。

## 测试

- 新增 `FavoriteRepositoryTest`：首次合并 + 全量覆盖、存量 externalId 回填、batch 失败不置 merged 不覆盖本地、删除跨设备传播、在途 pending 保留、增量 flush、匿名 no-op、登出清理。
- shared 全套测试通过；androidApp 编译通过。
- 备注：`add()/remove()` 手势路径含 `favorite_toggle` 埋点（Aptabase），纯 JVM host-test 未初始化会 NPE，故其本地写入+入队由「在途 pending」「flush」用例间接覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

引入云端驱动的收藏同步引擎，在保持本地收藏作为 UI 可信来源的同时，将已登录用户的数据与后端进行同步。

New Features:
- 为已认证的云同步在 `TrendingApi` 中新增服务端收藏 CRUD 和批量 API。
- 实现全局同步引擎 `FavoriteRepository`，用于管理本地收藏、待处理操作，以及登录触发的批量/刷新 + 全量刷新流程。
- 支持基于 `externalId` 的收藏和精选项标识，以与后端内容对齐并实现跨设备一致性。

Enhancements:
- 扩展 `SettingsManager`，以跟踪当前收藏、待处理收藏操作、合并状态，并在登出时清空收藏。
- 更新所有收藏入口（信息流、精选、趋势、收藏列表），改为使用全局收藏仓库而不是直接写入设置。
- 在已登录用户的应用启动时触发收藏同步，并在注销时清除同步状态，以避免跨账号数据泄漏。

Tests:
- 新增 `FavoriteRepositoryTest`，用于验证首次登录批量合并、`externalId` 回填、失败处理、跨设备删除传播、待处理操作的保留与刷新、匿名用户行为以及登出清理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a cloud-backed favorites sync engine that keeps local favorites as the UI source of truth while synchronizing logged-in users’ data with the backend.

New Features:
- Add server-side favorites CRUD and batch APIs to TrendingApi for authenticated cloud synchronization.
- Implement FavoriteRepository as a global sync engine that manages local favorites, pending operations, and login-triggered batch/flush + full refresh flows.
- Support externalId-based identification for favorites and picks to align with backend contents and enable cross-device consistency.

Enhancements:
- Extend SettingsManager to track current favorites, pending favorite operations, merge state, and to clear favorites on sign-out.
- Update all favorite entry points (feed, picks, trending, favorites list) to use the global favorite repository instead of writing directly to settings.
- Trigger favorites sync on app startup for logged-in users and clear sync state on logout to avoid cross-account data leakage.

Tests:
- Add FavoriteRepositoryTest to validate first-login batch merge, externalId backfill, failure handling, cross-device deletion propagation, pending-op preservation and flushing, anonymous behavior, and sign-out cleanup.

</details>