### PR TITLE
feat(chat): AI 回复时与点空白处自动收起键盘

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -1,5 +1,6 @@
 package whl.trending.chat.ui
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -31,7 +32,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -112,6 +115,13 @@ fun ChatScreen(
             viewModel.enableDeepResearch()
             if (viewModel.uiState.value.input.isBlank()) viewModel.updateInput(researchPrefill)
         }
+    }
+
+    // AI 一开始回复就收起键盘：把屏幕让给正文，用户不用先手动关键盘才能读回复。
+    // clearFocus 同时清焦点（而非只 hide），避免留下「键盘没了但光标还在闪」的中间态。
+    val focusManager = LocalFocusManager.current
+    LaunchedEffect(state.isSending) {
+        if (state.isSending) focusManager.clearFocus()
     }
 
     val drawerState = rememberDrawerState(DrawerValue.Closed)
@@ -258,7 +268,13 @@ fun ChatScreen(
                 }
             },
         ) { padding ->
-            Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            Box(
+                modifier = Modifier.fillMaxSize()
+                    .padding(padding)
+                    // 点消息区/欢迎区收起键盘。detectTapGestures 走 Main pass，
+                    // 消息里的链接点击、列表滚动等子手势照常先消费，不会被这里抢走
+                    .pointerInput(Unit) { detectTapGestures { focusManager.clearFocus() } },
+            ) {
                 if (state.messages.isEmpty()) {
                     // 尚无对话：展示欢迎区（实验性 + 每日额度说明）。发出第一条后 messages 非空，
                     // 自动切到 MessageList，与「介绍这个项目」chip 的隐藏时机一致。


### PR DESCRIPTION
## 背景

聊天页发完消息后键盘一直杵在那儿挡住半屏回复，得先手动关掉才能读；输入到一半想翻历史消息，也只能先点返回键收键盘。

## 改动

`ChatScreen.kt`（+17 行）：

1. **AI 开始回复时收起** — `LaunchedEffect(state.isSending)`，`isSending` 转 true 时 `focusManager.clearFocus()`。时机是点发送那一刻，不是回复结束——流式输出期间正是最需要屏幕的时候。
2. **点空白处收起** — 消息区/欢迎区那层 `Box` 加 `pointerInput { detectTapGestures { focusManager.clearFocus() } }`。

两点取舍：

- 用 `clearFocus()` 而非 `keyboardController.hide()`，避免留下「键盘没了但光标还在闪」的中间态。
- `detectTapGestures` 走 Main pass，子组件先消费，消息内链接点击、代码块复制、列表滚动都不受影响。

## 验证

Pixel_9_2 模拟器实测，`dumpsys input_method | grep mInputShown` 取证：

| 操作 | mInputShown |
|---|---|
| 点输入框 | `true` |
| 点消息区空白处 | `false` ✅ |
| 输入文字（发送前） | `true` |
| 点发送（AI 开始回复） | `false` ✅ |

回归项：列表滚动正常、代码块复制按钮正常弹出系统剪贴板预览。`:androidLibrary:chat:testDebugUnitTest` 通过。

## 未覆盖

顶栏区域点击不收键盘（只处理了内容区）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkVWi1hvvCHb4KtUNRyi5z

## Summary by Sourcery

通过在 AI 回复开始时以及在消息区域点击空白处时自动收起键盘，提升聊天界面的可用性。

新功能：
- 当聊天界面中 AI 开始发送消息时，自动收起键盘。
- 允许通过点击聊天内容区域的空白处来收起键盘。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve chat screen usability by automatically dismissing the keyboard when AI replies start and when tapping empty space in the message area.

New Features:
- Automatically dismiss the keyboard when AI message sending starts on the chat screen.
- Allow dismissing the keyboard by tapping empty space in the chat content area.

</details>