### PR TITLE
feat(account): 邮箱用户可关联 GitHub，打通 Pro 领取路径

### DIFF
--- a/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import whl.trending.ai.chat.globalChatScreen
+import whl.trending.ai.core.AccountLink
 import whl.trending.ai.core.App
 import whl.trending.ai.core.ProSponsor
 import whl.trending.ai.data.local.AppLanguage
@@ -115,7 +116,26 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         val loggedIn = whl.trending.ai.auth.globalAuthManager.authState.value is whl.trending.ai.auth.AuthState.LoggedIn
-        if (loggedIn && !globalSettingsManager.currentIsPro() && ProSponsor.shouldReconcile()) {
+        if (!loggedIn) return
+
+        // ① 刚去账户中心关联过 GitHub：先刷身份（fresh=1 绕开服务端 claims 缓存），
+        //    拿到 github_user_id 才谈得上对账 Pro——顺序反了会白跑一次 pro/refresh。
+        if (AccountLink.shouldRefreshIdentity()) {
+            lifecycleScope.launch {
+                val token = whl.trending.ai.auth.globalAuthManager.getAccessToken()
+                val repo = whl.trending.ai.data.repository.UserRepository()
+                val user = repo.syncMe(token, fresh = true)
+                if (user?.githubUserId != null) {
+                    AccountLink.markLinked()
+                    // 关联前可能早就赞助过（钱付了但身份对不上），补一次对账让 Pro 立即生效
+                    repo.refreshPro(token)
+                }
+            }
+            return
+        }
+
+        // ② 常规赞助对账窗口
+        if (!globalSettingsManager.currentIsPro() && ProSponsor.shouldReconcile()) {
             lifecycleScope.launch {
                 val token = whl.trending.ai.auth.globalAuthManager.getAccessToken()
                 if (whl.trending.ai.data.repository.UserRepository().refreshPro(token) == true) {

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -218,6 +218,11 @@
     <string name="account_tier_pro">Pro</string>
     <string name="account_upgrade_cta">升级 Pro</string>
     <string name="account_upgrade_hint">提升每日额度 · 绑定赞助的 GitHub 账户</string>
+    <string name="account_link_github">关联 GitHub</string>
+    <string name="account_link_github_desc">关联后可领取 Pro 权益，并使用 star、关注等 GitHub 功能</string>
+    <string name="account_link_required_title">需要先关联 GitHub</string>
+    <string name="account_link_required_message">Pro 权益通过 GitHub Sponsors 发放，需要你的账户关联 GitHub。你当前用邮箱登录，直接赞助不会自动生效。</string>
+    <string name="account_link_sponsor_anyway">仍要前往赞助</string>
     <string name="account_signin_for_more">登录即可获得每日 10 次额度</string>
     <string name="account_pro_active">你已是 Pro 会员，感谢支持！</string>
     <string name="account_github_entry">GitHub 主页</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -204,10 +204,10 @@
     <string name="profile_pro_badge">PRO</string>
     <string name="profile_pro_badge_desc">Pro 会员</string>
     <string name="profile_quota_title">AI 额度</string>
-    <string name="profile_quota_remaining">今日剩余 %1$d / %2$d</string>
+    <string name="profile_quota_used">已用 %1$s</string>
+    <string name="profile_quota_exhausted">今日额度已用完</string>
     <string name="profile_quota_reset_hours">约 %1$d 小时后重置</string>
     <string name="profile_quota_reset_soon">1 小时内重置</string>
-    <string name="profile_quota_rates">对话 1 · 搜索 3 · 研究 10</string>
     <string name="profile_quota_error">额度信息暂时无法获取</string>
     <!-- 账户中心 -->
     <string name="account_title">账户</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -219,7 +219,7 @@
     <string name="account_upgrade_cta">升级 Pro</string>
     <string name="account_upgrade_hint">提升每日额度 · 绑定赞助的 GitHub 账户</string>
     <string name="account_link_github">关联 GitHub</string>
-    <string name="account_link_github_desc">关联后可领取 Pro 权益，并使用 star、关注等 GitHub 功能</string>
+    <string name="account_link_github_desc">解锁 star、关注等功能；领取 Pro 权益也需要先关联</string>
     <string name="account_link_required_title">需要先关联 GitHub</string>
     <string name="account_link_required_message">Pro 权益通过 GitHub Sponsors 发放，需要你的账户关联 GitHub。你当前用邮箱登录，直接赞助不会自动生效。</string>
     <string name="account_link_sponsor_anyway">仍要前往赞助</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -219,7 +219,7 @@
     <string name="account_upgrade_cta">升级 Pro</string>
     <string name="account_upgrade_hint">提升每日额度 · 绑定赞助的 GitHub 账户</string>
     <string name="account_link_github">关联 GitHub</string>
-    <string name="account_link_github_desc">解锁 star、关注等功能；领取 Pro 权益也需要先关联</string>
+    <string name="account_link_github_desc">解锁 star、关注等 GitHub 功能</string>
     <string name="account_link_required_title">需要先关联 GitHub</string>
     <string name="account_link_required_message">Pro 权益通过 GitHub Sponsors 发放，需要你的账户关联 GitHub。你当前用邮箱登录，直接赞助不会自动生效。</string>
     <string name="account_link_sponsor_anyway">仍要前往赞助</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -219,7 +219,7 @@
     <string name="account_upgrade_cta">Upgrade to Pro</string>
     <string name="account_upgrade_hint">More daily credits · tied to your sponsoring GitHub account</string>
     <string name="account_link_github">Link GitHub</string>
-    <string name="account_link_github_desc">Unlocks starring and following; also required to claim Pro perks</string>
+    <string name="account_link_github_desc">Unlocks starring, following and other GitHub features</string>
     <string name="account_link_required_title">Link GitHub first</string>
     <string name="account_link_required_message">Pro perks are granted through GitHub Sponsors and need a GitHub account linked to yours. You signed in with email, so sponsoring now would not take effect automatically.</string>
     <string name="account_link_sponsor_anyway">Sponsor anyway</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -219,7 +219,7 @@
     <string name="account_upgrade_cta">Upgrade to Pro</string>
     <string name="account_upgrade_hint">More daily credits · tied to your sponsoring GitHub account</string>
     <string name="account_link_github">Link GitHub</string>
-    <string name="account_link_github_desc">Required for Pro perks, and unlocks starring and following</string>
+    <string name="account_link_github_desc">Unlocks starring and following; also required to claim Pro perks</string>
     <string name="account_link_required_title">Link GitHub first</string>
     <string name="account_link_required_message">Pro perks are granted through GitHub Sponsors and need a GitHub account linked to yours. You signed in with email, so sponsoring now would not take effect automatically.</string>
     <string name="account_link_sponsor_anyway">Sponsor anyway</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -203,10 +203,10 @@
     <string name="profile_repos">Repos</string>
     <string name="profile_pro_badge">PRO</string>
     <string name="profile_quota_title">AI credits</string>
-    <string name="profile_quota_remaining">%1$d of %2$d credits left today</string>
+    <string name="profile_quota_used">%1$s used</string>
+    <string name="profile_quota_exhausted">Daily limit reached</string>
     <string name="profile_quota_reset_hours">Resets in ~%1$d h</string>
     <string name="profile_quota_reset_soon">Resets within an hour</string>
-    <string name="profile_quota_rates">Chat 1 · Search 3 · Research 10</string>
     <string name="profile_quota_error">Couldn&apos;t load credits right now</string>
     <string name="profile_pro_badge_desc">Pro member</string>
     <!-- Account hub -->

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -218,6 +218,11 @@
     <string name="account_tier_pro">Pro</string>
     <string name="account_upgrade_cta">Upgrade to Pro</string>
     <string name="account_upgrade_hint">More daily credits · tied to your sponsoring GitHub account</string>
+    <string name="account_link_github">Link GitHub</string>
+    <string name="account_link_github_desc">Required for Pro perks, and unlocks starring and following</string>
+    <string name="account_link_required_title">Link GitHub first</string>
+    <string name="account_link_required_message">Pro perks are granted through GitHub Sponsors and need a GitHub account linked to yours. You signed in with email, so sponsoring now would not take effect automatically.</string>
+    <string name="account_link_sponsor_anyway">Sponsor anyway</string>
     <string name="account_signin_for_more">Sign in to get 10 credits a day</string>
     <string name="account_pro_active">You&apos;re a Pro member — thanks for the support!</string>
     <string name="account_github_entry">GitHub profile</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/AccountLink.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/AccountLink.kt
@@ -1,0 +1,54 @@
+package whl.trending.ai.core
+
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import whl.trending.ai.auth.LOGTO_ENDPOINT
+import whl.trending.ai.core.platform.getSystemLanguage
+import whl.trending.ai.core.platform.openUrl
+import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.data.local.globalSettingsManager
+
+/**
+ * 关联 GitHub 身份的入口 + 回前台刷新窗口。
+ *
+ * 背景：Pro 权益以 GitHub 数字 ID 为唯一键发放（后端 `pro_entitlements`），邮箱登录用户
+ * 的 Logto 账户没有 github identity，直接去赞助会「钱付了但权益对不上」。此处引导他们先
+ * 把 GitHub 关联到当前账户，关联后 identity 一挂上，Pro 判定与 GitHub 能力全部自动打通。
+ *
+ * 关联页是 Logto 预构建的单任务流程（见 [Constants.accountLinkGithubUrl]），必须在应用外
+ * 打开——它依赖浏览器侧的 Logto 会话 cookie，内置 WebView 里没有。因此与赞助页同构：
+ * 出去做事 → 用户手动返回 → ON_RESUME 时在 [shouldRefreshIdentity] 窗口内刷新身份。
+ */
+object AccountLink {
+
+    /** 打开关联页后允许刷新身份的时间窗口：够走完邮箱验证码 + GitHub 授权，又给请求数封顶。 */
+    private val REFRESH_WINDOW = 30.minutes
+
+    /** 入口来源词汇，用于 account_link_* 漏斗按入口拆分。 */
+    const val SOURCE_ACCOUNT = "account"
+    const val SOURCE_UPGRADE_DIALOG = "upgrade_dialog"
+
+    /** 打开 Logto 账户中心的 GitHub 关联页，并开启回前台刷新窗口。 */
+    fun openLinkGithubPage(source: String) {
+        trackEvent("account_link_start", mapOf("source" to source))
+        globalSettingsManager.setAccountLinkOpenedAt(Clock.System.now().toEpochMilliseconds())
+        openUrl(Constants.accountLinkGithubUrl(LOGTO_ENDPOINT, uiLocale()))
+    }
+
+    /** Logto 页面语言：跟 App 语言走，「跟随系统」时回落到系统语言。 */
+    private fun uiLocale(): String =
+        globalSettingsManager.currentAppLanguage().isoCode ?: getSystemLanguage()
+
+    /** 是否处于「刚打开过关联页」的窗口内——没去关联过的用户回前台零后端请求。 */
+    fun shouldRefreshIdentity(): Boolean {
+        val openedAt = globalSettingsManager.currentAccountLinkOpenedAt()
+        return openedAt > 0 &&
+            Clock.System.now().toEpochMilliseconds() - openedAt < REFRESH_WINDOW.inWholeMilliseconds
+    }
+
+    /** 确认身份已带上 GitHub 后调用，结束窗口。 */
+    fun markLinked() {
+        trackEvent("account_link_success")
+        globalSettingsManager.clearAccountLinkOpenedAt()
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/AccountLink.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/AccountLink.kt
@@ -2,6 +2,8 @@ package whl.trending.ai.core
 
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import whl.trending.ai.auth.LOGTO_ENDPOINT
 import whl.trending.ai.core.platform.getSystemLanguage
 import whl.trending.ai.core.platform.openUrl
@@ -51,9 +53,18 @@ object AccountLink {
             Clock.System.now().toEpochMilliseconds() - openedAt < REFRESH_WINDOW.inWholeMilliseconds
     }
 
-    /** 确认身份已带上 GitHub 后调用，结束窗口。 */
+    /**
+     * 关联成功信号。刷新身份的是 Activity 的 ON_RESUME（见 MainActivity），而账户页的
+     * [ProfileViewModel] 早已组合完毕、不会自己重拉——没有这个信号，Logto 那边绑好了，
+     * 界面却仍停在「关联 GitHub」。
+     */
+    private val _linked = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val linked: SharedFlow<Unit> = _linked
+
+    /** 确认身份已带上 GitHub 后调用：结束窗口并通知界面重载。 */
     fun markLinked() {
         trackEvent("account_link_success")
         globalSettingsManager.clearAccountLinkOpenedAt()
+        _linked.tryEmit(Unit)
     }
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/AccountLink.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/AccountLink.kt
@@ -35,9 +35,14 @@ object AccountLink {
         openUrl(Constants.accountLinkGithubUrl(LOGTO_ENDPOINT, uiLocale()))
     }
 
-    /** Logto 页面语言：跟 App 语言走，「跟随系统」时回落到系统语言。 */
-    private fun uiLocale(): String =
-        globalSettingsManager.currentAppLanguage().isoCode ?: getSystemLanguage()
+    /**
+     * Logto 页面语言：跟 App 语言走，「跟随系统」时回落到系统语言。
+     * 中文必须给 `zh-CN`——实测传裸 `zh` 时 Logto 匹配不到语言包，静默回落英文。
+     */
+    private fun uiLocale(): String {
+        val iso = globalSettingsManager.currentAppLanguage().isoCode ?: getSystemLanguage()
+        return if (iso.startsWith("zh")) "zh-CN" else iso
+    }
 
     /** 是否处于「刚打开过关联页」的窗口内——没去关联过的用户回前台零后端请求。 */
     fun shouldRefreshIdentity(): Boolean {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/Constants.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/Constants.kt
@@ -9,4 +9,24 @@ object Constants {
     const val GITHUB_SPONSORS_URL = "https://github.com/sponsors/HarlonWang"
     const val ALIPAY_ACCOUNT = "15865268560@163.com"
     const val AUTHOR_EMAIL = "81813780@qq.com"
+
+    /**
+     * Logto 账户中心的 GitHub 连接器 ID（后台「连接器 → GitHub」页的 ID，随租户固定）。
+     * 用于拼「关联社交身份」的预构建页地址，见 [accountLinkGithubUrl]。
+     */
+    private const val LOGTO_GITHUB_CONNECTOR_ID = "0xb17od4fhlnc4z1wmo8m"
+
+    /**
+     * Logto 预构建的「关联 GitHub」单任务流程页。Logto 自己完成身份验证（邮箱验证码）
+     * 与 GitHub 授权，我们只需在外部浏览器打开它。
+     *
+     * 刻意不传 `redirect=`：app 的 `cn.trendingai://` scheme 由 Logto SDK 的授权 Activity
+     * 独占，回跳会被当成 OAuth 登录回调解析。改用 `show_success=true` 让成功页停留，
+     * 用户手动返回 app，由 ON_RESUME 触发身份刷新（与赞助页回来对账同一套机制）。
+     *
+     * `ui_locales` 必传：实测 Custom Tab 里 Logto 不认浏览器的 Accept-Language，
+     * 不传会让中文用户看到英文页面。
+     */
+    fun accountLinkGithubUrl(endpoint: String, uiLocale: String): String =
+        "$endpoint/account/social/$LOGTO_GITHUB_CONNECTOR_ID?show_success=true&ui_locales=$uiLocale"
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -122,6 +122,7 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val FEED_HIGHLIGHTS_ONLY_KEY = "prefs_feed_filter_highlights"
     private val IS_PRO_KEY = "prefs_is_pro"
     private val SPONSOR_PAGE_OPENED_AT_KEY = "prefs_sponsor_page_opened_at"
+    private val ACCOUNT_LINK_OPENED_AT_KEY = "prefs_account_link_opened_at"
     private val SELECTED_CHAT_MODEL_KEY = "prefs_selected_chat_model"
     private val OPEN_LINKS_IN_CUSTOM_TAB_KEY = "prefs_open_links_in_custom_tab"
     private val TRENDING_NEW_ONLY_DEFAULT_KEY = "prefs_trending_new_only_default"
@@ -295,6 +296,11 @@ class SettingsManager(private val settings: ObservableSettings) {
 
     val appLanguage: Flow<AppLanguage> = settings.getIntFlow(LANGUAGE_KEY, AppLanguage.FOLLOW_SYSTEM.ordinal)
         .map { AppLanguage.entries.getOrElse(it) { AppLanguage.FOLLOW_SYSTEM } }
+
+    /** 同步读当前 App 语言，供非 Compose 上下文使用（如拼外链的 ui_locales 参数）。 */
+    fun currentAppLanguage(): AppLanguage = AppLanguage.entries.getOrElse(
+        settings.getInt(LANGUAGE_KEY, AppLanguage.FOLLOW_SYSTEM.ordinal)
+    ) { AppLanguage.FOLLOW_SYSTEM }
 
     fun setLanguage(language: AppLanguage) {
         settings.putInt(LANGUAGE_KEY, language.ordinal)
@@ -473,6 +479,20 @@ class SettingsManager(private val settings: ObservableSettings) {
 
     fun clearSponsorPageOpenedAt() {
         settings.putLong(SPONSOR_PAGE_OPENED_AT_KEY, 0L)
+    }
+
+    /**
+     * 最近一次打开 Logto 账户中心「关联 GitHub」页的时间戳（epoch millis），0 表示无待刷新的绑定意图。
+     * 与赞助时间戳分开：两者回前台后要做的事不同（绑定要先刷身份，赞助只需对账 Pro）。
+     */
+    fun currentAccountLinkOpenedAt(): Long = settings.getLong(ACCOUNT_LINK_OPENED_AT_KEY, 0L)
+
+    fun setAccountLinkOpenedAt(time: Long) {
+        settings.putLong(ACCOUNT_LINK_OPENED_AT_KEY, time)
+    }
+
+    fun clearAccountLinkOpenedAt() {
+        settings.putLong(ACCOUNT_LINK_OPENED_AT_KEY, 0L)
     }
 
     /** 选中的聊天模型 id：发请求时透传（服务端仍按 tier 强制）。默认免费 gpt-5.4。 */

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -151,8 +151,12 @@ open class TrendingApi {
         }
     }
 
-    open suspend fun fetchMe(accessToken: String): MeResponse {
-        val response = client.get("$baseHost/api/me") {
+    /**
+     * [fresh] = true 时带 `?fresh=1`：让服务端绕过 userinfo claims 的 10 分钟缓存重新拉取。
+     * 仅用于刚在账户中心关联身份后——否则读到的仍是关联前的 identities，UI 会以为没绑上。
+     */
+    open suspend fun fetchMe(accessToken: String, fresh: Boolean = false): MeResponse {
+        val response = client.get("$baseHost/api/me${if (fresh) "?fresh=1" else ""}") {
             header(HttpHeaders.Authorization, "Bearer $accessToken")
         }
         if (response.status.value !in 200..299) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/UserRepository.kt
@@ -11,7 +11,8 @@ open class UserRepository(private val api: TrendingApi = TrendingApi()) {
 
     // 真正的测试注入点：覆写此方法即可同时影响 fetchMe 与 syncMe（二者都经它取数）。
     // 注意：只覆写下面的 fetchMe 不影响 syncMe——syncMe 直接调 fetchMeResponse，会打真网络。
-    open suspend fun fetchMeResponse(accessToken: String): MeResponse = api.fetchMe(accessToken)
+    open suspend fun fetchMeResponse(accessToken: String, fresh: Boolean = false): MeResponse =
+        api.fetchMe(accessToken, fresh)
 
     open suspend fun fetchMe(accessToken: String): MeUser = fetchMeResponse(accessToken).user
 
@@ -26,10 +27,10 @@ open class UserRepository(private val api: TrendingApi = TrendingApi()) {
      * 登录成功/应用启动（已登录）时调用：服务端建档 + 刷新 last_login_at，并缓存头像与 Pro 权益态。
      * 失败静默——下次打开 Profile 仍会重试，不阻塞登录主流程。
      */
-    suspend fun syncMe(accessToken: String?): MeUser? {
+    suspend fun syncMe(accessToken: String?, fresh: Boolean = false): MeUser? {
         if (accessToken == null) return null
         return try {
-            val me = fetchMeResponse(accessToken)
+            val me = fetchMeResponse(accessToken, fresh)
             globalSettingsManager.setUserAvatarUrl(me.user.avatarUrl)
             globalSettingsManager.setGithubIdentity(me.user.githubLogin, me.user.githubUserId)
             globalSettingsManager.setUserEmail(me.user.email)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/AccountScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/AccountScreen.kt
@@ -286,7 +286,7 @@ fun AccountScreen(
                         item(key = "github_entry") {
                             GithubEntryCard(uiState = uiState, onClick = onNavigateToGithubProfile)
                         }
-                    } else if (uiState.user?.githubUserId == null) {
+                    } else if (uiState.loggedIn && uiState.user?.githubUserId == null) {
                         item(key = "link_github") {
                             LinkGithubCard(onClick = {
                                 AccountLink.openLinkGithubPage(AccountLink.SOURCE_ACCOUNT)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/AccountScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/AccountScreen.kt
@@ -99,8 +99,8 @@ import trendingai.shared.generated.resources.open_system_settings
 import trendingai.shared.generated.resources.personalization
 import trendingai.shared.generated.resources.profile_load_failed
 import trendingai.shared.generated.resources.profile_quota_error
-import trendingai.shared.generated.resources.profile_quota_rates
-import trendingai.shared.generated.resources.profile_quota_remaining
+import trendingai.shared.generated.resources.profile_quota_exhausted
+import trendingai.shared.generated.resources.profile_quota_used
 import trendingai.shared.generated.resources.profile_quota_reset_hours
 import trendingai.shared.generated.resources.profile_quota_reset_soon
 import trendingai.shared.generated.resources.profile_followers
@@ -113,6 +113,7 @@ import trendingai.shared.generated.resources.sign_out
 import trendingai.shared.generated.resources.sign_out_confirm
 import trendingai.shared.generated.resources.subscribe_title
 import trendingai.shared.generated.resources.subscription_reminders
+import kotlin.math.roundToInt
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.core.DateTimeUtils
 import whl.trending.ai.core.AccountLink
@@ -576,17 +577,28 @@ private fun PlanUsageCard(
 
             when {
                 quota != null -> {
+                    // 只讲「用掉了多大比例」和「何时重置」，不透出余额绝对值与单价：
+                    // 用户无从算计单价，后端调价/调额度也不必跟着改文案（改了就会说谎）。
+                    val usedRatio = remember(quota.balance, quota.dailyGrant) {
+                        if (quota.dailyGrant <= 0) 0f
+                        else ((quota.dailyGrant - quota.balance).toFloat() / quota.dailyGrant)
+                            .coerceIn(0f, 1f)
+                    }
+                    val exhausted = quota.balance <= 0
                     Text(
-                        stringResource(Res.string.profile_quota_remaining, quota.balance, quota.dailyGrant),
+                        if (exhausted) stringResource(Res.string.profile_quota_exhausted)
+                        else stringResource(
+                            Res.string.profile_quota_used,
+                            "${(usedRatio * 100).roundToInt()}%",
+                        ),
                         style = MaterialTheme.typography.bodyLarge,
                     )
                     LinearProgressIndicator(
-                        progress = {
-                            if (quota.dailyGrant <= 0) 0f
-                            else (quota.balance.toFloat() / quota.dailyGrant).coerceIn(0f, 1f)
-                        },
-                        // 用 secondary 而非 primary：满格时整条主题色过重，抢走卡片焦点
-                        color = MaterialTheme.colorScheme.secondary,
+                        // 进度条走「已用」方向：没用过时是空条（视觉最轻），越用越长；
+                        // 逼近上限才转 error 红，让「该升级了」的信号在需要时自己浮现。
+                        progress = { usedRatio },
+                        color = if (usedRatio >= 0.9f) MaterialTheme.colorScheme.error
+                        else MaterialTheme.colorScheme.secondary,
                         modifier = Modifier.fillMaxWidth(),
                     )
                     val resetHours = remember(quota.resetAt) { DateTimeUtils.hoursUntil(quota.resetAt) }
@@ -595,12 +607,13 @@ private fun PlanUsageCard(
                         resetHours <= 1 -> stringResource(Res.string.profile_quota_reset_soon)
                         else -> stringResource(Res.string.profile_quota_reset_hours, resetHours)
                     }
-                    Text(
-                        listOfNotNull(resetText, stringResource(Res.string.profile_quota_rates))
-                            .joinToString(" · "),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    if (resetText != null) {
+                        Text(
+                            resetText,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
 
                 quotaError -> Text(

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/AccountScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/AccountScreen.kt
@@ -72,6 +72,11 @@ import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.about_us
 import trendingai.shared.generated.resources.account_github_entry
 import trendingai.shared.generated.resources.account_github_entry_desc
+import trendingai.shared.generated.resources.account_link_github
+import trendingai.shared.generated.resources.account_link_github_desc
+import trendingai.shared.generated.resources.account_link_required_message
+import trendingai.shared.generated.resources.account_link_required_title
+import trendingai.shared.generated.resources.account_link_sponsor_anyway
 import trendingai.shared.generated.resources.account_plan_title
 import trendingai.shared.generated.resources.account_pro_active
 import trendingai.shared.generated.resources.account_signed_out_prompt
@@ -110,6 +115,7 @@ import trendingai.shared.generated.resources.subscribe_title
 import trendingai.shared.generated.resources.subscription_reminders
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.core.DateTimeUtils
+import whl.trending.ai.core.AccountLink
 import whl.trending.ai.core.ProSponsor
 import whl.trending.ai.core.platform.openAppSettings
 import whl.trending.ai.core.platform.trackEvent
@@ -158,6 +164,7 @@ fun AccountScreen(
     )
 
     var showSignOutDialog by remember { mutableStateOf(false) }
+    var showLinkGithubDialog by remember { mutableStateOf(false) }
 
     val snackbarHostState = remember { SnackbarHostState() }
     val settingsScope = rememberCoroutineScope()
@@ -182,6 +189,32 @@ fun AccountScreen(
             dismissButton = {
                 TextButton(onClick = { showSignOutDialog = false }) {
                     Text(stringResource(Res.string.cancel))
+                }
+            },
+        )
+    }
+
+    // 邮箱用户点「升级 Pro」时的拦截：Pro 权益以 GitHub 账户为发放主体，不先关联就会
+    // 「钱付了但权益对不上」。次按钮保留直接前往赞助页——有人只是想单纯支持，不图权益。
+    if (showLinkGithubDialog) {
+        AlertDialog(
+            onDismissRequest = { showLinkGithubDialog = false },
+            title = { Text(stringResource(Res.string.account_link_required_title)) },
+            text = { Text(stringResource(Res.string.account_link_required_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showLinkGithubDialog = false
+                    AccountLink.openLinkGithubPage(AccountLink.SOURCE_UPGRADE_DIALOG)
+                }) {
+                    Text(stringResource(Res.string.account_link_github))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showLinkGithubDialog = false
+                    ProSponsor.openSponsorPage(ProSponsor.SOURCE_ACCOUNT)
+                }) {
+                    Text(stringResource(Res.string.account_link_sponsor_anyway))
                 }
             },
         )
@@ -236,15 +269,28 @@ fun AccountScreen(
                             quotaError = uiState.quotaError,
                             loggedIn = uiState.loggedIn,
                             isPro = isPro,
-                            onUpgrade = { ProSponsor.openSponsorPage(ProSponsor.SOURCE_ACCOUNT) },
+                            onUpgrade = {
+                                // 没有 GitHub 身份就直奔赞助页 = 让用户白花钱，先引导关联
+                                if (uiState.user?.githubUserId == null) showLinkGithubDialog = true
+                                else ProSponsor.openSponsorPage(ProSponsor.SOURCE_ACCOUNT)
+                            },
                             onSignIn = { globalAuthManager.signIn("account_hub") },
                         )
                     }
 
-                    // ③ GitHub 主页入口卡（仅 GitHub 用户）
+                    // ③ GitHub 区：已关联给主页入口，未关联给关联入口。
+                    // 两处条件刻意不对称——githubUserId 是「是否已关联」的权威（Pro 判定同源），
+                    // githubLogin 才是能展示的名字。中间态（有 id 无 login，资料未同步）两块都不显示，
+                    // 好过让已关联的用户看到「关联 GitHub」或让主页卡显示 @null。
                     if (uiState.user?.githubLogin != null) {
                         item(key = "github_entry") {
                             GithubEntryCard(uiState = uiState, onClick = onNavigateToGithubProfile)
+                        }
+                    } else if (uiState.user?.githubUserId == null) {
+                        item(key = "link_github") {
+                            LinkGithubCard(onClick = {
+                                AccountLink.openLinkGithubPage(AccountLink.SOURCE_ACCOUNT)
+                            })
                         }
                     }
 
@@ -628,6 +674,32 @@ private fun TierPillFree() {
             .clip(MaterialTheme.shapes.small)
             .background(MaterialTheme.colorScheme.surfaceVariant)
             .padding(horizontal = 8.dp, vertical = 2.dp),
+    )
+}
+
+/**
+ * 关联 GitHub 入口卡（仅无 GitHub 身份的用户可见）。与 [GithubEntryCard] 同一套列表行语言，
+ * 占据它的位置——一个账户在这里要么是「已连接的 GitHub」，要么是「去连接」。
+ */
+@Composable
+private fun LinkGithubCard(onClick: () -> Unit) {
+    ListItem(
+        headlineContent = { Text(stringResource(Res.string.account_link_github)) },
+        supportingContent = {
+            Text(
+                stringResource(Res.string.account_link_github_desc),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        leadingContent = {
+            Icon(Icons.Default.AccountCircle, null, modifier = Modifier.size(40.dp))
+        },
+        trailingContent = {
+            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+        },
+        colors = ListItemDefaults.colors(containerColor = androidx.compose.ui.graphics.Color.Transparent),
+        modifier = Modifier.clickable(onClick = onClick),
     )
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/AccountScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/AccountScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.LoadingIndicator
@@ -62,6 +62,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -593,12 +596,20 @@ private fun PlanUsageCard(
                         ),
                         style = MaterialTheme.typography.bodyLarge,
                     )
-                    LinearProgressIndicator(
-                        // 进度条走「已用」方向：没用过时是空条（视觉最轻），越用越长；
+                    // 加粗到 8dp（默认 4dp）。振幅用组件默认函数：≤10% 与 ≥95% 自动收平成
+                    // 直线——逼近上限时正好是红色直线，比红色波浪更像警示，不必自定义。
+                    val barStroke = with(LocalDensity.current) {
+                        Stroke(width = 8.dp.toPx(), cap = StrokeCap.Round)
+                    }
+                    LinearWavyProgressIndicator(
+                        // 走「已用」方向：没用过时是空条（视觉最轻），越用越长；
                         // 逼近上限才转 error 红，让「该升级了」的信号在需要时自己浮现。
                         progress = { usedRatio },
                         color = if (usedRatio >= 0.9f) MaterialTheme.colorScheme.error
                         else MaterialTheme.colorScheme.secondary,
+                        stroke = barStroke,
+                        trackStroke = barStroke,
+                        // 保持默认容器高度：振幅按容器高度等比放大，撑高后波形会夸张到喧宾夺主
                         modifier = Modifier.fillMaxWidth(),
                     )
                     val resetHours = remember(quota.resetAt) { DateTimeUtils.hoursUntil(quota.resetAt) }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -15,6 +15,7 @@ import whl.trending.ai.auth.FollowingProvider
 import whl.trending.ai.auth.GithubTokenProvider
 import whl.trending.ai.auth.OwnRepoEventsProvider
 import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.core.AccountLink
 import whl.trending.ai.data.local.LastDataCache
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.local.globalLastDataCache
@@ -132,6 +133,15 @@ class ProfileViewModel(
                     }
                     is AuthState.LoggingIn -> Unit
                 }
+            }
+        }
+
+        // 关联 GitHub 成功：身份变了但登录态没变，authState 不会发射，只能靠这个信号。
+        // MainActivity 在 ON_RESUME 里已用 fresh 请求刷过服务端缓存，这里普通重载即可拿到新身份。
+        viewModelScope.launch {
+            AccountLink.linked.collect {
+                hasLoaded = false
+                load()
             }
         }
     }


### PR DESCRIPTION
## 问题

Pro 权益以 GitHub 数字 ID 为唯一键发放（后端 `pro_entitlements`），邮箱登录用户的 Logto 账户没有 github identity。他们点「升级 Pro」会直奔 GitHub Sponsors，赞助之后：

- webhook 按 `sponsorship.sponsor.id` 记账，权益挂在那个 GitHub 账户名下（钱没白花）
- 但当前 Logto 会话没有 github identity → `githubUserIdFromClaims` 返回 null → `/api/pro/refresh` 早退 → app 内**永远显示免费版，且没有任何解释**

掏钱之后才发现的静默失败。补救只能改用 GitHub 登录，而那是另一个账户，收藏和历史都不在一起。

## 方案

引导他们把 GitHub 关联到**当前**账户。关联后 identity 一挂上，Pro 判定、GitHub token（star/关注）全部自动打通，后端零改动。

关联走 Logto 预构建的 `/account/social/<connectorId>` 单任务页——Logto 自己完成邮箱验证码 + GitHub 授权，客户端只负责在外部浏览器打开它，省掉自行实现 verification + link 三步 API 和 OAuth 回调。

**刻意不传 `redirect=`**：`cn.trendingai://` scheme 由 Logto SDK 的授权 Activity 独占，回跳会被当成 OAuth 登录回调解析。改用 `show_success=true` 让成功页停留、用户手动返回，由 ON_RESUME 触发刷新——与「赞助页回来对账」复用同一套已验证的机制。

## 改动

- 账户页在 GitHub 主页卡的位置给出「关联 GitHub」入口（仅登录且无 GitHub 身份时）
- 邮箱用户点「升级 Pro」先弹说明，主按钮去关联，次按钮仍可直接赞助（有人只想单纯支持，不图权益）
- 回前台后按 `AccountLink` 窗口刷新身份（`/api/me?fresh=1` 绕开服务端 claims 缓存），拿到 `github_user_id` 再补一次 `pro/refresh`——覆盖「关联前就已赞助」的存量用户
- `AccountLink.linked` 信号：关联成功后通知 `ProfileViewModel` 重载。登录态没变、`authState` 不发射，没有这个信号界面会停在「关联 GitHub」
- 埋点 `account_link_start` / `account_link_success`

## 依赖

- 后端 PR `HarlonWang/github-ai-trending-api#25`（`?fresh=1`）**需先上线**
- Logto 后台：账户中心 → 身份标识 → 社交身份改为「可编辑」、电子邮件地址改为「只读」（验证身份需要）— 已配置
- GitHub OAuth App 回调地址放宽到 `https://auth.trendingai.cn/` — 已配置，原因见下

## 真机验证（Pixel_9_2）

用一个只有邮箱、无 GitHub 身份的 Logto 账号完整跑通：入口显示 → 升级拦截 → 邮箱验证码 → GitHub 授权（测试小号）→ 「更新成功」→ Logto 侧 identity 写入（令牌活跃）→ `/api/me` 返回 GitHub 身份 → 界面切换为「GitHub 主页」入口。

冲突路径也实测到了：GitHub 已属于另一个 Logto 用户时 Logto 拒绝关联，app 正确降级（仍显示未关联），不产生脏数据。

### 过程中修掉的坑

1. **GitHub OAuth App 回调地址**：绑定流程用 `/account/callback/social/<id>`，与登录的 `/callback/<id>` 没有公共前缀，OAuth App 又只能填一个回调地址 → 放宽到根路径，两条流程都匹配
2. **匿名态误显示入口**：`user` 为 null 时 `githubUserId` 自然也是 null，条件被意外命中
3. **`ui_locales` 传裸 `zh` 静默回落英文**：Logto 只认 `zh-CN`
4. **绑定成功后界面不刷新**：即上面的 `AccountLink.linked` 信号

## 范围

仅 Android。`iosApp` / `iosMain` 目前没有任何 Logto 集成，登录是 Android 独有能力。本期不做解绑（Logto 的 `/remove` 路由现成，但解绑会让 Pro 失效，价值低风险高）。

## 已知限制

Logto 预构建 UI 在「该 GitHub 已关联到其他账户」时给的是英文 toast，即使页面其余部分是中文。这是 Logto 的翻译缺口，改不了；要处理就得放弃预构建 UI 自行实现三步 API，不划算。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6Vw5zmB2PyJCjgbqZC8AF