### PR TITLE
refactor(ui): 顶栏滚动变色统一到 TrendingScaffold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,25 @@
     ```
     不传 `indicator` 会回落到默认的 `CircularProgressIndicator`，与全 app 的 `LoadingIndicator` 风格不一致。参照 `Picks/Feed/Trending/Profile` 各 Screen 的写法。
 
+- **页面骨架统一**：所有页面用 `whl.trending.ai.ui.common` 的 `TrendingScaffold` + `TrendingTopAppBar`，**不直接用 `Scaffold` + `TopAppBar`**。
+
+  ```kotlin
+  TrendingScaffold(
+      topBar = {
+          TrendingTopAppBar(
+              title = { Text(stringResource(Res.string.xxx)) },
+              navigationIcon = { /* 返回键 */ },
+          )
+      },
+  ) { padding -> /* content */ }
+  ```
+
+  - 效果：内容滚动时顶栏底色从 `surface` 过渡到 `surfaceContainer`（M3 的 scrolledContainerColor），把顶栏和滚上来的内容分开。全 app 统一为 `pinnedScrollBehavior`——顶栏只变色、不折叠隐藏。
+  - `scrollBehavior` 的创建、`Modifier.nestedScroll` 挂载、传给 `TopAppBar` 这三步都封在组件内部，经 `LocalTopAppBarScrollBehavior` 送达。**页面不要自己 `remember` behavior，也不要把它当参数往下传**——顶栏常被拆成独立的私有 composable（首页四个 tab 各一个），手工传参只要漏一处，那一页就静默失去变色，正是 0.22.0 前的状态。
+  - 顶栏拆成子 composable 时，子函数里直接调 `TrendingTopAppBar` 即可，不需要任何参数透传。
+  - `TrendingScaffold` 只透传各页实际用到的 `Scaffold` 参数，缺什么补什么。
+  - **唯一例外是 `ReadmeScreen`**：正文是 WebView，滚动不经过 Compose 的 nestedScroll，收不到变色事件，因此保留原生 `Scaffold` + 写死 `containerColor = surfaceContainer`。改动那一页时别"顺手统一"回来。
+
 ## 发布前冒烟（必做）
 
 **打 tag 前必须跑 `scripts/release-smoke.sh` 并看到 PASS。** 它构建 r2 渠道 release 包（与线上同样开 R8 minify）、安装到 Pixel_9_2 模拟器、启动并检查崩溃日志与进程存活。日常开发全用 debug 包（不混淆），R8 裁剪类问题只有 release 包能暴露——0.20.0 曾因此启动即崩、发布后才发现（room 2.6.1 老 keep 规则 + R8 full mode 裁掉 WorkDatabase_Impl 构造器）。FAIL 时禁止发布，先按崩溃堆栈排查。

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -18,9 +18,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalNavigationDrawer
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -40,6 +38,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 import whl.trending.ai.chat.ChatContext
+import whl.trending.ai.ui.common.TrendingScaffold
+import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.chat.ChatViewModel
 import whl.trending.chat.DetailSummaryPolicy
 import whl.trending.chat.R
@@ -137,9 +137,9 @@ fun ChatScreen(
             )
         },
     ) {
-        Scaffold(
+        TrendingScaffold(
             topBar = {
-                TopAppBar(
+                TrendingTopAppBar(
                     title = {
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Text(

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/TrendingScaffold.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/TrendingScaffold.kt
@@ -1,0 +1,95 @@
+package whl.trending.ai.ui.common
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+
+/**
+ * 当前页面的顶栏滚动行为，由 [TrendingScaffold] 提供、[TrendingTopAppBar] 自动消费。
+ *
+ * 走 CompositionLocal 而不是逐层传参，是因为顶栏常被拆成独立的私有 composable（首页四个 tab 各一个），
+ * 手工传参时只要有一处忘了写，那一页就静默失去滚动变色——正是这次要统一掉的问题。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+val LocalTopAppBarScrollBehavior = compositionLocalOf<TopAppBarScrollBehavior?> { null }
+
+/**
+ * 全 app 统一的页面骨架：在 [Scaffold] 基础上把顶栏的滚动联动接好。
+ *
+ * 内容滚动时，顶栏底色会从 `surface` 过渡到 `surfaceContainer`（M3 的 scrolledContainerColor），
+ * 用一层底色把顶栏和滚上来的内容区分开。行为固定为 [TopAppBarDefaults.pinnedScrollBehavior]：
+ * 顶栏只变色、不折叠隐藏。
+ *
+ * 页面不要直接用 [Scaffold] + [TopAppBar]，否则拿不到这套联动。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TrendingScaffold(
+    modifier: Modifier = Modifier,
+    scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(),
+    topBar: @Composable () -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
+    snackbarHost: @Composable () -> Unit = {},
+    floatingActionButton: @Composable () -> Unit = {},
+    floatingActionButtonPosition: FabPosition = FabPosition.End,
+    containerColor: Color = MaterialTheme.colorScheme.background,
+    contentColor: Color = contentColorFor(containerColor),
+    contentWindowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    CompositionLocalProvider(LocalTopAppBarScrollBehavior provides scrollBehavior) {
+        Scaffold(
+            modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+            topBar = topBar,
+            bottomBar = bottomBar,
+            snackbarHost = snackbarHost,
+            floatingActionButton = floatingActionButton,
+            floatingActionButtonPosition = floatingActionButtonPosition,
+            containerColor = containerColor,
+            contentColor = contentColor,
+            contentWindowInsets = contentWindowInsets,
+            content = content,
+        )
+    }
+}
+
+/**
+ * 全 app 统一的顶栏：默认取用 [TrendingScaffold] 提供的滚动行为，调用方无需接线。
+ *
+ * 不在 [TrendingScaffold] 里时（LocalTopAppBarScrollBehavior 为 null）退化成普通 [TopAppBar]。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TrendingTopAppBar(
+    title: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable RowScope.() -> Unit = {},
+    colors: TopAppBarColors = TopAppBarDefaults.topAppBarColors(),
+    scrollBehavior: TopAppBarScrollBehavior? = LocalTopAppBarScrollBehavior.current,
+) {
+    TopAppBar(
+        title = title,
+        modifier = modifier,
+        navigationIcon = navigationIcon,
+        actions = actions,
+        colors = colors,
+        scrollBehavior = scrollBehavior,
+    )
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
@@ -213,6 +213,9 @@ fun ReadmeScreen(
                         )
                     }
                 },
+                // 全 app 唯一不走 TrendingScaffold + TrendingTopAppBar 的页面：正文是 WebView，
+                // 它的滚动不经过 Compose 的 nestedScroll，滚动驱动的顶栏变色在这里根本收不到事件。
+                // 故直接固定成滚动后的色值，视觉上与其他页滚起来之后保持一致。别按统一规范改回去。
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.surfaceContainer
                 )

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/favorites/FavoriteListScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/favorites/FavoriteListScreen.kt
@@ -4,6 +4,8 @@ import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.globalFavoriteRepository
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.ui.common.AiSummaryBox
+import whl.trending.ai.ui.common.TrendingScaffold
+import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.ai.ui.picks.SourceTag
 import whl.trending.ai.core.platform.trackEvent
 import androidx.compose.runtime.LaunchedEffect
@@ -31,12 +33,8 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -71,19 +69,16 @@ fun FavoriteListScreen(
     onOpenUrl: (url: String) -> Unit = {}
 ) {
     val favorites by globalSettingsManager.favorites.collectAsState(emptyList())
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     LaunchedEffect(Unit) {
         val items = globalSettingsManager.favorites.first()
         trackEvent("favorite_list_view", mapOf("count" to items.size))
     }
 
-    Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+    TrendingScaffold(
         topBar = {
-            TopAppBar(
+            TrendingTopAppBar(
                 title = { Text(stringResource(Res.string.favorites)) },
-                scrollBehavior = scrollBehavior,
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(Res.string.back))

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feedback/FeedbackScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feedback/FeedbackScreen.kt
@@ -1,6 +1,8 @@
 package whl.trending.ai.ui.feedback
 
 import whl.trending.ai.core.Constants
+import whl.trending.ai.ui.common.TrendingScaffold
+import whl.trending.ai.ui.common.TrendingTopAppBar
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -23,12 +25,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -85,9 +85,9 @@ fun FeedbackScreen(
         }
     }
 
-    Scaffold(
+    TrendingScaffold(
         topBar = {
-            TopAppBar(
+            TrendingTopAppBar(
                 title = { Text(stringResource(Res.string.feedback)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -32,10 +32,7 @@ import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -49,7 +46,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.luminance
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -78,6 +74,8 @@ import whl.trending.ai.chat.globalChatScreen
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.ChatModelsProvider
 import whl.trending.ai.data.repository.UserRepository
+import whl.trending.ai.ui.common.TrendingScaffold
+import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.ai.ui.feed.FeedScreen
 import whl.trending.ai.ui.feed.FeedViewModel
 import whl.trending.ai.ui.picks.PicksScreen
@@ -162,10 +160,7 @@ fun HomeScreen(
         }
     }
 
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
-
-    Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+    TrendingScaffold(
         topBar = {
             when (selectedTab) {
                 HomeTab.GitHub -> TrendingTopBar(
@@ -175,8 +170,7 @@ fun HomeScreen(
                     selectedBatch = trendingUiState.selectedBatch,
                     newOnly = trendingUiState.newOnly,
                     onToggleNewOnly = { trendingViewModel.toggleNewOnly() },
-                    scrollBehavior = scrollBehavior,
-                    onTitleClick = { showFilterSheet = true },
+                                onTitleClick = { showFilterSheet = true },
                     onHistoryClick = { showHistorySheet = true },
                     authState = authState,
                     userAvatarUrl = userAvatarUrl,
@@ -184,8 +178,7 @@ fun HomeScreen(
                 )
                 HomeTab.Picks -> PicksTopBar(
                     date = picksUiState?.picks?.metadata?.date,
-                    scrollBehavior = scrollBehavior,
-                    authState = authState,
+                                authState = authState,
                     userAvatarUrl = userAvatarUrl,
                     onNavigateToAccount = onNavigateToAccount,
                 )
@@ -201,8 +194,7 @@ fun HomeScreen(
                                 tint = Color.Unspecified
                             )
                         },
-                        scrollBehavior = scrollBehavior,
-                        authState = authState,
+                                        authState = authState,
                         userAvatarUrl = userAvatarUrl,
                         onNavigateToAccount = onNavigateToAccount,
                     )
@@ -222,8 +214,7 @@ fun HomeScreen(
                                 tint = Color.Unspecified
                             )
                         },
-                        scrollBehavior = scrollBehavior,
-                        authState = authState,
+                                        authState = authState,
                         userAvatarUrl = userAvatarUrl,
                         onNavigateToAccount = onNavigateToAccount,
                     )
@@ -338,7 +329,6 @@ private fun TrendingTopBar(
     selectedBatch: String?,
     newOnly: Boolean,
     onToggleNewOnly: () -> Unit,
-    scrollBehavior: androidx.compose.material3.TopAppBarScrollBehavior,
     onTitleClick: () -> Unit,
     onHistoryClick: () -> Unit,
     authState: AuthState,
@@ -352,7 +342,7 @@ private fun TrendingTopBar(
         else -> selectedPeriod
     }
 
-    TopAppBar(
+    TrendingTopAppBar(
         title = {
             Column(
                 modifier = Modifier
@@ -388,7 +378,6 @@ private fun TrendingTopBar(
                 )
             }
         },
-        scrollBehavior = scrollBehavior,
         navigationIcon = {
             Box(modifier = Modifier.padding(horizontal = 12.dp), contentAlignment = Alignment.Center) {
                 Icon(
@@ -468,13 +457,11 @@ private fun AccountAction(authState: AuthState, userAvatarUrl: String?, onClick:
 @Composable
 private fun PicksTopBar(
     date: String?,
-    scrollBehavior: androidx.compose.material3.TopAppBarScrollBehavior,
     authState: AuthState,
     userAvatarUrl: String?,
     onNavigateToAccount: () -> Unit,
 ) {
-    TopAppBar(
-        scrollBehavior = scrollBehavior,
+    TrendingTopAppBar(
         title = {
             Column {
                 Text(
@@ -502,13 +489,11 @@ private fun PicksTopBar(
 private fun FeedTopBar(
     title: String,
     navigationIcon: @Composable () -> Unit,
-    scrollBehavior: androidx.compose.material3.TopAppBarScrollBehavior,
     authState: AuthState,
     userAvatarUrl: String?,
     onNavigateToAccount: () -> Unit,
 ) {
-    TopAppBar(
-        scrollBehavior = scrollBehavior,
+    TrendingTopAppBar(
         title = {
             Text(
                 text = title,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/AccountScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/AccountScreen.kt
@@ -40,14 +40,12 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -131,6 +129,8 @@ import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.QuotaResponse
 import whl.trending.ai.notification.globalDailyPicksNotifier
 import whl.trending.ai.ui.settings.themeModeText
+import whl.trending.ai.ui.common.TrendingScaffold
+import whl.trending.ai.ui.common.TrendingTopAppBar
 
 /**
  * 账户中心（统一 Hub）：应用「关于我」的唯一入口，替代原独立的个人主页 + 设置页。
@@ -227,9 +227,9 @@ fun AccountScreen(
         )
     }
 
-    Scaffold(
+    TrendingScaffold(
         topBar = {
-            TopAppBar(
+            TrendingTopAppBar(
                 title = {
                     Text(stringResource(if (authSupported) Res.string.account_title else Res.string.settings))
                 },

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubProfileScreen.kt
@@ -29,9 +29,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -97,6 +95,8 @@ import trendingai.shared.generated.resources.time_hours_ago
 import trendingai.shared.generated.resources.time_just_now
 import trendingai.shared.generated.resources.time_minutes_ago
 import whl.trending.ai.core.DateTimeUtils
+import whl.trending.ai.ui.common.TrendingScaffold
+import whl.trending.ai.ui.common.TrendingTopAppBar
 
 /**
  * GitHub 开发者档案子页：从账户 Hub 的「GitHub 主页」入口卡进入。
@@ -133,9 +133,9 @@ fun GithubProfileScreen(
         if (shouldLoadMore) viewModel.loadMoreFeed()
     }
 
-    Scaffold(
+    TrendingScaffold(
         topBar = {
-            TopAppBar(
+            TrendingTopAppBar(
                 title = { Text(stringResource(Res.string.account_github_entry)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/PaginatedListScaffold.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/PaginatedListScaffold.kt
@@ -20,9 +20,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -36,6 +34,8 @@ import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.back
 import trendingai.shared.generated.resources.list_load_failed
 import trendingai.shared.generated.resources.profile_retry
+import whl.trending.ai.ui.common.TrendingScaffold
+import whl.trending.ai.ui.common.TrendingTopAppBar
 
 /**
  * GitHub 下钻列表的通用骨架：TopAppBar + loading/error/empty/列表 四态 + 触底翻页。
@@ -65,9 +65,9 @@ fun <T> PaginatedListScaffold(
         if (shouldLoadMore) onLoadMore()
     }
 
-    Scaffold(
+    TrendingScaffold(
         topBar = {
-            TopAppBar(
+            TrendingTopAppBar(
                 title = { Text(title) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/AboutScreen.kt
@@ -5,6 +5,8 @@ import whl.trending.ai.core.ProSponsor
 import whl.trending.ai.core.platform.getAppVersion
 import whl.trending.ai.core.platform.isIosPlatform
 import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.ui.common.TrendingScaffold
+import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.ai.ui.home.githubLogoPainter
 import whl.trending.ai.update.globalUpdateChecker
 
@@ -37,10 +39,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -88,9 +88,9 @@ fun AboutScreen(
         DonateDialog(onDismiss = { showDonateDialog = false })
     }
 
-    Scaffold(
+    TrendingScaffold(
         topBar = {
-            TopAppBar(
+            TrendingTopAppBar(
                 title = { Text(stringResource(Res.string.about_us)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/AppSettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/AppSettingsScreen.kt
@@ -28,11 +28,9 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -89,6 +87,8 @@ import whl.trending.ai.data.local.SummaryLanguage
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.remote.ApiException
 import whl.trending.ai.data.repository.TrendingRepository
+import whl.trending.ai.ui.common.TrendingScaffold
+import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.ai.ui.home.HomeTab
 
 /**
@@ -148,9 +148,9 @@ fun AppSettingsScreen(
         LanguageCaptureDialog(isLoggedIn = isLoggedIn, onDismiss = { showLangCaptureDialog = false })
     }
 
-    Scaffold(
+    TrendingScaffold(
         topBar = {
-            TopAppBar(
+            TrendingTopAppBar(
                 title = { Text(stringResource(Res.string.app_settings)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/AppearanceScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/AppearanceScreen.kt
@@ -11,6 +11,8 @@ import whl.trending.ai.ui.theme.ThemeSeed
 import whl.trending.ai.ui.theme.SwatchShapes
 import whl.trending.ai.ui.theme.hsvToArgb
 import whl.trending.ai.ui.theme.rememberMorph
+import whl.trending.ai.ui.common.TrendingScaffold
+import whl.trending.ai.ui.common.TrendingTopAppBar
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
@@ -46,10 +48,8 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -96,9 +96,9 @@ fun AppearanceScreen(
         remember { globalSettingsManager.currentCustomSeedColor() }
     )
 
-    Scaffold(
+    TrendingScaffold(
         topBar = {
-            TopAppBar(
+            TrendingTopAppBar(
                 title = { Text(stringResource(Res.string.appearance)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/ColorLabScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/ColorLabScreen.kt
@@ -38,13 +38,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
@@ -91,6 +89,8 @@ import trendingai.shared.generated.resources.color_lab_title
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.CustomThemeEntry
 import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.ui.common.TrendingScaffold
+import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.ai.ui.theme.Hsv
 import whl.trending.ai.ui.theme.ThemeContrastOption
 import whl.trending.ai.ui.theme.ThemeStyleOption
@@ -206,9 +206,9 @@ fun ColorLabScreen(onBack: () -> Unit) {
         }
     }
 
-    Scaffold(
+    TrendingScaffold(
         topBar = {
-            TopAppBar(
+            TrendingTopAppBar(
                 title = { Text(stringResource(Res.string.color_lab_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/subscribe/SubscribeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/subscribe/SubscribeScreen.kt
@@ -1,6 +1,8 @@
 package whl.trending.ai.ui.subscribe
 
 import whl.trending.ai.data.model.SubscribeStatus
+import whl.trending.ai.ui.common.TrendingScaffold
+import whl.trending.ai.ui.common.TrendingTopAppBar
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -25,11 +27,9 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -93,9 +93,9 @@ fun SubscribeScreen(
         }
     }
 
-    Scaffold(
+    TrendingScaffold(
         topBar = {
-            TopAppBar(
+            TrendingTopAppBar(
                 title = { Text(stringResource(Res.string.subscribe_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {


### PR DESCRIPTION
## 问题

首页和收藏页各自手工接了 `pinnedScrollBehavior`，滚动时顶栏底色会从 `surface` 过渡到 `surfaceContainer`；其余 10 处 `TopAppBar` 没接，滚动时不变色——同一个 app 里两种表现。

M3 的顶栏变色要同时做两件事才生效：`Scaffold` 上挂 `Modifier.nestedScroll(behavior.nestedScrollConnection)`，且 `TopAppBar` 收到 `scrollBehavior`。漏掉任一项就静默失效。

## 改动

新增 `shared/.../ui/common/TrendingScaffold.kt`：`TrendingScaffold` + `TrendingTopAppBar` + `LocalTopAppBarScrollBehavior`。behavior 的创建、`nestedScroll` 挂载、传给 `TopAppBar` 三步全封在组件内部，页面只写：

```kotlin
TrendingScaffold(
    topBar = { TrendingTopAppBar(title = { Text(...) }, navigationIcon = { ... }) },
) { padding -> /* content */ }
```

12 处顶栏全部迁移，包括原本已有效果的首页和收藏页——统一之后首页的 `TrendingTopBar` / `PicksTopBar` / `FeedTopBar` 不用再逐个透传 `scrollBehavior` 参数，正是那种传参方式让人容易漏掉一处。`ChatScreen` 在 `androidLibrary/chat`，跨模块引用 shared 的组件（该模块本就 `implementation(project(":shared"))`，依赖方向不变）。

`CLAUDE.md` 的「UI 规范」补了「页面骨架统一」一条，含用法、原理和例外。

## 唯一例外：ReadmeScreen

正文是 WebView，滚动不经过 Compose 的 nestedScroll，收不到变色事件，因此保留原生 `Scaffold` + 写死 `containerColor = surfaceContainer`（视觉上等同于其他页滚动后的状态），并在代码里注明原因，避免以后被「顺手统一」掉。

## 验证

Pixel_9_2 模拟器实测，顶栏取样点像素对比（`surface` = (246,250,250)，`surfaceContainer` = (231,239,239)）：

| 页面 | 结果 |
|---|---|
| 首页 GitHub tab | 246 → 231 ✅ 原有效果保持 |
| 账户页 | 246 → 231 ✅ 新生效 |
| 配色实验室 | 253 → 241 ✅ 新生效 |
| AI 对话（跨模块） | 滚到顶 246、滚动后 231 ✅ 双向都对 |
| HN / PH / Picks tab | 顶栏随共享 state 呈 231，确认 CompositionLocal 已接上 |

无崩溃日志。

**未实测到的**：外观、应用设置、关于、反馈、订阅、收藏、GitHub 主页及两个下钻列表——这些页面内容不满一屏或列表为空（测试账号 0 粉丝 0 仓库 0 动态），滚不动，变色无从触发；截图确认渲染与返回正常。它们与已验证页面走同一条代码路径，但没有实测证据。

## 已知的既有现象（非本 PR 引入）

首页四个 tab 共用同一个 `scrollBehavior` state，切 tab 不重置——在 GitHub tab 滚很深后切到 PH tab，即使列表在顶部顶栏仍是深色。改动前是一个 behavior 实例传给四个顶栏，改动后是一个实例经 CompositionLocal 送达，实例数与生命周期一致，行为未变。要修需给 `TrendingScaffold` 加 `key` 参数让切 tab 时 state 重建，超出本次范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MBW4d41L8fPwrHqWg7YeA