### PR TITLE
feat(chat): 未手选模型不带 model 字段，默认模型跟随服务端

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -17,7 +17,8 @@ import kotlinx.coroutines.launch
 import whl.trending.ai.chat.ChatContext
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
-import whl.trending.ai.data.model.ChatModelOption
+import whl.trending.ai.data.model.ChatModelsResponse
+import whl.trending.ai.data.model.resolveDisplayedChatModel
 import whl.trending.ai.data.repository.ChatModelsProvider
 import whl.trending.chat.engine.ChatEngine
 import whl.trending.chat.engine.ChatException
@@ -51,18 +52,26 @@ class ChatViewModel(
     initialContext: ChatContext? = null,
     initialMessages: List<ChatMessage> = emptyList(),
     private val store: ChatStore? = null,
-    private val loadModels: suspend () -> List<ChatModelOption> = { ChatModelsProvider.get() },
+    private val loadModels: suspend () -> ChatModelsResponse = { ChatModelsProvider.get() },
     private val track: (String, Map<String, String>) -> Unit = { name, props -> trackEvent(name, props) },
-    private val selectedModelId: () -> String? =
-        { runCatching { globalSettingsManager.currentSelectedChatModel() }.getOrNull() },
+    private val selectedModelId: () -> String? = {
+        // 留痕记「实际生效」而非「手选值」：未手选时手选值是空哨兵，实际用的是目录里的免费默认项
+        runCatching {
+            resolveDisplayedChatModel(
+                ChatModelsProvider.cachedOrEmpty(),
+                globalSettingsManager.currentSelectedChatModel(),
+                globalSettingsManager.currentIsPro(),
+            )?.id
+        }.getOrNull()
+    },
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ChatUiState(messages = initialMessages))
     val uiState: StateFlow<ChatUiState> = _uiState.asStateFlow()
 
-    // 可选模型目录（驱动模型选择器）。拉取失败保持空列表 → 选择器隐藏、退回默认模型。
-    private val _models = MutableStateFlow<List<ChatModelOption>>(emptyList())
-    val models: StateFlow<List<ChatModelOption>> = _models.asStateFlow()
+    // 可选模型目录 + 服务端默认（驱动模型选择器）。拉取失败保持空目录 → 选择器隐藏、请求不带 model。
+    private val _catalog = MutableStateFlow(ChatModelsResponse())
+    val catalog: StateFlow<ChatModelsResponse> = _catalog.asStateFlow()
 
     /** 会话列表（抽屉数据源）；纯内存模式恒为空 */
     val threads: StateFlow<List<ThreadSummary>> =
@@ -109,7 +118,7 @@ class ChatViewModel(
 
     init {
         viewModelScope.launch {
-            _models.value = runCatching { loadModels() }.getOrDefault(emptyList())
+            _catalog.value = runCatching { loadModels() }.getOrDefault(ChatModelsResponse())
         }
     }
 

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -64,6 +64,13 @@ class ChatApi(
 
         /** 流式请求总时长上限：生成 2500~4000 字解读可能远超普通请求，放到 5 分钟 */
         private const val STREAM_REQUEST_TIMEOUT_MS = 300_000L
+
+        /**
+         * wire 序列化配置的唯一定义：请求编码（ContentNegotiation）与 wire 闸门测试
+         * （ChatApiWireTest）共用同一实例——改这里的配置（如 encodeDefaults/explicitNulls）
+         * 测试即变红。测试若自建配置相同的 Json 副本，配置漂移时闸门会静默失效。
+         */
+        internal val wireJson = Json { ignoreUnknownKeys = true }
     }
 
     /** content 两态：纯文本为 JSON string；末条带图 user 消息为 OpenAI 多模态 parts 数组 */
@@ -119,7 +126,7 @@ class ChatApi(
         val tier: String? = null,
     )
 
-    private val json = Json { ignoreUnknownKeys = true }
+    private val json = wireJson
 
     private val client = HttpClient(OkHttp) {
         install(ContentNegotiation) {

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -163,9 +163,10 @@ class ChatApi(
                         WireContext(it.title, it.summary, it.sourceUrl)
                     },
                     // 发送前按目录缓存解析实际生效模型（与选择器同一套判定），避免选择器未挂载时
-                    // 把过期的 Pro 专属选择原样发出；目录未拉到则透传，服务端仍按 tier 强制兜底
+                    // 把过期的 Pro 专属选择原样发出；未手选 / 选择失效解析为 null，此时字段被
+                    // encodeDefaults=false 省略，默认模型由服务端定（客户端不复述模型 id）
                     model = resolveEffectiveChatModel(
-                        ChatModelsProvider.cachedOrEmpty(),
+                        ChatModelsProvider.cachedOrEmpty().models,
                         globalSettingsManager.currentSelectedChatModel(),
                         globalSettingsManager.currentIsPro(),
                     ),

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -244,9 +244,9 @@ fun ChatScreen(
                     // 常驻模型选择器（≤1 个模型时自动隐藏）。research 模式下整个隐藏：
                     // 模型由服务端钉死，选择器留着会误导用户以为选的模型生效
                     if (mode != whl.trending.chat.model.ChatMode.DeepResearch) {
-                        val models by viewModel.models.collectAsState()
+                        val catalog by viewModel.catalog.collectAsState()
                         ModelPicker(
-                            models = models,
+                            catalog = catalog,
                             modifier = Modifier.padding(horizontal = 12.dp),
                         )
                     }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -24,12 +24,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.model.CHAT_MODEL_UNSET
 import whl.trending.ai.data.model.ChatModelOption
+import whl.trending.ai.data.model.ChatModelsResponse
+import whl.trending.ai.data.model.catalogDefaultChatModel
+import whl.trending.ai.data.model.resolveDisplayedChatModel
 import whl.trending.ai.data.model.resolveEffectiveChatModel
 import whl.trending.chat.R
 
 /**
- * 常驻模型选择器（对所有用户透出）。默认显示免费 gpt-5.6-luna；Pro 专属项对免费用户锁定，
+ * 常驻模型选择器（对所有用户透出）。未手选时显示目录里的免费默认项；Pro 专属项对免费用户锁定，
  * 点锁定项 → 纯告知弹窗（说明该模型属于 Pro，可继续用默认模型），不外跳赞助页。
  *
  * 2026-07-26 起此处不再承担 Pro 转化：与配额触顶卡同一决策——功能受限的当下推销观感差，
@@ -39,9 +43,10 @@ import whl.trending.chat.R
  */
 @Composable
 internal fun ModelPicker(
-    models: List<ChatModelOption>,
+    catalog: ChatModelsResponse,
     modifier: Modifier = Modifier,
 ) {
+    val models = catalog.models
     if (models.size <= 1) return
 
     val isPro by globalSettingsManager.isPro.collectAsState(initial = globalSettingsManager.currentIsPro())
@@ -64,20 +69,17 @@ internal fun ModelPicker(
         )
     }
 
-    // 自愈守卫：若持久化的选择对本用户已锁定（Pro 过期未登出、或上个 Pro 用户遗留），
-    // 复位到默认免费模型。判定与 ChatApi 发送共用 resolveEffectiveChatModel——
-    // 即使本组件未挂载，发送侧也会按同一规则兜底。
+    // 自愈守卫：若持久化的选择对本用户已锁定（Pro 过期未登出、或上个 Pro 用户遗留）或已下架，
+    // 清回未手选——不写入某个具体 id，默认是谁由服务端说了算。判定与 ChatApi 发送共用
+    // resolveEffectiveChatModel——即使本组件未挂载，发送侧也会按同一规则兜底。
     LaunchedEffect(models, isPro) {
-        val effective = resolveEffectiveChatModel(models, selectedId, isPro)
-        if (effective != selectedId) {
-            globalSettingsManager.setSelectedChatModel(effective)
+        if (selectedId != CHAT_MODEL_UNSET && resolveEffectiveChatModel(models, selectedId, isPro) == null) {
+            globalSettingsManager.clearSelectedChatModel()
         }
     }
 
     // 展示同样带 tier 守卫：锁定项永不显示为当前选择（覆盖自愈生效前的那一帧）
-    val current = models.firstOrNull { it.id == selectedId }?.takeIf { !(it.proOnly && !isPro) }
-        ?: models.firstOrNull { !it.proOnly }
-        ?: models.first()
+    val current = resolveDisplayedChatModel(catalog, selectedId, isPro) ?: return
 
     Box(modifier) {
         AssistChip(
@@ -104,10 +106,13 @@ internal fun ModelPicker(
                     } else null,
                     onClick = {
                         expanded = false
-                        if (locked) {
-                            unlockDialogModel = model
-                        } else {
-                            globalSettingsManager.setSelectedChatModel(model.id)
+                        when {
+                            locked -> unlockDialogModel = model
+                            // 选「默认项」记为未手选而非钉住这个 id：否则后端换默认模型时，
+                            // 只是点过一次默认的用户会被永久留在旧模型上——正是要解掉的耦合
+                            model.id == catalogDefaultChatModel(catalog)?.id ->
+                                globalSettingsManager.clearSelectedChatModel()
+                            else -> globalSettingsManager.setSelectedChatModel(model.id)
                         }
                     },
                 )

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -48,6 +48,9 @@ internal fun ModelPicker(
 ) {
     val models = catalog.models
     if (models.size <= 1) return
+    // 契约破损守卫：default 不可解析（缺失/悬空，正常不该发生）时整体缺席、不接受任何写入——
+    // 否则「点默认项记未手选」分支会静默失效，把用户的默认意图误写成钉住具体 id
+    val catalogDefault = catalogDefaultChatModel(catalog) ?: return
 
     val isPro by globalSettingsManager.isPro.collectAsState(initial = globalSettingsManager.currentIsPro())
     val selectedId by globalSettingsManager.selectedChatModel
@@ -78,8 +81,9 @@ internal fun ModelPicker(
         }
     }
 
-    // 展示同样带 tier 守卫：锁定项永不显示为当前选择（覆盖自愈生效前的那一帧）
-    val current = resolveDisplayedChatModel(catalog, selectedId, isPro) ?: return
+    // 展示同样带 tier 守卫：锁定项永不显示为当前选择（覆盖自愈生效前的那一帧）。
+    // 上方守卫已保证 default 可解析，这里必非空；?: 仅作类型收窄
+    val current = resolveDisplayedChatModel(catalog, selectedId, isPro) ?: catalogDefault
 
     Box(modifier) {
         AssistChip(
@@ -110,7 +114,7 @@ internal fun ModelPicker(
                             locked -> unlockDialogModel = model
                             // 选「默认项」记为未手选而非钉住这个 id：否则后端换默认模型时，
                             // 只是点过一次默认的用户会被永久留在旧模型上——正是要解掉的耦合
-                            model.id == catalogDefaultChatModel(catalog)?.id ->
+                            model.id == catalogDefault.id ->
                                 globalSettingsManager.clearSelectedChatModel()
                             else -> globalSettingsManager.setSelectedChatModel(model.id)
                         }

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
@@ -97,7 +97,7 @@ class ChatViewModelPersistenceTest {
 
     /** 构造并执行入口进入（Screen 的 enterEntry 时序在测试里显式驱动） */
     private fun vm(engine: ChatEngine, context: ChatContext? = null) =
-        ChatViewModel(engine, context, store = store, loadModels = { emptyList() }, track = { _, _ -> }, selectedModelId = { "gpt-5.5" })
+        ChatViewModel(engine, context, store = store, loadModels = { whl.trending.ai.data.model.ChatModelsResponse() }, track = { _, _ -> }, selectedModelId = { "gpt-5.5" })
             .also { it.enterEntry(context) }
 
     @Test

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelStreamingTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelStreamingTest.kt
@@ -77,7 +77,7 @@ class ChatViewModelStreamingTest {
     }
 
     private fun vm(engine: ChatEngine, track: (String, Map<String, String>) -> Unit = { _, _ -> }) =
-        ChatViewModel(engine, context, loadModels = { emptyList() }, track = track)
+        ChatViewModel(engine, context, loadModels = { whl.trending.ai.data.model.ChatModelsResponse() }, track = track)
 
     @Test
     fun `发送后流式定稿：assistant 消息内容为全文，isSending 复位`() = runTest(dispatcher) {

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatApiWireTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatApiWireTest.kt
@@ -2,6 +2,7 @@ package whl.trending.chat.engine
 
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertFalse
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
@@ -20,5 +21,27 @@ class ChatApiWireTest {
             ChatApi.ChatRequest(messages = emptyList(), lang = "zh", stream = true),
         )
         assertContains(body, "\"stream\":true")
+    }
+
+    /**
+     * 同一条 encodeDefaults=false 规则，这次是**指望**它省略：未手选模型时 model 解析为 null，
+     * 字段必须整个消失，让服务端按 tier 决定默认模型（免费白名单 / Pro 目录都回落 DEFAULT_MODEL）。
+     * 若哪天开了 encodeDefaults 或改用 explicitNulls 发出 `"model":null`，后端仍会兜底，
+     * 但「客户端不复述默认模型 id」的约定就断了——此测试是那道闸。
+     */
+    @Test
+    fun `未手选模型时请求体不带 model 字段`() {
+        val body = Json { ignoreUnknownKeys = true }.encodeToString(
+            ChatApi.ChatRequest(messages = emptyList(), lang = "zh", model = null, stream = true),
+        )
+        assertFalse(body.contains("\"model\""), "未手选却发了 model 字段: $body")
+    }
+
+    @Test
+    fun `手选模型时请求体照常带 model 字段`() {
+        val body = Json { ignoreUnknownKeys = true }.encodeToString(
+            ChatApi.ChatRequest(messages = emptyList(), lang = "zh", model = "gpt-6", stream = true),
+        )
+        assertContains(body, "\"model\":\"gpt-6\"")
     }
 }

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatApiWireTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatApiWireTest.kt
@@ -4,10 +4,12 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertFalse
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 
 /**
  * 请求方向的 wire 序列化断言。
+ *
+ * 全部用 [ChatApi.wireJson]——生产环境 ContentNegotiation 装的同一实例，而非自建配置相同的
+ * 副本：副本在生产配置漂移（如误开 encodeDefaults）时照样绿，闸门形同虚设。
  *
  * 回归背景：kotlinx.serialization 默认 encodeDefaults=false，带默认值的属性在值等于默认值时
  * 会被整个省略——`stream: Boolean = true` 曾因此从请求体里消失，服务端 `body.stream === true`
@@ -17,7 +19,7 @@ class ChatApiWireTest {
 
     @Test
     fun `chat 请求体必须序列化出 stream true`() {
-        val body = Json { ignoreUnknownKeys = true }.encodeToString(
+        val body = ChatApi.wireJson.encodeToString(
             ChatApi.ChatRequest(messages = emptyList(), lang = "zh", stream = true),
         )
         assertContains(body, "\"stream\":true")
@@ -31,7 +33,7 @@ class ChatApiWireTest {
      */
     @Test
     fun `未手选模型时请求体不带 model 字段`() {
-        val body = Json { ignoreUnknownKeys = true }.encodeToString(
+        val body = ChatApi.wireJson.encodeToString(
             ChatApi.ChatRequest(messages = emptyList(), lang = "zh", model = null, stream = true),
         )
         assertFalse(body.contains("\"model\""), "未手选却发了 model 字段: $body")
@@ -39,7 +41,7 @@ class ChatApiWireTest {
 
     @Test
     fun `手选模型时请求体照常带 model 字段`() {
-        val body = Json { ignoreUnknownKeys = true }.encodeToString(
+        val body = ChatApi.wireJson.encodeToString(
             ChatApi.ChatRequest(messages = emptyList(), lang = "zh", model = "gpt-6", stream = true),
         )
         assertContains(body, "\"model\":\"gpt-6\"")

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -18,7 +18,7 @@ import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import whl.trending.ai.core.platform.getSystemLanguage
 import whl.trending.ai.core.platform.trackEvent
-import whl.trending.ai.data.model.DEFAULT_CHAT_MODEL
+import whl.trending.ai.data.model.CHAT_MODEL_UNSET
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.data.model.PendingFavoriteOp
 
@@ -495,16 +495,20 @@ class SettingsManager(private val settings: ObservableSettings) {
         settings.putLong(ACCOUNT_LINK_OPENED_AT_KEY, 0L)
     }
 
-    /** 选中的聊天模型 id：发请求时透传（服务端仍按 tier 强制）。默认免费 gpt-5.6-luna。 */
-    val selectedChatModel: Flow<String> = settings.getStringFlow(SELECTED_CHAT_MODEL_KEY, DEFAULT_CHAT_MODEL)
+    /**
+     * 用户手选的聊天模型 id；[CHAT_MODEL_UNSET]（默认）= 未手选，请求不带 model、跟随服务端默认。
+     *
+     * 发请求时透传手选值：免费档服务端按白名单强制，Pro 档服务端尊重此选择。
+     */
+    val selectedChatModel: Flow<String> = settings.getStringFlow(SELECTED_CHAT_MODEL_KEY, CHAT_MODEL_UNSET)
 
-    fun currentSelectedChatModel(): String = settings.getString(SELECTED_CHAT_MODEL_KEY, DEFAULT_CHAT_MODEL)
+    fun currentSelectedChatModel(): String = settings.getString(SELECTED_CHAT_MODEL_KEY, CHAT_MODEL_UNSET)
 
     fun setSelectedChatModel(id: String) {
         settings.putString(SELECTED_CHAT_MODEL_KEY, id)
     }
 
-    /** 登出时调用：清掉可能残留的 Pro 模型选择，避免下个用户继承（回落到默认 gpt-5.6-luna）。 */
+    /** 登出时调用：清掉可能残留的 Pro 模型选择，避免下个用户继承（回到未手选、跟随服务端默认）。 */
     fun clearSelectedChatModel() {
         settings.remove(SELECTED_CHAT_MODEL_KEY)
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/ChatModelOption.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/ChatModelOption.kt
@@ -2,8 +2,15 @@ package whl.trending.ai.data.model
 
 import kotlinx.serialization.Serializable
 
-/** 免费默认模型（与后端 FREE_MODELS[0] 对齐）。选择器与请求兜底都用它。 */
-const val DEFAULT_CHAT_MODEL = "gpt-5.6-luna"
+/**
+ * 「未手选模型」的哨兵值：请求不带 model 字段，由服务端按 tier 决定默认。
+ *
+ * 客户端刻意不再硬编码默认模型 id。后端 `resolveModel(tier, undefined)` 两档都回落
+ * `DEFAULT_MODEL`，所以「不传」就是「跟随后端默认」——后端换默认模型不必跟着发版。
+ * 曾经硬编码是有代价的：免费档被后端白名单拍平看不出问题，Pro 档 `isOfferedModel` 放行，
+ * 于是未手选的 Pro 用户实际被钉在客户端常量上，后端调档对存量版本无效（0aac277）。
+ */
+const val CHAT_MODEL_UNSET = ""
 
 /**
  * 一个可选聊天模型（来自 `GET /api/chat/models`，后端从 OpenAI 动态取）。
@@ -29,17 +36,46 @@ data class ChatModelOption(
     }
 }
 
+/**
+ * 模型目录（`GET /api/chat/models` 的完整响应，也是客户端内的流通类型）。
+ *
+ * @param default 未手选时服务端实际使用的模型 id（后端 DEFAULT_MODEL，恒指向 [models] 中的免费项）。
+ *   显式契约字段——客户端不硬编码默认模型 id，也不按「免费项排最前」的排序习惯去猜。
+ *   缺省 `""` 仅为解码容错（部署窗口内的旧缓存响应）：解析不到默认项时相关展示各自缺省，不猜。
+ */
 @Serializable
-data class ChatModelsResponse(val models: List<ChatModelOption> = emptyList())
+data class ChatModelsResponse(
+    val models: List<ChatModelOption> = emptyList(),
+    val default: String = "",
+)
 
 /**
- * 计算实际生效的模型 id：持久化的选择对当前用户不可用（Pro 专属但非 Pro、或已不在目录中）时
- * 回落 [DEFAULT_CHAT_MODEL]；目录为空（尚未拉到）时原样透传，交服务端按 tier 强制。
+ * 计算请求该带的模型 id，`null` = 不带 model 字段、由服务端决定默认。
+ *
+ * 返回 null 的三种情形：未手选（[CHAT_MODEL_UNSET]）、选择已不在目录中、选择是 Pro 专属但当前非 Pro。
+ * 目录为空（尚未拉到）时手选值原样透传，交服务端按 tier 强制。
  *
  * 选择器的自愈与 ChatApi 的发送共用本函数——「界面显示的」与「请求发出的」始终同一套判定。
  */
-fun resolveEffectiveChatModel(models: List<ChatModelOption>, selectedId: String, isPro: Boolean): String {
+fun resolveEffectiveChatModel(models: List<ChatModelOption>, selectedId: String, isPro: Boolean): String? {
+    if (selectedId == CHAT_MODEL_UNSET) return null
     if (models.isEmpty()) return selectedId
     val sel = models.firstOrNull { it.id == selectedId }
-    return if (sel == null || (sel.proOnly && !isPro)) DEFAULT_CHAT_MODEL else selectedId
+    return if (sel == null || (sel.proOnly && !isPro)) null else selectedId
+}
+
+/**
+ * 目录声明的默认模型条目：`default` 字段指向的那一项。
+ * 目录尚未拉到、或字段缺失/悬空（不该发生，后端有测试钉住）时为 null——不猜，不回落排序。
+ */
+fun catalogDefaultChatModel(catalog: ChatModelsResponse): ChatModelOption? =
+    catalog.models.firstOrNull { it.id == catalog.default }
+
+/**
+ * 当前实际生效的模型条目，供展示与「哪个模型答的」留痕用。
+ * 未手选 / 手选失效时取 [catalogDefaultChatModel]，与服务端的兜底一致。
+ */
+fun resolveDisplayedChatModel(catalog: ChatModelsResponse, selectedId: String, isPro: Boolean): ChatModelOption? {
+    val effective = resolveEffectiveChatModel(catalog.models, selectedId, isPro)
+    return catalog.models.firstOrNull { it.id == effective } ?: catalogDefaultChatModel(catalog)
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -5,7 +5,6 @@ import whl.trending.ai.data.model.AppConfigResponse
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.data.model.FavoritesResponse
 import whl.trending.ai.data.model.FeedResponse
-import whl.trending.ai.data.model.ChatModelOption
 import whl.trending.ai.data.model.ChatModelsResponse
 import whl.trending.ai.data.model.MeResponse
 import whl.trending.ai.data.model.ProRefreshResponse
@@ -200,13 +199,13 @@ open class TrendingApi {
         return response.body<AppConfigResponse>()
     }
 
-    /** 聊天可选模型目录（公开只读；后端从 OpenAI 动态取 + 缓存）。 */
-    open suspend fun fetchChatModels(): List<ChatModelOption> {
+    /** 聊天可选模型目录 + 服务端默认（公开只读；后端从 OpenAI 动态取 + 缓存）。 */
+    open suspend fun fetchChatModels(): ChatModelsResponse {
         val response = client.get("$baseHost/api/chat/models")
         if (response.status.value !in 200..299) {
             throw ApiException(response.status.value, response.bodyAsText())
         }
-        return response.body<ChatModelsResponse>().models
+        return response.body<ChatModelsResponse>()
     }
 
     // ---- 收藏云同步（设计稿 2026-07-24-favorites-cloud-sync，B 档）----

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/ChatModelsProvider.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/ChatModelsProvider.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import whl.trending.ai.data.model.ChatModelsResponse
+import whl.trending.ai.data.model.catalogDefaultChatModel
 import whl.trending.ai.data.remote.TrendingApi
 
 /**
@@ -19,21 +20,32 @@ import whl.trending.ai.data.remote.TrendingApi
  * 失败不缓存空结果，下次自动重试。缓存单元是完整响应（目录 + 服务端默认 id），不拆散。
  */
 object ChatModelsProvider {
-    private val api = TrendingApi()
+    /** 测试注入口（FakeApi 覆写模式）；生产恒为真实 API。 */
+    internal var api: TrendingApi = TrendingApi()
     private val mutex = Mutex()
 
     @Volatile
     private var cache: ChatModelsResponse? = null
 
-    /** 取模型目录：命中缓存直接返回；否则拉一次，成功才缓存（失败返回空目录、下次重试）。 */
+    /**
+     * 取模型目录：命中缓存直接返回；否则拉一次，**完整**才缓存——目录非空且 default 指向
+     * 目录内（default 已是契约必需字段，缺失/悬空的破损响应当次照常返回、但不足以长期缓存，
+     * 否则一次坏响应会钉住整个进程、后端恢复后也不自愈）。失败/不完整下次 [get] 自动重试。
+     */
     suspend fun get(): ChatModelsResponse {
         cache?.let { return it }
         return mutex.withLock {
             cache?.let { return it }
             val fetched = runCatching { api.fetchChatModels() }.getOrDefault(ChatModelsResponse())
-            if (fetched.models.isNotEmpty()) cache = fetched
+            if (fetched.models.isNotEmpty() && catalogDefaultChatModel(fetched) != null) cache = fetched
             fetched
         }
+    }
+
+    /** 测试用：清缓存并复位注入。 */
+    internal fun resetForTests() {
+        cache = null
+        api = TrendingApi()
     }
 
     /** 已缓存的目录（无网络副作用）；尚未拉到时为空目录。发送热路径用它，避免冷拉阻塞聊天请求。 */

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/ChatModelsProvider.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/ChatModelsProvider.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import whl.trending.ai.data.model.ChatModelOption
+import whl.trending.ai.data.model.ChatModelsResponse
 import whl.trending.ai.data.remote.TrendingApi
 
 /**
@@ -16,28 +16,28 @@ import whl.trending.ai.data.remote.TrendingApi
  * 期间 chip 一直不出现——被误认为「没有模型列表」；后续会话命中后端热缓存才秒出。
  *
  * 修法：全进程只拉一次并缓存（[get]），且在应用启动时[warmUp]预热，让 chip 在任何会话打开前就绪。
- * 失败不缓存空结果，下次自动重试。
+ * 失败不缓存空结果，下次自动重试。缓存单元是完整响应（目录 + 服务端默认 id），不拆散。
  */
 object ChatModelsProvider {
     private val api = TrendingApi()
     private val mutex = Mutex()
 
     @Volatile
-    private var cache: List<ChatModelOption>? = null
+    private var cache: ChatModelsResponse? = null
 
-    /** 取模型目录：命中缓存直接返回；否则拉一次，成功才缓存（失败返回空、下次重试）。 */
-    suspend fun get(): List<ChatModelOption> {
+    /** 取模型目录：命中缓存直接返回；否则拉一次，成功才缓存（失败返回空目录、下次重试）。 */
+    suspend fun get(): ChatModelsResponse {
         cache?.let { return it }
         return mutex.withLock {
             cache?.let { return it }
-            val fetched = runCatching { api.fetchChatModels() }.getOrDefault(emptyList())
-            if (fetched.isNotEmpty()) cache = fetched
+            val fetched = runCatching { api.fetchChatModels() }.getOrDefault(ChatModelsResponse())
+            if (fetched.models.isNotEmpty()) cache = fetched
             fetched
         }
     }
 
-    /** 已缓存的目录（无网络副作用）；尚未拉到时为空列表。发送热路径用它，避免冷拉阻塞聊天请求。 */
-    fun cachedOrEmpty(): List<ChatModelOption> = cache ?: emptyList()
+    /** 已缓存的目录（无网络副作用）；尚未拉到时为空目录。发送热路径用它，避免冷拉阻塞聊天请求。 */
+    fun cachedOrEmpty(): ChatModelsResponse = cache ?: ChatModelsResponse()
 
     /** 应用启动时预热（fire-and-forget），避免首个 chat 等冷拉取。 */
     fun warmUp(scope: CoroutineScope) {

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/model/ChatModelOptionTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/model/ChatModelOptionTest.kt
@@ -2,46 +2,99 @@ package whl.trending.ai.data.model
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlinx.serialization.json.Json
 
-/** 模型目录的解码容错与 [resolveEffectiveChatModel] 生效判定单测。 */
+/** 模型目录的解码容错与 [resolveEffectiveChatModel] / [resolveDisplayedChatModel] 判定单测。 */
 class ChatModelOptionTest {
 
-    private val free = ChatModelOption(id = "gpt-5.4", name = "GPT-5.4", minTier = ChatModelOption.TIER_USER)
+    private val free = ChatModelOption(id = "gpt-5.6-luna", name = "GPT-5.6 Luna", minTier = ChatModelOption.TIER_USER)
     private val pro = ChatModelOption(id = "gpt-6", name = "GPT-6", minTier = ChatModelOption.TIER_PRO)
-    private val catalog = listOf(free, pro)
+    private val catalog = ChatModelsResponse(models = listOf(free, pro), default = free.id)
 
     @Test
     fun entry_missing_name_and_minTier_decodes_with_defaults() {
-        val parsed = Json.decodeFromString<ChatModelsResponse>("""{"models":[{"id":"m1"}]}""")
+        val parsed = Json.decodeFromString<ChatModelsResponse>("""{"default":"m1","models":[{"id":"m1"}]}""")
         val model = parsed.models.single()
         assertEquals("m1", model.name)
         assertEquals(ChatModelOption.TIER_USER, model.minTier)
         assertEquals(false, model.proOnly)
+        assertEquals("m1", parsed.default)
+    }
+
+    /** 部署窗口内的旧缓存响应没有 default 字段：解码不炸，默认项判定为「不知道」 */
+    @Test
+    fun response_missing_default_decodes_and_yields_no_default() {
+        val parsed = Json.decodeFromString<ChatModelsResponse>("""{"models":[{"id":"m1"}]}""")
+        assertNull(catalogDefaultChatModel(parsed))
     }
 
     @Test
     fun free_selection_passes_through() {
-        assertEquals("gpt-5.4", resolveEffectiveChatModel(catalog, "gpt-5.4", isPro = false))
+        assertEquals("gpt-5.6-luna", resolveEffectiveChatModel(catalog.models, "gpt-5.6-luna", isPro = false))
     }
 
     @Test
     fun pro_selection_kept_for_pro_user() {
-        assertEquals("gpt-6", resolveEffectiveChatModel(catalog, "gpt-6", isPro = true))
+        assertEquals("gpt-6", resolveEffectiveChatModel(catalog.models, "gpt-6", isPro = true))
+    }
+
+    /** 核心解耦断言：没手选就不带 model，默认是谁由服务端定，客户端不复述模型 id。 */
+    @Test
+    fun unset_selection_sends_no_model() {
+        assertNull(resolveEffectiveChatModel(catalog.models, CHAT_MODEL_UNSET, isPro = false))
+        assertNull(resolveEffectiveChatModel(catalog.models, CHAT_MODEL_UNSET, isPro = true))
+        assertNull(resolveEffectiveChatModel(emptyList(), CHAT_MODEL_UNSET, isPro = true))
     }
 
     @Test
-    fun stale_pro_selection_falls_back_to_default_for_free_user() {
-        assertEquals(DEFAULT_CHAT_MODEL, resolveEffectiveChatModel(catalog, "gpt-6", isPro = false))
+    fun stale_pro_selection_sends_no_model_for_free_user() {
+        assertNull(resolveEffectiveChatModel(catalog.models, "gpt-6", isPro = false))
     }
 
     @Test
-    fun selection_absent_from_catalog_falls_back_to_default() {
-        assertEquals(DEFAULT_CHAT_MODEL, resolveEffectiveChatModel(catalog, "removed-model", isPro = true))
+    fun selection_absent_from_catalog_sends_no_model() {
+        assertNull(resolveEffectiveChatModel(catalog.models, "removed-model", isPro = true))
     }
 
     @Test
-    fun empty_catalog_passes_selection_through_unchanged() {
+    fun empty_catalog_passes_explicit_selection_through_unchanged() {
         assertEquals("gpt-6", resolveEffectiveChatModel(emptyList(), "gpt-6", isPro = false))
+    }
+
+    @Test
+    fun displayed_model_is_declared_default_when_unset() {
+        assertEquals(free, resolveDisplayedChatModel(catalog, CHAT_MODEL_UNSET, isPro = false))
+        assertEquals(free, resolveDisplayedChatModel(catalog, CHAT_MODEL_UNSET, isPro = true))
+    }
+
+    /** 默认项由 default 字段声明，不靠排序猜：指向的项即使不排最前、目录里另有免费项也照选 */
+    @Test
+    fun displayed_model_follows_declared_default_not_ordering() {
+        val otherFree = ChatModelOption(id = "gpt-5.6-terra", name = "GPT-5.6 Terra", minTier = ChatModelOption.TIER_USER)
+        val declared = ChatModelsResponse(models = listOf(otherFree, free, pro), default = free.id)
+        assertEquals(free, resolveDisplayedChatModel(declared, CHAT_MODEL_UNSET, isPro = false))
+    }
+
+    @Test
+    fun displayed_model_never_shows_locked_entry_to_free_user() {
+        assertEquals(free, resolveDisplayedChatModel(catalog, "gpt-6", isPro = false))
+        assertEquals(pro, resolveDisplayedChatModel(catalog, "gpt-6", isPro = true))
+    }
+
+    @Test
+    fun displayed_model_is_null_before_catalog_arrives() {
+        assertNull(resolveDisplayedChatModel(ChatModelsResponse(), CHAT_MODEL_UNSET, isPro = false))
+        assertNull(catalogDefaultChatModel(ChatModelsResponse()))
+    }
+
+    /** default 悬空（指向不在目录里的 id，契约破损）：不猜别的项，判定为「不知道」 */
+    @Test
+    fun dangling_default_yields_no_default() {
+        val broken = ChatModelsResponse(models = listOf(free, pro), default = "ghost-model")
+        assertNull(catalogDefaultChatModel(broken))
+        assertNull(resolveDisplayedChatModel(broken, CHAT_MODEL_UNSET, isPro = false))
+        // 有效的手选不受契约破损影响，照常显示
+        assertEquals(pro, resolveDisplayedChatModel(broken, "gpt-6", isPro = true))
     }
 }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/repository/ChatModelsProviderTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/repository/ChatModelsProviderTest.kt
@@ -1,0 +1,77 @@
+package whl.trending.ai.data.repository
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import whl.trending.ai.data.model.ChatModelOption
+import whl.trending.ai.data.model.ChatModelsResponse
+import whl.trending.ai.data.remote.TrendingApi
+
+/** 可编程返回序列的 FakeModelsApi：按调用次序弹出预设响应，并计数。 */
+private class FakeModelsApi(private val responses: MutableList<ChatModelsResponse>) : TrendingApi() {
+    var fetchCount = 0
+
+    override suspend fun fetchChatModels(): ChatModelsResponse {
+        fetchCount++
+        return responses.removeAt(0)
+    }
+}
+
+/** [ChatModelsProvider] 缓存准入判定单测：完整响应才长期缓存，破损响应当次可用、下次重试。 */
+class ChatModelsProviderTest {
+
+    private val free = ChatModelOption(id = "gpt-5.6-luna", minTier = ChatModelOption.TIER_USER)
+    private val pro = ChatModelOption(id = "gpt-6", minTier = ChatModelOption.TIER_PRO)
+    private val complete = ChatModelsResponse(models = listOf(free, pro), default = free.id)
+
+    @BeforeTest
+    fun setUp() = ChatModelsProvider.resetForTests()
+
+    @AfterTest
+    fun tearDown() = ChatModelsProvider.resetForTests()
+
+    private fun inject(vararg responses: ChatModelsResponse): FakeModelsApi =
+        FakeModelsApi(responses.toMutableList()).also { ChatModelsProvider.api = it }
+
+    @Test
+    fun complete_response_is_cached_and_not_refetched() = runTest {
+        val api = inject(complete)
+        assertEquals(complete, ChatModelsProvider.get())
+        assertEquals(complete, ChatModelsProvider.get()) // 第二次命中缓存
+        assertEquals(1, api.fetchCount)
+        assertEquals(complete, ChatModelsProvider.cachedOrEmpty())
+    }
+
+    /** 核心准入断言：default 缺失的响应当次照常返回，但不进缓存——下次重试可自愈，
+     *  不会被一次坏响应钉住整个进程 */
+    @Test
+    fun response_missing_default_is_served_once_but_not_cached() = runTest {
+        val broken = ChatModelsResponse(models = listOf(free, pro), default = "")
+        val api = inject(broken, complete)
+        assertEquals(broken, ChatModelsProvider.get())          // 当次可用
+        assertEquals(ChatModelsResponse(), ChatModelsProvider.cachedOrEmpty()) // 未缓存
+        assertEquals(complete, ChatModelsProvider.get())        // 重试拿到修复后的响应
+        assertEquals(2, api.fetchCount)
+        assertEquals(complete, ChatModelsProvider.cachedOrEmpty()) // 这次才缓存
+    }
+
+    @Test
+    fun response_with_dangling_default_is_not_cached() = runTest {
+        val dangling = ChatModelsResponse(models = listOf(free, pro), default = "ghost-model")
+        inject(dangling, complete)
+        ChatModelsProvider.get()
+        assertEquals(ChatModelsResponse(), ChatModelsProvider.cachedOrEmpty())
+        assertEquals(complete, ChatModelsProvider.get())
+    }
+
+    /** 既有语义回归：空目录（拉取失败降级）照旧不缓存、下次重试 */
+    @Test
+    fun empty_catalog_is_not_cached() = runTest {
+        val api = inject(ChatModelsResponse(), complete)
+        assertEquals(ChatModelsResponse(), ChatModelsProvider.get())
+        assertEquals(complete, ChatModelsProvider.get())
+        assertEquals(2, api.fetchCount)
+    }
+}


### PR DESCRIPTION
## 背景

0aac277（客户端默认模型对齐 gpt-5.6-luna）暴露出客户端与后端的强耦合：客户端硬编码 `DEFAULT_CHAT_MODEL` 且发请求总是显式携带 model。免费档被服务端白名单拍平看不出问题；Pro 档 `isOfferedModel` 放行显式请求，**未手选的 Pro 用户实际被钉在客户端常量上**——后端每次调整默认档（如降本切档）都需要客户端跟版，且对存量老版本无效。

## 方案

把「默认模型是谁」的所有权完全交还服务端，客户端不再持有任何模型 id 字面量：

| 概念 | 改前 | 改后 |
|---|---|---|
| 未手选 | 持久化默认值 = 硬编码常量 | 空哨兵 `CHAT_MODEL_UNSET`，请求**不带 model 字段** |
| 默认是谁 | 客户端常量复述 | 读目录 `default` 字段（后端 a276efc，已上线） |
| 手选失效 | 改写为默认 id | 清回未手选 |
| 点选默认项 | 钉住该 id | 记为未手选 |
| 留痕 | 记手选值（可能错） | 记实际生效项；目录未拉到记 null，不猜 |

- `resolveEffectiveChatModel` 返回可空：null → `encodeDefaults=false` 省略 model 字段 → 服务端 `resolveModel(tier, undefined)` 两档回落自己的 `DEFAULT_MODEL`
- `catalogDefaultChatModel` 纯查表（`firstOrNull { it.id == catalog.default }`），**无猜测 fallback**：字段缺失/悬空 → null，chip 不渲染、留痕记 null
- 目录流通类型统一为 `ChatModelsResponse`（目录 + default 不拆散）；wire 解码方式不变，仅不再拆包丢外壳

## 测试

- wire 层：未手选时请求体不含 `"model"` 键 / 手选照常携带（与既有 stream 测试同一条序列化规则的正反面）
- 目录判定 13 例：含「default 由字段声明、不靠排序猜」「悬空不回落」「旧响应缺 default 解码容错」
- 变异验证：抹掉未手选分支后核心断言如期失败
- `:shared` + `:androidLibrary:chat` 单测、Android/iOS target 编译全绿

## 发版约束

需后端 `default` 字段先上线——已满足（a276efc 已部署，线上验证 `default: "gpt-5.6-luna"` 稳定返回）。老客户端 `ignoreUnknownKeys` 忽略新字段，零影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BJhvCJMuuQokKLeQcDEnk

## Summary by Sourcery

通过将未设置或无效的用户选择视为“无模型”，并让客户端消费完整的聊天模型目录（包括声明的默认模型），将默认聊天模型的选择委托给服务器。

New Features:
- 支持显式的“未设置聊天模型”标记，当使用该标记时，聊天请求将省略 `model` 字段并遵循服务器端默认设置。
- 使用目录响应而非硬编码的客户端常量，在模型选择器中展示服务器声明的默认聊天模型。

Bug Fixes:
- 对免费用户清除无效模型选择并回退到服务器默认，以防止他们被固定在已废弃的仅限 Pro 或已移除的模型上。
- 确保对免费用户展示的当前模型不会显示被锁定的仅限 Pro 的条目。

Enhancements:
- 扩展聊天模型目录的处理逻辑以包含 `default` 字段，并提供用于解析“实际生效模型”和“展示用模型条目”的辅助方法。
- 更新持久化和分析逻辑，记录真正生效的模型而非原始选择值，包括默认模型的情况。
- 优化模型选择器行为，使选择默认条目时重置为“未设置”，而不是固定到该特定模型 id。

Tests:
- 添加单元测试，用于验证目录默认值解析、悬空或缺失默认值的处理、未设置选择以及展示模型逻辑。
- 添加联线路测试，断言在未选择模型时请求会省略 `model` 字段，而在显式选择模型时请求会包含该字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Delegate default chat model selection to the server by treating unset or invalid user selections as no model and wiring the client to consume the full chat models catalog including the declared default.

New Features:
- Support an explicit unset chat model sentinel that causes chat requests to omit the model field and follow the server-side default.
- Surface the server-declared default chat model in the picker using the catalog response instead of a hardcoded client constant.

Bug Fixes:
- Prevent free-tier users from being pinned to obsolete Pro-only or removed models by clearing invalid selections and falling back to the server default.
- Ensure the displayed current model never shows a locked Pro-only entry for free users.

Enhancements:
- Extend chat model catalog handling to include a default field, with helpers for resolving the effective and displayed model entries.
- Update persistence and analytics to record the actually effective model rather than the raw selection, including the default case.
- Refine model picker behavior so selecting the default entry resets to unset instead of pinning that specific id.

Tests:
- Add unit tests for catalog default resolution, dangling or missing default handling, unset selections, and displayed model logic.
- Add wire tests to assert that requests omit the model field when no model is selected and include it when a model is explicitly chosen.

</details>