### PR TITLE
feat(auth): 会话失效自愈 + 刷新单飞 + 失败可观测

### DIFF
--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
 import org.jose4j.jwt.consumer.ErrorCodes
 import org.jose4j.jwt.consumer.InvalidJwtException
+import org.json.JSONObject
 import io.logto.sdk.core.exception.ResponseException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -228,11 +229,20 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
             tokenFlight.get()?.let { return it.await() }
             val flight = CompletableDeferred<String?>()
             if (tokenFlight.compareAndSet(null, flight)) {
-                logtoClient.getAccessToken { exception, accessToken ->
-                    exception?.let { onTokenRefreshFailure(it) }
-                    // 先撤下再 complete：此刻 token 已在 SDK 内存缓存，迟到者新开一轮也是同步命中
+                // okhttp 保证回调必达终态（onResponse/onFailure），无需自设超时；但「SDK 同步抛异常」
+                // 与「我们的失败处理自身抛异常」两条路径会让 flight 悬挂、拖死后续所有取 token——
+                // 都以 try/runCatching 兜住，保证 flight 必然 complete、tokenFlight 必然撤下。
+                try {
+                    logtoClient.getAccessToken { exception, accessToken ->
+                        runCatching { exception?.let { onTokenRefreshFailure(it) } }
+                        // 先撤下再 complete：此刻 token 已在 SDK 内存缓存，迟到者新开一轮也是同步命中
+                        tokenFlight.set(null)
+                        flight.complete(accessToken?.token)
+                    }
+                } catch (t: Throwable) {
                     tokenFlight.set(null)
-                    flight.complete(accessToken?.token)
+                    flight.complete(null)
+                    throw t
                 }
                 return flight.await()
             }
@@ -276,12 +286,16 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
      * 会话确定已死的判据：token 端点以 HTTP 400 + `error=invalid_grant` 拒绝 refresh（响应体如
      * `{"error":"invalid_grant","error_detail":"refresh token not found"}`——吊销、有效期到期、
      * 轮换竞态都落在这里）。**仅此一种情况允许清会话**：网络失败/超时/5xx 都可能是暂时的，
-     * 误清会把弱网（漫游）用户的好会话踢下线。
+     * 误清会把弱网（漫游）用户的好会话踢下线。error 字段按 JSON 解析而非子串匹配，
+     * 解析不出时保守地不清会话（宁可维持旧死循环也不误杀好会话）。
      */
     private fun isSessionExpired(causeChain: List<Throwable>): Boolean = causeChain.any {
-        it is ResponseException && it.responseCode == HTTP_BAD_REQUEST &&
-            it.responseContent?.contains("\"invalid_grant\"") == true
+        it is ResponseException && it.responseCode == HTTP_BAD_REQUEST && it.oidcError() == "invalid_grant"
     }
+
+    /** 从 OIDC token 端点错误响应体（RFC 6749 §5.2 JSON）提取 `error` 字段；非 JSON 时返回 null */
+    private fun ResponseException.oidcError(): String? =
+        responseContent?.let { runCatching { JSONObject(it).optString("error") }.getOrNull() }
 
     /**
      * 会话失效处置：清 SDK 凭证 + 本地用户状态，降为登出态，经 [SignInFailureBus] 弹「重新登录」引导。

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -18,16 +18,18 @@ import java.net.SocketTimeoutException
 import java.net.URL
 import java.net.UnknownHostException
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
 import org.jose4j.jwt.consumer.ErrorCodes
 import org.jose4j.jwt.consumer.InvalidJwtException
 import org.json.JSONObject
 import io.logto.sdk.core.exception.ResponseException
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import whl.trending.ai.BuildConfig
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
@@ -52,8 +54,8 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
     /** 会话失效处理的一次性标志：清理是幂等的，但提示/埋点只该发一次；重新登录成功后复位 */
     private val sessionExpiredHandled = AtomicBoolean(false)
 
-    /** 在途的 token 获取（single-flight）：并发调用共享同一次 SDK 刷新，见 [getAccessToken] */
-    private val tokenFlight = AtomicReference<CompletableDeferred<String?>?>(null)
+    /** token 获取互斥锁：并发调用串行化，同一时刻至多一条真实刷新，见 [getAccessToken] */
+    private val tokenMutex = Mutex()
 
     private val logtoClient = LogtoClient(
         LogtoConfig(
@@ -221,32 +223,34 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
     override suspend fun getAccessToken(): String? {
         // 竞态由 SDK 的 CredentialGuard 兜底：登出后的在途刷新会以 NOT_AUTHENTICATED 收尾、不写回。
         if (!logtoClient.isAuthenticated) return null
-        // Single-flight：进一次账户页 quota/me 等会并发各要一次 token，access token 恰好过期时
+        // 互斥串行：进一次账户页 quota/me 等会并发各要一次 token，access token 恰好过期时
         // 若各自透传 SDK 就是多条并发 refresh 同时打到 Logto——轮换开启时这正是「持久化到已被
-        // 替换的旧 token → 下次 invalid_grant」的竞态源头（2026-08-01 事故）。收敛为同一时刻
-        // 至多一条真实刷新，后到者共享同一结果；SDK 内存缓存命中时回调同步返回，无额外开销。
-        while (true) {
-            tokenFlight.get()?.let { return it.await() }
-            val flight = CompletableDeferred<String?>()
-            if (tokenFlight.compareAndSet(null, flight)) {
-                // okhttp 保证回调必达终态（onResponse/onFailure），无需自设超时；但「SDK 同步抛异常」
-                // 与「我们的失败处理自身抛异常」两条路径会让 flight 悬挂、拖死后续所有取 token——
-                // 都以 try/runCatching 兜住，保证 flight 必然 complete、tokenFlight 必然撤下。
-                try {
+        // 替换的旧 token → 下次 invalid_grant」的竞态源头（2026-08-01 事故）。串行化后同一时刻
+        // 至多一条真实刷新，后到者进锁时命中 SDK 内存缓存、同步返回，去重效果等价。
+        //
+        // 选 Mutex 而非共享 Deferred 的 single-flight：SDK 的解析/校验跑在 okhttp 回调内部，
+        // 一旦抛出（如 captive portal 对 token 端点返回 200+HTML，gson 解析必炸），我们的
+        // completion 永远不来——共享 Deferred 需要手工簿记（超时守卫/CAS 摘除/代际保护）才能
+        // 不泄漏，而锁 + 每调用方超时在结构上自愈：超时取消协程即释放锁，下一个调用者自然重来，
+        // 无任何跨协程共享状态可泄漏。
+        var timedOut = true
+        val token = withTimeoutOrNull(TOKEN_GUARD_TIMEOUT_MS) {
+            tokenMutex.withLock {
+                suspendCancellableCoroutine { cont ->
                     logtoClient.getAccessToken { exception, accessToken ->
                         runCatching { exception?.let { onTokenRefreshFailure(it) } }
-                        // 先撤下再 complete：此刻 token 已在 SDK 内存缓存，迟到者新开一轮也是同步命中
-                        tokenFlight.set(null)
-                        flight.complete(accessToken?.token)
+                        // 超时/取消后迟到的 resume 落在已取消的 continuation 上，被安全忽略
+                        cont.resume(accessToken?.token) { _, _, _ -> }
                     }
-                } catch (t: Throwable) {
-                    tokenFlight.set(null)
-                    flight.complete(null)
-                    throw t
                 }
-                return flight.await()
-            }
+            }.also { timedOut = false }
         }
+        // 走到这里的 null 分两种：SDK 正常失败（已在 onTokenRefreshFailure 归因上报）与超时。
+        // 超时=SDK 异步链断裂或极端慢网，单独上报；调用方视角与其他失败一致（拿不到 token）。
+        if (timedOut) {
+            trackEvent("token_refresh_failed", mapOf("reason" to "guard_timeout", "logto_type" to "none"))
+        }
+        return token
     }
 
     /**
@@ -393,6 +397,13 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         private const val TAG = "LogtoAuth"
         private const val LOGTO_APP_ID = "lasqslwwdjbim73vgkapj"
         private const val HTTP_BAD_REQUEST = 400
+
+        /**
+         * token 获取的调用方超时：SDK 内部完整链路是 oidc-config + token 端点两跳网络请求，
+         * okhttp 默认超时兜底下正常路径远在 30s 内到达终态；超过即判定 SDK 异步链已断
+         * （回调不会再来），放弃本次并释放锁。误判代价仅为返回一次 null（等同现有失败路径）。
+         */
+        private const val TOKEN_GUARD_TIMEOUT_MS = 30_000L
         private const val CLOCK_PROBE_TIMEOUT_MS = 3_000
         private const val AUTH_PROBE_TIMEOUT_MS = 5_000
 

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -246,8 +246,22 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
      *   「加载失败/重试」死循环。清会话降为登出态，引导重新登录（见 [handleSessionExpired]）。
      */
     private fun onTokenRefreshFailure(exception: LogtoException) {
-        // NOT_AUTHENTICATED：登出竞态的正常收尾（CredentialGuard），不是故障，不上报不处置
-        if (exception.message == LogtoException.Type.NOT_AUTHENTICATED.name) return
+        // NOT_AUTHENTICATED 有两个来源（SDK 的 isAuthenticated 只看 idToken）：
+        // ① 登出竞态（isAuthenticated 已 false）：CredentialGuard 的正常收尾，不上报不处置；
+        // ② idToken 尚在而 refreshToken 缺失（两键分次 apply 落盘间进程被杀的部分写入、或
+        //    服务端未发 RT）：SDK 自认已登录却永远换不出 token——不处置就是零观测的永久僵尸
+        //    （账户页无限「加载失败/重试」）。按会话失效走同一条恢复路径：清会话 + 重登引导。
+        //    已知微窄边角：显式登出先清 RT 后清 idToken，在途刷新回调恰落其间会多弹一次
+        //    过期提示，窗口为微秒级且 sessionExpiredHandled 保证仅一次，不为其加锁。
+        if (exception.message == LogtoException.Type.NOT_AUTHENTICATED.name) {
+            if (!logtoClient.isAuthenticated) return
+            trackEvent(
+                "token_refresh_failed",
+                mapOf("reason" to "no_refresh_token", "logto_type" to LogtoException.Type.NOT_AUTHENTICATED.name),
+            )
+            handleSessionExpired()
+            return
+        }
         val causeChain = generateSequence(exception.cause) { it.cause }.toList()
         val reason = when {
             isClockSkew(causeChain) -> "clock_skew"

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -1,6 +1,7 @@
 package whl.trending.ai.auth
 
 import android.app.Activity
+import android.app.Application
 import android.os.SystemClock
 import android.util.Log
 import io.logto.sdk.android.LogtoClient
@@ -48,26 +49,7 @@ import whl.trending.ai.data.repository.globalFavoriteRepository
 class LogtoAuthManager(activity: Activity) : AuthManager {
     private val activityRef = WeakReference(activity)
 
-    /** 时钟偏差提示的进程级一次性标志（刷新路径专用；显式登录失败不受限，每次都给反馈） */
-    private val clockSkewHinted = AtomicBoolean(false)
-
-    /** 会话失效处理的一次性标志：清理是幂等的，但提示/埋点只该发一次；重新登录成功后复位 */
-    private val sessionExpiredHandled = AtomicBoolean(false)
-
-    /** token 获取互斥锁：并发调用串行化，同一时刻至多一条真实刷新，见 [getAccessToken] */
-    private val tokenMutex = Mutex()
-
-    private val logtoClient = LogtoClient(
-        LogtoConfig(
-            endpoint = LOGTO_ENDPOINT,
-            appId = LOGTO_APP_ID,
-            // email：邮箱验证码登录的 email claim；对存量会话不追溯（老 token 无此授权，重登后才有）
-            scopes = listOf("identities", "email"),
-            resources = null,
-            usingPersistStorage = true,
-        ),
-        activity.application,
-    )
+    private val logtoClient = obtainClient(activity.application)
 
     private val _authState = MutableStateFlow<AuthState>(
         if (logtoClient.isAuthenticated) AuthState.LoggedIn else AuthState.LoggedOut
@@ -397,6 +379,39 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         private const val TAG = "LogtoAuth"
         private const val LOGTO_APP_ID = "lasqslwwdjbim73vgkapj"
         private const val HTTP_BAD_REQUEST = 400
+
+        /**
+         * LogtoClient 进程级单例：manager 随每次 Activity.onCreate 重建（仅为刷新 activityRef），
+         * 但 client 持有内存 token 状态——RT 在构造时读入字段、AT 缓存只在内存。若 client 跟着
+         * 重建：①旧实例在途刷新与新实例刷新不互斥（轮换竞态跨实例复活）；②轮换后新实例仍拿
+         * 构造时的旧 RT → invalid_grant；③每次配置变更 AT 缓存丢失、白白多刷一次。故单例化。
+         */
+        @Volatile
+        private var sharedClient: LogtoClient? = null
+
+        private fun obtainClient(application: Application): LogtoClient =
+            sharedClient ?: synchronized(LogtoAuthManager::class.java) {
+                sharedClient ?: LogtoClient(
+                    LogtoConfig(
+                        endpoint = LOGTO_ENDPOINT,
+                        appId = LOGTO_APP_ID,
+                        // email：邮箱验证码登录的 email claim；对存量会话不追溯（老 token 无此授权，重登后才有）
+                        scopes = listOf("identities", "email"),
+                        resources = null,
+                        usingPersistStorage = true,
+                    ),
+                    application,
+                ).also { sharedClient = it }
+            }
+
+        /** token 获取互斥锁：进程级——跨 manager 实例的并发调用也串行化，见 [getAccessToken] */
+        private val tokenMutex = Mutex()
+
+        /** 时钟偏差提示的进程级一次性标志（刷新路径专用；显式登录失败不受限，每次都给反馈） */
+        private val clockSkewHinted = AtomicBoolean(false)
+
+        /** 会话失效处理的一次性标志：清理是幂等的，但提示/埋点只该发一次；重新登录成功后复位 */
+        private val sessionExpiredHandled = AtomicBoolean(false)
 
         /**
          * token 获取的调用方超时：SDK 内部完整链路是 oidc-config + token 端点两跳网络请求，

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -153,15 +153,12 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         val causeChain = generateSequence(exception.cause) { it.cause }.toList()
         val reason = when {
             logtoType == LogtoException.Type.USER_CANCELED.name -> SignInFailureReason.USER_CANCELED
-            // 时钟偏差：id_token 的 iat/exp 校验被 jose4j 拒绝（容差 60s）。必须先于网络类判定——
-            // 重试永远失败，通用提示会把用户引进死循环（2026-07-22 模拟器慢 63s 实测的坑）
-            isClockSkew(causeChain) -> SignInFailureReason.CLOCK_SKEW
-            causeChain.any { it is SocketTimeoutException } -> SignInFailureReason.TIMEOUT
-            causeChain.any { it is UnknownHostException || it is ConnectException || it is IOException } -> SignInFailureReason.NETWORK
-            logtoType in NETWORK_LOGTO_TYPES -> SignInFailureReason.NETWORK
-            logtoType == LogtoException.Type.UNABLE_TO_LAUNCH_BROWSER.name -> SignInFailureReason.NO_BROWSER
-            logtoType in CONFIG_LOGTO_TYPES -> SignInFailureReason.CONFIG
-            else -> SignInFailureReason.OTHER
+            else -> connectivityReason(causeChain) ?: when {
+                logtoType in NETWORK_LOGTO_TYPES -> SignInFailureReason.NETWORK
+                logtoType == LogtoException.Type.UNABLE_TO_LAUNCH_BROWSER.name -> SignInFailureReason.NO_BROWSER
+                logtoType in CONFIG_LOGTO_TYPES -> SignInFailureReason.CONFIG
+                else -> SignInFailureReason.OTHER
+            }
         }
         val props = buildMap<String, Any> {
             put("reason", reason.name.lowercase())
@@ -260,12 +257,10 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
             return
         }
         val causeChain = generateSequence(exception.cause) { it.cause }.toList()
+        // invalid_grant（HTTP 400 拒绝）与连接层归因在异常形态上互斥，先后无行为差异
         val reason = when {
-            isClockSkew(causeChain) -> "clock_skew"
             isSessionExpired(causeChain) -> "invalid_grant"
-            causeChain.any { it is SocketTimeoutException } -> "timeout"
-            causeChain.any { it is UnknownHostException || it is ConnectException || it is IOException } -> "network"
-            else -> "other"
+            else -> connectivityReason(causeChain)?.name?.lowercase() ?: "other"
         }
         trackEvent(
             "token_refresh_failed",
@@ -306,6 +301,19 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         clearLocalUserState()
         SignInFailureBus.emit(SignInFailureReason.SESSION_EXPIRED)
         if (BuildConfig.DEBUG) Log.w(TAG, "session expired: credentials cleared, sign-in hint emitted")
+    }
+
+    /**
+     * cause 链的连接层归因（时钟偏差/超时/网络），登录失败与静默刷新失败两条埋点链路共用——
+     * 口径必须一致，sign_in_error 与 token_refresh_failed 的 reason 分布才可横向对比。
+     * 时钟偏差必须先于网络类判定：重试永远失败，通用网络提示会把用户引进死循环
+     * （2026-07-22 模拟器慢 63s 实测的坑）。流程特有类型（取消/配置/invalid_grant 等）由调用方自判。
+     */
+    private fun connectivityReason(causeChain: List<Throwable>): SignInFailureReason? = when {
+        isClockSkew(causeChain) -> SignInFailureReason.CLOCK_SKEW
+        causeChain.any { it is SocketTimeoutException } -> SignInFailureReason.TIMEOUT
+        causeChain.any { it is UnknownHostException || it is ConnectException || it is IOException } -> SignInFailureReason.NETWORK
+        else -> null
     }
 
     /**

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -18,14 +18,15 @@ import java.net.SocketTimeoutException
 import java.net.URL
 import java.net.UnknownHostException
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
-import kotlin.coroutines.resume
 import org.jose4j.jwt.consumer.ErrorCodes
 import org.jose4j.jwt.consumer.InvalidJwtException
+import io.logto.sdk.core.exception.ResponseException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.suspendCancellableCoroutine
 import whl.trending.ai.BuildConfig
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
@@ -46,6 +47,12 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
 
     /** 时钟偏差提示的进程级一次性标志（刷新路径专用；显式登录失败不受限，每次都给反馈） */
     private val clockSkewHinted = AtomicBoolean(false)
+
+    /** 会话失效处理的一次性标志：清理是幂等的，但提示/埋点只该发一次；重新登录成功后复位 */
+    private val sessionExpiredHandled = AtomicBoolean(false)
+
+    /** 在途的 token 获取（single-flight）：并发调用共享同一次 SDK 刷新，见 [getAccessToken] */
+    private val tokenFlight = AtomicReference<CompletableDeferred<String?>?>(null)
 
     private val logtoClient = LogtoClient(
         LogtoConfig(
@@ -106,6 +113,8 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
             val durationMs = SystemClock.elapsedRealtime() - signInStartedAt
             if (logtoException == null && logtoClient.isAuthenticated) {
                 _authState.value = AuthState.LoggedIn
+                // 重登拿到全新 grant，之后若再次失效仍需完整走一遍会话失效处理
+                sessionExpiredHandled.set(false)
                 // method 为选择器意图；托管页内切换方式的边角（邮箱屏仍可能展示社交按钮）不在客户端识别
                 trackEvent(
                     "sign_in_success",
@@ -190,6 +199,12 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         } else {
             logtoClient.clearCredentials { /* 本地凭证已清除即视为登出 */ }
         }
+        clearLocalUserState()
+        trackEvent("sign_out")
+    }
+
+    /** 登出/会话失效共用的本地状态清理（幂等）：用户身份缓存、收藏同步、GitHub 数据源、登录态 */
+    private fun clearLocalUserState() {
         globalSettingsManager.setUserAvatarUrl(null)
         globalSettingsManager.setGithubIdentity(null, null)
         globalSettingsManager.setUserEmail(null)
@@ -200,33 +215,86 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
         FollowingProvider.shared.clear()
         OwnRepoEventsProvider.shared.clear()
         _authState.value = AuthState.LoggedOut
-        trackEvent("sign_out")
     }
 
     override suspend fun getAccessToken(): String? {
         // 竞态由 SDK 的 CredentialGuard 兜底：登出后的在途刷新会以 NOT_AUTHENTICATED 收尾、不写回。
         if (!logtoClient.isAuthenticated) return null
-        return suspendCancellableCoroutine { cont ->
-            logtoClient.getAccessToken { exception, accessToken ->
-                exception?.let { maybeHintRefreshClockSkew(it) }
-                cont.resume(accessToken?.token)
+        // Single-flight：进一次账户页 quota/me 等会并发各要一次 token，access token 恰好过期时
+        // 若各自透传 SDK 就是多条并发 refresh 同时打到 Logto——轮换开启时这正是「持久化到已被
+        // 替换的旧 token → 下次 invalid_grant」的竞态源头（2026-08-01 事故）。收敛为同一时刻
+        // 至多一条真实刷新，后到者共享同一结果；SDK 内存缓存命中时回调同步返回，无额外开销。
+        while (true) {
+            tokenFlight.get()?.let { return it.await() }
+            val flight = CompletableDeferred<String?>()
+            if (tokenFlight.compareAndSet(null, flight)) {
+                logtoClient.getAccessToken { exception, accessToken ->
+                    exception?.let { onTokenRefreshFailure(it) }
+                    // 先撤下再 complete：此刻 token 已在 SDK 内存缓存，迟到者新开一轮也是同步命中
+                    tokenFlight.set(null)
+                    flight.complete(accessToken?.token)
+                }
+                return flight.await()
             }
         }
     }
 
     /**
-     * 静默刷新失败若是时钟偏差，重试/重登都救不回来（新 token 的 id_token 校验同样失败），而 app 仍
-     * 自认已登录、请求被服务端按匿名处理（authDegraded）——用户看到的「重试」提示是死循环。
-     * 弹一次时钟修复提示（复用 [SignInFailureBus] 的 CLOCK_SKEW 通道），进程内只弹一次防打扰
-     * （getAccessToken 每次请求都会调）。
+     * 静默刷新失败的归因、埋点与处置。登录流程失败有 sign_in_error 漏斗，这里是它的镜像——
+     * 没有本事件时，用户处于「僵尸登录态」（本地自认已登录、请求被服务端按匿名处理）完全不可见，
+     * 只能等用户报障后翻 Logto 审计日志（2026-08-01 事故里另一位用户失败一上午无人知晓）。
+     *
+     * 两类可行动失败就地处置：
+     * - 时钟偏差：重试/重登都救不回（新 token 的 id_token 校验同样失败），提示修时钟，进程内一次；
+     * - 会话失效（invalid_grant）：refresh token 在服务端已不存在，重试永远失败——原表现是账户页
+     *   「加载失败/重试」死循环。清会话降为登出态，引导重新登录（见 [handleSessionExpired]）。
      */
-    private fun maybeHintRefreshClockSkew(exception: LogtoException) {
+    private fun onTokenRefreshFailure(exception: LogtoException) {
+        // NOT_AUTHENTICATED：登出竞态的正常收尾（CredentialGuard），不是故障，不上报不处置
+        if (exception.message == LogtoException.Type.NOT_AUTHENTICATED.name) return
         val causeChain = generateSequence(exception.cause) { it.cause }.toList()
-        if (!isClockSkew(causeChain)) return
-        if (clockSkewHinted.compareAndSet(false, true)) {
-            trackEvent("token_refresh_clock_skew", emptyMap())
-            SignInFailureBus.emit(SignInFailureReason.CLOCK_SKEW)
+        val reason = when {
+            isClockSkew(causeChain) -> "clock_skew"
+            isSessionExpired(causeChain) -> "invalid_grant"
+            causeChain.any { it is SocketTimeoutException } -> "timeout"
+            causeChain.any { it is UnknownHostException || it is ConnectException || it is IOException } -> "network"
+            else -> "other"
         }
+        trackEvent(
+            "token_refresh_failed",
+            mapOf("reason" to reason, "logto_type" to (exception.message ?: "unknown")),
+        )
+        when (reason) {
+            "clock_skew" -> if (clockSkewHinted.compareAndSet(false, true)) {
+                SignInFailureBus.emit(SignInFailureReason.CLOCK_SKEW)
+            }
+            "invalid_grant" -> handleSessionExpired()
+        }
+    }
+
+    /**
+     * 会话确定已死的判据：token 端点以 HTTP 400 + `error=invalid_grant` 拒绝 refresh（响应体如
+     * `{"error":"invalid_grant","error_detail":"refresh token not found"}`——吊销、有效期到期、
+     * 轮换竞态都落在这里）。**仅此一种情况允许清会话**：网络失败/超时/5xx 都可能是暂时的，
+     * 误清会把弱网（漫游）用户的好会话踢下线。
+     */
+    private fun isSessionExpired(causeChain: List<Throwable>): Boolean = causeChain.any {
+        it is ResponseException && it.responseCode == HTTP_BAD_REQUEST &&
+            it.responseContent?.contains("\"invalid_grant\"") == true
+    }
+
+    /**
+     * 会话失效处置：清 SDK 凭证 + 本地用户状态，降为登出态，经 [SignInFailureBus] 弹「重新登录」引导。
+     * 不走 [signOut]——不拉起浏览器 end-session（token 已死无可吊销，且不该在用户浏览内容时突然
+     * 弹出浏览器），也不上报 sign_out（这不是用户动作）。浏览器侧 Logto 会话通常仍在，
+     * 重新登录多为一跳静默回到原账号，摩擦很小。
+     */
+    private fun handleSessionExpired() {
+        if (!sessionExpiredHandled.compareAndSet(false, true)) return
+        logtoClient.clearCredentials { /* 本地凭证清除即生效 */ }
+        clearLocalUserState()
+        SignInFailureBus.emit(SignInFailureReason.SESSION_EXPIRED)
+        if (BuildConfig.DEBUG) Log.w(TAG, "session expired: credentials cleared, sign-in hint emitted")
     }
 
     /**
@@ -310,6 +378,7 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
     companion object {
         private const val TAG = "LogtoAuth"
         private const val LOGTO_APP_ID = "lasqslwwdjbim73vgkapj"
+        private const val HTTP_BAD_REQUEST = 400
         private const val CLOCK_PROBE_TIMEOUT_MS = 3_000
         private const val AUTH_PROBE_TIMEOUT_MS = 5_000
 

--- a/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/auth/LogtoAuthManager.kt
@@ -51,9 +51,6 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
 
     private val logtoClient = obtainClient(activity.application)
 
-    private val _authState = MutableStateFlow<AuthState>(
-        if (logtoClient.isAuthenticated) AuthState.LoggedIn else AuthState.LoggedOut
-    )
     override val authState: StateFlow<AuthState> = _authState.asStateFlow()
     override val isSupported: Boolean = true
 
@@ -415,8 +412,21 @@ class LogtoAuthManager(activity: Activity) : AuthManager {
                         usingPersistStorage = true,
                     ),
                     application,
-                ).also { sharedClient = it }
+                ).also {
+                    sharedClient = it
+                    // 登录态初始化只在首个 client 诞生时做一次；后续 manager 重建不得重置——
+                    // 否则会踩掉在途的 LoggingIn / 回调刚写入的终态
+                    _authState.value = if (it.isAuthenticated) AuthState.LoggedIn else AuthState.LoggedOut
+                }
             }
+
+        /**
+         * 进程级登录态流：manager 随 Activity 重建，若 flow 留在实例上，落在旧实例的回调
+         * （登录成功写 LoggedIn / 会话失效写 LoggedOut）只会更新旧 flow，新实例与 UI 永远
+         * 看不到——SignInFailureBus 当年为失败事件专设进程级总线就是绕这个坑，状态流本身
+         * 提级后这一族「写错实例」问题整体消失。
+         */
+        private val _authState = MutableStateFlow<AuthState>(AuthState.LoggedOut)
 
         /** token 获取互斥锁：进程级——跨 manager 实例的并发调用也串行化，见 [getAccessToken] */
         private val tokenMutex = Mutex()

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -197,7 +197,7 @@
     <string name="sign_in_hint_clock_skew">设备时间与实际时间偏差超过一分钟，登录安全校验无法通过。请在系统设置中开启「自动设置时间」后重试。</string>
     <string name="sign_in_hint_dismiss">知道了</string>
     <string name="sign_in_hint_session_expired_title">登录已过期</string>
-    <string name="sign_in_hint_session_expired">登录状态已失效，收藏同步和会员功能已暂停。重新登录即可恢复。</string>
+    <string name="sign_in_hint_session_expired">登录状态已过期，重新登录后可继续使用账户相关功能。</string>
     <string name="sign_in_hint_relogin">重新登录</string>
     <string name="profile_load_failed">加载失败</string>
     <string name="profile_retry">重试</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -196,6 +196,9 @@
     <string name="sign_in_hint_connectivity">GitHub 登录需要能正常访问 github.com，请检查网络后重试。</string>
     <string name="sign_in_hint_clock_skew">设备时间与实际时间偏差超过一分钟，登录安全校验无法通过。请在系统设置中开启「自动设置时间」后重试。</string>
     <string name="sign_in_hint_dismiss">知道了</string>
+    <string name="sign_in_hint_session_expired_title">登录已过期</string>
+    <string name="sign_in_hint_session_expired">登录状态已失效，收藏同步和会员功能已暂停。重新登录即可恢复。</string>
+    <string name="sign_in_hint_relogin">重新登录</string>
     <string name="profile_load_failed">加载失败</string>
     <string name="profile_retry">重试</string>
     <string name="profile_followers">粉丝</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -197,7 +197,7 @@
     <string name="sign_in_hint_clock_skew">Your device clock is off by more than a minute, so the sign-in security check fails. Turn on automatic date &amp; time in system settings, then try again.</string>
     <string name="sign_in_hint_dismiss">Got it</string>
     <string name="sign_in_hint_session_expired_title">Session expired</string>
-    <string name="sign_in_hint_session_expired">Your sign-in has expired, so favorites sync and Pro features are paused. Sign in again to restore them.</string>
+    <string name="sign_in_hint_session_expired">Your sign-in has expired. Sign in again to keep using account features.</string>
     <string name="sign_in_hint_relogin">Sign in again</string>
     <string name="profile_load_failed">Failed to load profile</string>
     <string name="profile_retry">Retry</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -196,6 +196,9 @@
     <string name="sign_in_hint_connectivity">GitHub sign-in needs to reach github.com. Please check your connection and try again.</string>
     <string name="sign_in_hint_clock_skew">Your device clock is off by more than a minute, so the sign-in security check fails. Turn on automatic date &amp; time in system settings, then try again.</string>
     <string name="sign_in_hint_dismiss">Got it</string>
+    <string name="sign_in_hint_session_expired_title">Session expired</string>
+    <string name="sign_in_hint_session_expired">Your sign-in has expired, so favorites sync and Pro features are paused. Sign in again to restore them.</string>
+    <string name="sign_in_hint_relogin">Sign in again</string>
     <string name="profile_load_failed">Failed to load profile</string>
     <string name="profile_retry">Retry</string>
     <string name="profile_followers">Followers</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/auth/AuthManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/auth/AuthManager.kt
@@ -21,6 +21,13 @@ enum class SignInFailureReason {
 
     /** 设备时钟偏差超出 id_token 校验容差（Logto SDK 60s）：重试无用，提示修时间（见 SignInHintHost） */
     CLOCK_SKEW,
+
+    /**
+     * 静默刷新被 Logto 以 invalid_grant 拒绝——refresh token 在服务端已不存在（吊销/到期/轮换竞态）。
+     * 与登录流程失败不同：此时本地会话已被清除（见 LogtoAuthManager 的会话失效处理），
+     * 提示的目的是让用户知道「需要重新登录」，而不是对着账户页的失败态反复重试。
+     */
+    SESSION_EXPIRED,
     OTHER,
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.data.repository.UserRepository
 import whl.trending.ai.data.repository.globalFavoriteRepository
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
@@ -76,14 +77,18 @@ internal fun MutableList<Any>.safePop() {
 fun App() {
     val backStack = remember { mutableStateListOf<Any>(Home) }
 
-    // 收藏云同步触发：放在 App 根部而非 HomeScreen——登录常发生在账户页（Home 已被覆盖、
-    // 其 LaunchedEffect 已随 NavEntry 销毁），只挂 HomeScreen 会导致「账户页登录→进我的收藏」
-    // 这条主路径永远不触发同步。根部 composition 全程存活，登录态一变即触发；实际同步在
+    // 收藏云同步 + 身份/Pro 态同步（syncMe）触发：放在 App 根部而非 HomeScreen——登录常发生在
+    // 账户页（Home 已被覆盖、其 LaunchedEffect 已随 NavEntry 销毁），只挂 HomeScreen 会导致
+    // 「账户页登录」这条主路径永远不触发。syncMe 是 setIsPro 的日常唯一写入点：曾只挂 Home，
+    // 账户页重登后本地 isPro 恒 false、Pro 用户被当免费档提示升级（2026-08-03，会话失效重登
+    // 成为常态路径后放大为必现）。根部 composition 全程存活，登录态一变即触发；收藏同步在
     // 仓库自有 scope 上跑（requestSync），不受任何屏切换取消。
     val authState by globalAuthManager.authState.collectAsState()
+    val userRepository = remember { UserRepository() }
     LaunchedEffect(authState) {
         if (authState is AuthState.LoggedIn) {
             globalFavoriteRepository.requestSync()
+            userRepository.syncMe(globalAuthManager.getAccessToken())
         }
     }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SignInHintHost.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SignInHintHost.kt
@@ -14,14 +14,19 @@ import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.sign_in_hint_clock_skew
 import trendingai.shared.generated.resources.sign_in_hint_connectivity
 import trendingai.shared.generated.resources.sign_in_hint_dismiss
+import trendingai.shared.generated.resources.sign_in_hint_relogin
+import trendingai.shared.generated.resources.sign_in_hint_session_expired
+import trendingai.shared.generated.resources.sign_in_hint_session_expired_title
 import trendingai.shared.generated.resources.sign_in_hint_title
 import whl.trending.ai.auth.SignInFailureBus
 import whl.trending.ai.auth.SignInFailureReason
+import whl.trending.ai.auth.globalAuthManager
 
 /**
  * 全局登录失败提示宿主：收集 [SignInFailureBus] 的失败事件，对可行动的失败类别弹轻量弹窗——
  * 连通性类（NETWORK/TIMEOUT）引导检查网络；时钟偏差类（CLOCK_SKEW）引导修系统时间，
  * 后者若只给通用提示，用户会陷入「重试永远失败」的死循环（时钟不修，id_token 校验必败）。
+ * 会话失效类（SESSION_EXPIRED）引导重新登录：本地会话已被清除，确认键直接拉起登录选择器。
  *
  * 用弹窗（独立窗口）而非 Snackbar：① 不占/不盖 app 布局；② 登录失败值得被明确看见，Snackbar 易被错过。
  * 放在 App 根部（与 WhatsNewHost 平级），是因为登录有 4 个触发点（首页头像 / Trending·Readme 的
@@ -40,28 +45,56 @@ fun SignInHintHost() {
     }
 
     hint?.let { reason ->
+        val sessionExpired = reason == SignInFailureReason.SESSION_EXPIRED
         AlertDialog(
             onDismissRequest = { hint = null },
-            title = { Text(stringResource(Res.string.sign_in_hint_title)) },
+            title = {
+                Text(
+                    stringResource(
+                        if (sessionExpired) Res.string.sign_in_hint_session_expired_title
+                        else Res.string.sign_in_hint_title,
+                    ),
+                )
+            },
             text = {
                 Text(
                     stringResource(
-                        if (reason == SignInFailureReason.CLOCK_SKEW) Res.string.sign_in_hint_clock_skew
-                        else Res.string.sign_in_hint_connectivity,
+                        when (reason) {
+                            SignInFailureReason.SESSION_EXPIRED -> Res.string.sign_in_hint_session_expired
+                            SignInFailureReason.CLOCK_SKEW -> Res.string.sign_in_hint_clock_skew
+                            else -> Res.string.sign_in_hint_connectivity
+                        },
                     ),
                 )
             },
             confirmButton = {
-                TextButton(onClick = { hint = null }) {
-                    Text(stringResource(Res.string.sign_in_hint_dismiss))
+                if (sessionExpired) {
+                    // 浏览器侧 Logto 会话通常还在（本地只清了凭证），重登多为一跳静默回到原账号
+                    TextButton(onClick = {
+                        hint = null
+                        globalAuthManager.signIn("session_expired_hint")
+                    }) {
+                        Text(stringResource(Res.string.sign_in_hint_relogin))
+                    }
+                } else {
+                    TextButton(onClick = { hint = null }) {
+                        Text(stringResource(Res.string.sign_in_hint_dismiss))
+                    }
                 }
             },
+            dismissButton = if (sessionExpired) {
+                {
+                    TextButton(onClick = { hint = null }) {
+                        Text(stringResource(Res.string.sign_in_hint_dismiss))
+                    }
+                }
+            } else null,
         )
     }
 }
 
 /**
- * 是否值得弹提示：仅限用户可行动的失败（查网络 / 修时钟）。
+ * 是否值得弹提示：仅限用户可行动的失败（查网络 / 修时钟 / 重新登录）。
  *
  * USER_CANCELED 不弹——用户主动关闭授权页是常见操作，弹提示既误导又打扰。代价是已缓存 OIDC 配置的
  * 老用户断网登录（错误落在浏览器内、被归为 USER_CANCELED）收不到提示，这是取舍后的选择。
@@ -70,7 +103,8 @@ fun SignInHintHost() {
 private fun SignInFailureReason.shouldHint(): Boolean = when (this) {
     SignInFailureReason.NETWORK,
     SignInFailureReason.TIMEOUT,
-    SignInFailureReason.CLOCK_SKEW -> true
+    SignInFailureReason.CLOCK_SKEW,
+    SignInFailureReason.SESSION_EXPIRED -> true
     SignInFailureReason.USER_CANCELED,
     SignInFailureReason.NO_BROWSER,
     SignInFailureReason.CONFIG,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -73,7 +73,6 @@ import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.chat.globalChatScreen
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.ChatModelsProvider
-import whl.trending.ai.data.repository.UserRepository
 import whl.trending.ai.ui.common.TrendingScaffold
 import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.ai.ui.feed.FeedScreen
@@ -142,16 +141,10 @@ fun HomeScreen(
     val authManager = globalAuthManager
     val authState by authManager.authState.collectAsState()
     val userAvatarUrl by globalSettingsManager.userAvatarUrl.collectAsState(null)
-    val userRepository = remember { UserRepository() }
 
-    // 应用启动且已登录：服务端建档/刷新 last_login_at + 同步头像（幂等，失败静默）。
-    // 收藏云同步不在此触发——它挂在 App 根部（见 App.kt），以覆盖账户页登录等 Home 未激活的路径。
-    LaunchedEffect(authState) {
-        val state = authState
-        if (state is AuthState.LoggedIn) {
-            userRepository.syncMe(authManager.getAccessToken())
-        }
-    }
+    // syncMe（建档 + 头像/GitHub 身份/isPro 缓存）不在此触发——已随收藏同步一起挂在 App 根部
+    // （见 App.kt）：登录常发生在账户页，Home 的 LaunchedEffect 彼时已随 NavEntry 销毁，
+    // 挂这里会漏掉「账户页登录」主路径（isPro 不回写，Pro 用户被当免费档，2026-08-03 必现修复）。
 
     // 预热聊天模型目录：让选择器 chip 在用户首次进入 chat 前就绪，避免冷首拉导致 chip 迟迟不出现。
     LaunchedEffect(Unit) {


### PR DESCRIPTION
## 背景

2026-08-01 事故:refresh token 在 Logto 侧失效(`invalid_grant: refresh token not found`)后,账户页陷入「加载失败/重试」死循环且不发任何 API 请求,chat/收藏被无声降级为匿名档(authDegraded)。审计日志显示多位真实用户处于同一僵尸状态。

服务端已处置:Logto 关闭 refresh token 轮换、有效期调至 180 天。但 token 总有失效时刻(180 天到期即必然走到),客户端必须能体面收场——本 PR 落地三项客户端优化。

## 改动

1. **会话失效自愈**( LogtoAuthManager ):`getAccessToken` 失败时识别「token 端点 HTTP 400 + `invalid_grant`」这一确定性死亡签名 → 清 SDK 凭证与本地用户状态、降为登出态,经 `SignInFailureBus` 新增 `SESSION_EXPIRED` 通道弹「登录已过期」对话框,确认键直通登录选择器。**仅对确定性拒绝清会话**,网络失败/超时/5xx 不动(弱网误杀会把漫游用户的好会话踢下线);时钟偏差判定保持优先。
2. **刷新单飞**:并发 `getAccessToken`(账户页 quota+me 并发场景)收敛为同一时刻至多一条真实刷新,后到者共享结果。这是轮换竞态「持久化到已被替换的旧 token」的源头;日后若重开轮换也不再复活。
3. **失败可观测**:新增 `token_refresh_failed` 事件带 reason 分类(invalid_grant/clock_skew/timeout/network/other),替代原 `token_refresh_clock_skew`。Aptabase 面板可直接回答「有多少用户处于僵尸登录态」。

## 验证(模拟器 debug 包实测)

- 登录后用 `/oidc/token/revocation` 人为吊销 refresh token 复现事故 → 冷启动即弹「Session expired」对话框(不再死循环),点「Sign in again」经浏览器静默重登恢复;logcat 出现 `session expired: credentials cleared` 处置日志。
- Logto 审计对表:该次失败仅 **1 条**刷新记录(旧版同场景恒为同秒 **2 条**,如 08-01 13:47:42×2 / 13:48:21×2),单飞生效。
- 审计日志同时可见其他用户的旧版仍在成对刷新 + invalid_grant 失败风暴,佐证本修复需要随版本发出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

改进客户端在处理 Logto 令牌刷新失败时的行为，以避免“僵尸会话”，并让失败情况更易于被观测到。

New Features:
- 添加单航班（single-flight）访问令牌刷新机制，使并发请求共享同一次底层刷新操作。
- 显示全局的“会话已过期”登录提示，当刷新令牌失效时，允许用户重新发起登录流程。
- 引入 `token_refresh_failed` 分析事件，并对失败原因进行分类，用于监控令牌刷新失败和僵尸登录状态。

Bug Fixes:
- 将来自 Logto 令牌端点的可预期的 `invalid_grant` 响应视为会话过期，清除凭据和本地状态，而不是让应用停留在损坏的“已登录”状态。

Enhancements:
- 将本地用户状态清理逻辑集中化，使登出和会话过期流程都能一致地重置缓存的身份和认证状态。
- 在用户重新登录成功后，重置会话过期处理逻辑，以确保后续的过期事件能够被正确处理。
- 扩展登录提示对话框以处理会话过期场景，提供本地化文案，并可直接导航到登录流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve client handling of Logto token refresh failures to avoid zombie sessions and make failures observable.

New Features:
- Add single-flight access token refresh so concurrent requests share one underlying refresh operation.
- Show a global "session expired" sign-in hint that lets users re-initiate login when the refresh token is invalidated.
- Introduce a token_refresh_failed analytics event with categorized reasons to monitor refresh failures and zombie login states.

Bug Fixes:
- Treat deterministic invalid_grant responses from the Logto token endpoint as session expiry, clearing credentials and local state instead of leaving the app in a broken logged-in state.

Enhancements:
- Centralize local user state clearing so logout and session-expiry flows consistently reset cached identity and auth state.
- Reset session-expiry handling after successful re-login to ensure future expirations are processed correctly.
- Extend the sign-in hint dialog to handle session expiry with localized copy and direct navigation to the sign-in flow.

</details>