### PR TITLE
refactor(favorites): 收藏改单向同步，砍掉 op 队列与双真源

### DIFF
--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -130,6 +130,7 @@
     <string name="favorites_empty">暂无收藏</string>
     <string name="favorites_empty_hint">点击内容底部的菜单即可收藏</string>
     <string name="favorites_removed">已取消收藏</string>
+    <string name="favorites_action_failed">收藏同步失败，请检查网络后重试</string>
     <string name="action_favorite">收藏</string>
     <string name="action_unfavorite">取消收藏</string>
     <string name="action_star">Star</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -130,6 +130,7 @@
     <string name="favorites_empty">No favorites yet</string>
     <string name="favorites_empty_hint">Tap the menu on any item to save it here</string>
     <string name="favorites_removed">Removed from favorites</string>
+    <string name="favorites_action_failed">Couldn&apos;t sync your favorites. Check your connection and try again.</string>
     <string name="action_favorite">Favorite</string>
     <string name="action_unfavorite">Unfavorite</string>
     <string name="action_star">Star</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
@@ -40,6 +40,7 @@ import whl.trending.ai.chat.ChatContext
 import whl.trending.ai.chat.globalChatScreen
 import whl.trending.ai.core.platform.openUrl
 import whl.trending.ai.ui.common.ForceUpdateGate
+import whl.trending.ai.ui.common.FavoriteErrorHost
 import whl.trending.ai.ui.common.SignInHintHost
 import whl.trending.ai.ui.common.SignInMethodChooserHost
 import whl.trending.ai.ui.common.SponsorLinkHost
@@ -298,6 +299,8 @@ fun App() {
                         }
                     }
                 )
+                // 排在 NavDisplay 之后：Snackbar 不是独立窗口，先绘制会被页面内容盖住
+                FavoriteErrorHost()
             }
         }
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -17,10 +17,8 @@ import kotlinx.serialization.json.Json
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import whl.trending.ai.core.platform.getSystemLanguage
-import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.model.CHAT_MODEL_UNSET
 import whl.trending.ai.data.model.FavoriteItem
-import whl.trending.ai.data.model.PendingFavoriteOp
 
 /**
  * 持久化存的是 ordinal，新档位只能追加在末尾，否则老用户的选择会错位。
@@ -111,6 +109,8 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val LAST_UPDATE_CHECK_KEY = "prefs_last_update_check"
     private val LAST_SEEN_WHATSNEW_KEY = "prefs_last_seen_whatsnew_version"
     private val FAVORITES_KEY = "prefs_favorites"
+    private val FAVORITES_CACHE_KEY = "prefs_favorites_cache"
+    // 下面两个键已废弃（旧 op 队列 / 首次合并标记），仅由 migrateFavoritesStorageIfNeeded 读取后清除
     private val FAVORITES_PENDING_KEY = "prefs_favorites_pending"
     private val FAVORITES_MERGED_KEY = "prefs_favorites_merged"
     private val SUBSCRIBED_EMAIL_KEY = "prefs_subscribed_email"
@@ -350,69 +350,53 @@ class SettingsManager(private val settings: ObservableSettings) {
     fun setLastSeenWhatsNewVersion(version: String) =
         settings.putString(LAST_SEEN_WHATSNEW_KEY, version)
 
-    val favorites: Flow<List<FavoriteItem>> = settings.getStringOrNullFlow(FAVORITES_KEY)
-        .map { json ->
-            if (json.isNullOrEmpty()) emptyList()
-            else runCatching { Json.decodeFromString<List<FavoriteItem>>(json) }.getOrElse { emptyList() }
-        }
+    // ---- 收藏：两份存储，各自只有一个写入者，永不互相合并 ----
+    // [localFavorites]（FAVORITES_KEY）= 未登录时的唯一真源，同时是「有条目待导入云端」的信号；
+    // [cachedFavorites]（FAVORITES_CACHE_KEY）= 已登录时服务端收藏的只读镜像。
+    // 登录态决定读哪一份（见 FavoriteRepository.favorites），两份从不 merge，故无需任何同步状态位。
 
-    fun addFavorite(item: FavoriteItem) {
-        val current = getCurrentFavorites()
-        if (current.any { it.url == item.url }) return
-        val updated = listOf(item) + current
-        settings.putString(FAVORITES_KEY, Json.encodeToString(updated))
-        // 当前所有调用点均为用户手势，集中在此埋点即可覆盖各页面入口；
-        // 若未来引入同步/导入等非手势写入，需绕开本方法或拆分埋点
-        trackEvent("favorite_toggle", mapOf("on" to true, "source" to item.source))
-    }
+    val localFavorites: Flow<List<FavoriteItem>> = settings.getStringOrNullFlow(FAVORITES_KEY)
+        .map { decodeFavorites(it) }
 
-    fun removeFavorite(url: String) {
-        val current = getCurrentFavorites()
-        val updated = current.filter { it.url != url }
-        settings.putString(FAVORITES_KEY, Json.encodeToString(updated))
-        trackEvent("favorite_toggle", mapOf("on" to false))
-    }
+    fun currentLocalFavorites(): List<FavoriteItem> = decodeFavorites(settings.getStringOrNull(FAVORITES_KEY))
 
-    /** 当前收藏快照（同步引擎读本地态用）。 */
-    fun currentFavorites(): List<FavoriteItem> = getCurrentFavorites()
+    fun setLocalFavorites(items: List<FavoriteItem>) = writeFavorites(FAVORITES_KEY, items)
 
-    private fun getCurrentFavorites(): List<FavoriteItem> {
-        val json = settings.getStringOrNull(FAVORITES_KEY) ?: return emptyList()
+    val cachedFavorites: Flow<List<FavoriteItem>> = settings.getStringOrNullFlow(FAVORITES_CACHE_KEY)
+        .map { decodeFavorites(it) }
+
+    fun currentCachedFavorites(): List<FavoriteItem> = decodeFavorites(settings.getStringOrNull(FAVORITES_CACHE_KEY))
+
+    fun setCachedFavorites(items: List<FavoriteItem>) = writeFavorites(FAVORITES_CACHE_KEY, items)
+
+    private fun decodeFavorites(json: String?): List<FavoriteItem> {
+        if (json.isNullOrEmpty()) return emptyList()
         return runCatching { Json.decodeFromString<List<FavoriteItem>>(json) }.getOrElse { emptyList() }
     }
 
-    /**
-     * 用服务端全量列表覆盖本地收藏缓存（云同步「打开时全量拉取」用）。
-     * 非用户手势，不埋点；与 [addFavorite]/[removeFavorite] 的手势写入区分。
-     */
-    fun replaceFavorites(items: List<FavoriteItem>) {
-        settings.putString(FAVORITES_KEY, Json.encodeToString(items))
-    }
-
-    // ---- 云同步状态：待同步 op 队列 + 首次登录合并标记 ----
-
-    fun getPendingFavoriteOps(): List<PendingFavoriteOp> {
-        val json = settings.getStringOrNull(FAVORITES_PENDING_KEY) ?: return emptyList()
-        return runCatching { Json.decodeFromString<List<PendingFavoriteOp>>(json) }.getOrElse { emptyList() }
-    }
-
-    fun setPendingFavoriteOps(ops: List<PendingFavoriteOp>) {
-        if (ops.isEmpty()) settings.remove(FAVORITES_PENDING_KEY)
-        else settings.putString(FAVORITES_PENDING_KEY, Json.encodeToString(ops))
-    }
-
-    /** 是否已完成本次登录的首次合并（true 后走增量 op flush，false 时走全量 batch 合并）。 */
-    fun favoritesMerged(): Boolean = settings.getBoolean(FAVORITES_MERGED_KEY, false)
-
-    fun setFavoritesMerged(value: Boolean) {
-        settings.putBoolean(FAVORITES_MERGED_KEY, value)
+    private fun writeFavorites(key: String, items: List<FavoriteItem>) {
+        if (items.isEmpty()) settings.remove(key) else settings.putString(key, Json.encodeToString(items))
     }
 
     /**
-     * 登出时清空账号收藏与同步状态：收藏已安全存于该账号云端，清本地避免账号间数据串味
-     * （下个账号登录时不会把上一个账号的收藏 batch 合并上去）。匿名重新收藏从空开始。
+     * 登出时只清云端镜像：那份数据属于刚登出的账号，留着会串到下个账号。
+     * 不清 [localFavorites]——它装的是匿名期收藏（登录后导入成功即被清空，非空说明尚未成功上云），
+     * 不属于任何账号，登出后应原样回到匿名态继续可见。
      */
     fun clearFavoritesOnSignOut() {
+        settings.remove(FAVORITES_CACHE_KEY)
+    }
+
+    /**
+     * 一次性存储迁移：0.22.0 的收藏同步把服务端全量写回 FAVORITES_KEY，并用 merged 标记记账。
+     * 新模型下 FAVORITES_KEY 专表「待导入」，若把老用户那份（已在云端）留在原处，
+     * 升级后会被当成待导入再 batch 上去一次——本身幂等无害，但会把用户在另一台设备已删、
+     * 本机尚未 GET 到的条目复活。故按老 merged 标记把它搬进镜像键，并清掉两个废弃键。
+     */
+    fun migrateFavoritesStorageIfNeeded() {
+        if (!settings.getBoolean(FAVORITES_MERGED_KEY, false)) return
+        val synced = decodeFavorites(settings.getStringOrNull(FAVORITES_KEY))
+        if (synced.isNotEmpty()) setCachedFavorites(synced)
         settings.remove(FAVORITES_KEY)
         settings.remove(FAVORITES_PENDING_KEY)
         settings.remove(FAVORITES_MERGED_KEY)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/FavoriteItem.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/FavoriteItem.kt
@@ -17,35 +17,13 @@ data class FavoriteItem(
      */
     val openUrl: String? = null,
     /**
-     * 与后端 contents 表对齐的内容标识（github=owner/repo、hn=story id、ph=node id），
-     * 云同步以 (source, externalId) 为唯一键。存量本地收藏 / 无法解析时为空串，
-     * 首次同步由 [resolvedExternalId] best-effort 回填（github 从 url 反解，其余用 url 派生）。
+     * 与后端 contents 表对齐的内容标识（github=owner/repo、hn=story id、ph=node id）。
+     * 各页面收藏时都自带（来自 API），仅 0.22.0 之前的存量本地收藏为空串——
+     * 上云前由 `FavoriteRepository.withExternalId` 用 url 顶上，不做反解。
      */
     val externalId: String = ""
 ) {
     /** 打开收藏时应使用的地址 */
     val targetUrl: String get() = openUrl?.takeIf { it.isNotBlank() } ?: url
-
-    /**
-     * 云同步用的 external_id：优先用已有值；缺失时 best-effort 回填——
-     * github 从 url 反解 owner/repo，其余源用 url 派生合成键（`url:<url>`，仅保证用户内唯一，不与 contents join）。
-     */
-    val resolvedExternalId: String
-        get() = externalId.ifBlank {
-            if (source == "github") {
-                val path = url
-                    .removePrefix("https://github.com/")
-                    .removePrefix("http://github.com/")
-                    .trimEnd('/')
-                val parts = path.split("/")
-                if (parts.size >= 2 && parts[0].isNotBlank() && parts[1].isNotBlank()) {
-                    "${parts[0]}/${parts[1]}"
-                } else {
-                    "url:$url"
-                }
-            } else {
-                "url:$url"
-            }
-        }
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/FavoritesResponse.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/FavoritesResponse.kt
@@ -2,24 +2,11 @@ package whl.trending.ai.data.model
 
 import kotlinx.serialization.Serializable
 
-/** GET /api/favorites 响应：服务端返回的收藏全量列表（字段名与 [FavoriteItem] 对齐，可直接反序列化）。 */
+/**
+ * GET /api/favorites 响应：服务端返回的收藏全量列表（字段名与 [FavoriteItem] 对齐，可直接反序列化）。
+ * 同一形状也用作 POST /api/favorites/batch 的请求体。
+ */
 @Serializable
 data class FavoritesResponse(
     val favorites: List<FavoriteItem> = emptyList()
-)
-
-/**
- * 收藏本地待同步操作（pending op），登录且已完成首次合并后产生：
- * 每次收藏/取消先落本地即时生效，再入队一条 op，后台 flush 到服务端；flush 失败留队列下次重试。
- * delete 需 (source, externalId) 打服务端；[url] 供本地缓存合并（applyPending）按 url 定位。
- */
-@Serializable
-data class PendingFavoriteOp(
-    /** "add" | "delete" */
-    val op: String,
-    val url: String,
-    val source: String,
-    val externalId: String,
-    /** add 时携带完整快照，供 flush 上云与在途合并回填 */
-    val item: FavoriteItem? = null
 )

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -208,10 +208,10 @@ open class TrendingApi {
         return response.body<ChatModelsResponse>()
     }
 
-    // ---- 收藏云同步（设计稿 2026-07-24-favorites-cloud-sync，B 档）----
-    // 全部经 Bearer 鉴权；调用方（FavoriteRepository）负责传入 externalId 已回填的条目。
+    // ---- 收藏（登录用户；服务端是唯一真源，见 FavoriteRepository）----
+    // 全部经 Bearer 鉴权；调用方负责传入 externalId 非空的条目。
 
-    /** 拉取该用户全量收藏。非 2xx 抛 [ApiException]，供调用方在失败时保留本地、不覆盖。 */
+    /** 拉取该用户全量收藏。非 2xx 抛 [ApiException]，供调用方在失败时保留镜像、不覆盖。 */
     open suspend fun fetchFavorites(accessToken: String): List<FavoriteItem> {
         val response = client.get("$baseHost/api/favorites") {
             header(HttpHeaders.Authorization, "Bearer $accessToken")
@@ -222,7 +222,7 @@ open class TrendingApi {
         return response.body<FavoritesResponse>().favorites
     }
 
-    /** upsert 单条收藏（幂等）。返回是否成功，失败由调用方入队重试。 */
+    /** upsert 单条收藏（幂等）。返回是否成功，失败由调用方回滚乐观更新。 */
     open suspend fun putFavorite(accessToken: String, item: FavoriteItem): Boolean {
         val response = client.put("$baseHost/api/favorites") {
             header(HttpHeaders.Authorization, "Bearer $accessToken")
@@ -242,7 +242,7 @@ open class TrendingApi {
         return response.status.value in 200..299
     }
 
-    /** 批量 upsert（登录首次合并本地收藏）。 */
+    /** 批量 upsert（登录时一次性导入匿名期本地收藏；幂等，失败可原样重来）。 */
     open suspend fun batchPutFavorites(accessToken: String, items: List<FavoriteItem>): Boolean {
         val response = client.post("$baseHost/api/favorites/batch") {
             header(HttpHeaders.Authorization, "Bearer $accessToken")

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/FavoriteRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/FavoriteRepository.kt
@@ -3,175 +3,183 @@ package whl.trending.ai.data.repository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import whl.trending.ai.auth.AuthManager
+import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.globalAuthManager
+import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.FavoriteItem
-import whl.trending.ai.data.model.PendingFavoriteOp
 import whl.trending.ai.data.remote.TrendingApi
 
 /**
- * 收藏云同步引擎（设计稿 2026-07-24-favorites-cloud-sync，B 档：本地缓存 + 幂等 CRUD + 打开时全量拉取覆盖）。
+ * 收藏读写的唯一入口。一条数据永远只有一个真源，同步只有一个方向：
  *
- * - 本地缓存（[SettingsManager] 的 favorites）始终是 UI 即时真源，离线可用；网络在后台跑、失败不打断。
- * - 收藏/取消：先落本地即时生效，登录且已完成首次合并后入队一条 op 并后台 flush；失败留队列下次重试。
- * - [sync]（登录/启动触发）：首次登录把全部本地收藏 batch 上云合并，之后 flush 增量 op；随后全量 GET 覆盖本地。
- * - 删除跨设备传播靠「打开时全量 GET 覆盖」完成，无墓碑。
+ * - **未登录**：[SettingsManager.localFavorites] 是唯一真源，纯本地、离线可用（与云同步上线前一致）。
+ * - **登录那一刻**：把 local 那份一次性 batch 上云，成功后清空——这是全链路唯一一次「本地 → 云端」。
+ * - **已登录**：服务端是唯一真源，[SettingsManager.cachedFavorites] 只是它的只读镜像；
+ *   收藏/取消先乐观改镜像再打接口，失败原样回滚并发 [errors]（离线不支持收藏，是有意的功能裁剪）。
  *
- * UI 只需把原先直调 SettingsManager 的收藏读写改为调本类；收藏列表流仍读 SettingsManager.favorites 不变。
+ * 因此这里没有 pending 队列、没有 dirty/merged 状态位、没有双向合并与冲突判定：
+ * 「local 非空」本身就是「还欠一次导入」的信号，导入失败不清空、下次 [sync] 原样重来即可（batch 幂等）。
  */
 class FavoriteRepository(
     private val settings: SettingsManager,
     private val api: TrendingApi,
-    private val tokenProvider: suspend () -> String?,
+    /**
+     * 取当前 [AuthManager] 而非直接持有实例：配置变更会重建 Activity 并替换 [globalAuthManager]，
+     * 持有旧实例会让登录态判断永久停在注入前的 Noop（登录后仍走本地分支）。
+     */
+    private val authProvider: () -> AuthManager = { globalAuthManager },
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    /** 埋点注入点：host 单测里 Aptabase 未初始化，直调 trackEvent 会 NPE */
+    private val track: (String, Map<String, Any>) -> Unit = { name, props -> trackEvent(name, props) },
 ) {
-    // 序列化所有网络同步，避免 flush 与全量覆盖交错导致缓存被旧快照回冲
+    // 串行化所有收藏写入：连点两次、以及与 sync 的并发，都不允许交错读-改-写同一份存储
     private val mutex = Mutex()
 
-    /** 收藏：本地即时写入 + 埋点（沿用 SettingsManager 手势路径），随后后台推送。 */
-    fun add(item: FavoriteItem) {
-        val resolved = if (item.externalId.isBlank()) item.copy(externalId = item.resolvedExternalId) else item
-        settings.addFavorite(resolved)
-        if (canSyncOps()) {
-            scope.launch { pushOp(PendingFavoriteOp("add", resolved.url, resolved.source, resolved.externalId, resolved)) }
-        }
-    }
-
-    /** 取消收藏：按 url 本地删除 + 埋点，随后后台推送删除。 */
-    fun remove(url: String) {
-        val existing = settings.currentFavorites().firstOrNull { it.url == url }
-        settings.removeFavorite(url)
-        if (existing != null && canSyncOps()) {
-            scope.launch { pushOp(PendingFavoriteOp("delete", url, existing.source, existing.resolvedExternalId, null)) }
-        }
+    init {
+        settings.migrateFavoritesStorageIfNeeded()
     }
 
     /**
-     * 登录 / 启动时的同步。传入 access token（null=匿名，直接返回，纯本地）。
-     * 内部吞掉网络异常：失败保留本地态，下次再试。
+     * 当前应展示的收藏列表：登录态读云端镜像，否则读本地那份——**按登录态二选一，不做合并**。
+     *
+     * authState 用 cold flow 延迟到订阅时才读 [authProvider]，与 WhileSubscribed 配合，
+     * 天然跟上 Activity 重建后的实例替换。
      */
-    suspend fun sync(accessToken: String?) {
-        val token = accessToken ?: return
-        mutex.withLock {
-            runCatching {
-                if (!settings.favoritesMerged()) {
-                    // 首次登录合并：全部本地收藏（含匿名期 + 存量，externalId 回填）batch 上云
-                    val local = settings.currentFavorites().map { withResolvedId(it) }
-                    if (local.isNotEmpty() && !api.batchPutFavorites(token, local)) {
-                        return@runCatching // batch 失败：不置 merged、不覆盖本地，下次重试
-                    }
-                    settings.setPendingFavoriteOps(emptyList()) // batch 已全覆盖，清历史 op
-                    settings.setFavoritesMerged(true)
-                } else {
-                    flushPending(token)
-                }
-                // 全量拉取覆盖本地；叠加在途/未 flush 成功的 pending，避免刚发生的本地改动被旧快照冲掉
-                val server = api.fetchFavorites(token)
-                val merged = applyPending(server, settings.getPendingFavoriteOps())
-                settings.replaceFavorites(merged)
+    val favorites: StateFlow<List<FavoriteItem>> = combine(
+        flow { emitAll(authProvider().authState) },
+        settings.localFavorites,
+        settings.cachedFavorites,
+    ) { state, local, cached ->
+        if (state is AuthState.LoggedIn) cached else local
+    }.stateIn(scope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /** 列表页判断「这条是否已收藏」用；由 [favorites] 派生，全 app 只解析一次存储。 */
+    val favoriteUrls: StateFlow<Set<String>> = favorites
+        .map { items -> items.mapTo(mutableSetOf()) { it.url } }
+        .stateIn(scope, SharingStarted.WhileSubscribed(5_000), emptySet())
+
+    private val _errors = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+    /** 收藏/取消失败（登录态下网络不可用等），由根部宿主统一提示。 */
+    val errors: SharedFlow<Unit> = _errors.asSharedFlow()
+
+    /** 收藏 / 取消收藏（按当前是否已收藏自动取反）。传入完整快照，取消时只用到 url。 */
+    fun toggle(item: FavoriteItem) {
+        scope.launch {
+            mutex.withLock {
+                if (currentFavorites().any { it.url == item.url }) removeLocked(item.url) else addLocked(item)
             }
         }
     }
 
     /**
-     * 触发一次同步，运行在仓库自有 [scope] 上（**不绑定任何 Compose composition**）。
-     * 必须用它、而非在 composable 的 LaunchedEffect 里直接 await [sync]——否则用户登录后
-     * 一旦离开当前屏（如登录发生在账户页、随即进"我的收藏"），composition 退出会取消协程
-     * （LeftCompositionCancellationException），[sync] 半途中断、[replaceFavorites] 不执行，
-     * 云端收藏拉不下来。token 由自身 [tokenProvider] 取，调用方无需持有。
+     * 登录后 / 启动时的同步：先把匿名期攒下的收藏一次性导入，再用服务端全量刷新镜像。
+     * 网络异常一律吞掉——本地态保持不变，下次进来重来。
      */
-    fun requestSync() {
-        scope.launch {
-            val token = tokenProvider() ?: return@launch
-            sync(token)
+    suspend fun sync() {
+        mutex.withLock {
+            val token = authProvider().getAccessToken() ?: return
+            runCatching {
+                val pending = settings.currentLocalFavorites()
+                if (pending.isNotEmpty()) {
+                    // 导入失败就此打住：此时不能刷新镜像，否则登录态读到的镜像里没有这批条目，
+                    // 用户会以为匿名期的收藏丢了（其实还在 local 键里等下次导入）
+                    if (!api.batchPutFavorites(token, pending.map { withExternalId(it) })) return@runCatching
+                    settings.setLocalFavorites(emptyList())
+                }
+                settings.setCachedFavorites(api.fetchFavorites(token))
+            }
         }
     }
 
     /**
-     * 登出清理：清空本地收藏 + 同步状态，避免账号间串味。由登出流程调用。
-     *
-     * 取舍：会一并清掉未 flush 成功的 pending op。极端场景「离线新增一条收藏（flush 失败留队列）
-     * → 立即登出」下，该条既未上云也被清除 → 丢失。不在此做 best-effort flush，因为：
-     * (1) 该场景前提是离线，flush 同样发不出去；(2) 登出流程开头已吊销凭证，此刻已无有效 token。
-     * 唯一能不丢的做法是「登出不清、留到下次登录再传」，但那会重开要防的账号串味。
-     * 详见设计稿 §6.2。
+     * 触发一次同步，跑在仓库自有 [scope] 上（**不绑定任何 Compose composition**）。
+     * 必须用它、而非在 composable 的 LaunchedEffect 里直接 await [sync]——否则用户登录后
+     * 一旦离开当前屏（如登录发生在账户页、随即进「我的收藏」），composition 退出会取消协程
+     * （LeftCompositionCancellationException），[sync] 半途中断，云端收藏拉不下来。
      */
+    fun requestSync() {
+        scope.launch { sync() }
+    }
+
+    /** 登出清理：只清云端镜像，匿名期那份不动（见 [SettingsManager.clearFavoritesOnSignOut]）。 */
     fun onSignOut() {
         settings.clearFavoritesOnSignOut()
     }
 
     // ---- 内部 ----
 
-    /**
-     * 仅在已完成首次合并后才入队增量 op；否则本地改动由首次 batch 合并整体覆盖。
-     * merged 只有在带真实 token 的 [sync] 成功后才置 true，故匿名 / iOS(Noop 无 token) 恒为 false，
-     * 天然不入队、队列不膨胀，无需再看平台是否支持登录。
-     */
-    private fun canSyncOps(): Boolean = settings.favoritesMerged()
+    private fun isLoggedIn(): Boolean = authProvider().authState.value is AuthState.LoggedIn
 
     /**
-     * 入队一条 op 并尝试 flush，全程持 [mutex]——与 [sync] 串行化。
-     * 关键：pending 键的读-改-写只允许在 mutex 内发生（enqueue/flush/sync 都在锁内），
-     * 否则主线程 enqueue 与后台 flush 并行 RMW 同一 prefs 键会 lost-update、静默丢一条收藏。
+     * 当前收藏的同步快照。[favorites] 是 StateFlow，首个值要等订阅后才到，
+     * 进屏即读（如收藏列表页的曝光埋点）会拿到初始空列表，故直接读存储。
      */
-    private suspend fun pushOp(op: PendingFavoriteOp) {
-        mutex.withLock {
-            enqueueLocked(op)
-            val token = tokenProvider() ?: return@withLock // 匿名/无 token：留队列，下次 sync 再推
-            runCatching { flushPending(token) }
+    fun currentFavorites(): List<FavoriteItem> =
+        if (isLoggedIn()) settings.currentCachedFavorites() else settings.currentLocalFavorites()
+
+    private suspend fun addLocked(item: FavoriteItem) {
+        val entry = withExternalId(item)
+        track("favorite_toggle", mapOf("on" to true, "source" to entry.source))
+        if (!isLoggedIn()) {
+            settings.setLocalFavorites(listOf(entry) + settings.currentLocalFavorites().filterNot { it.url == entry.url })
+            return
+        }
+        val before = settings.currentCachedFavorites()
+        settings.setCachedFavorites(listOf(entry) + before.filterNot { it.url == entry.url }) // 乐观
+        val token = authProvider().getAccessToken()
+        val ok = token != null && runCatching { api.putFavorite(token, entry) }.getOrDefault(false)
+        if (!ok) {
+            settings.setCachedFavorites(before)
+            _errors.tryEmit(Unit)
         }
     }
 
-    /** 必须在 [mutex] 内调用。同一 (op,url) 去重合并：保留最新一条，避免同键 op 堆积。 */
-    private fun enqueueLocked(op: PendingFavoriteOp) {
-        val kept = settings.getPendingFavoriteOps().filterNot { it.op == op.op && it.url == op.url }
-        settings.setPendingFavoriteOps(kept + op)
-    }
-
-    /** 逐条推送队列；成功的移出队列，遇失败保留剩余（含当前）待下次重试。必须在 [mutex] 内调用。 */
-    private suspend fun flushPending(token: String) {
-        val ops = settings.getPendingFavoriteOps()
-        if (ops.isEmpty()) return
-        val done = mutableListOf<PendingFavoriteOp>()
-        for (op in ops) {
-            val ok = when (op.op) {
-                "add" -> op.item?.let { api.putFavorite(token, withResolvedId(it)) } ?: true
-                "delete" -> api.deleteFavorite(token, op.source, op.externalId)
-                else -> true // 未知 op 直接丢弃
-            }
-            if (ok) done += op else break
+    private suspend fun removeLocked(url: String) {
+        track("favorite_toggle", mapOf("on" to false))
+        if (!isLoggedIn()) {
+            settings.setLocalFavorites(settings.currentLocalFavorites().filterNot { it.url == url })
+            return
         }
-        if (done.isNotEmpty()) {
-            settings.setPendingFavoriteOps(settings.getPendingFavoriteOps().filterNot { it in done })
+        val before = settings.currentCachedFavorites()
+        val target = before.firstOrNull { it.url == url } ?: return
+        settings.setCachedFavorites(before.filterNot { it.url == url }) // 乐观
+        val token = authProvider().getAccessToken()
+        val ok = token != null &&
+            runCatching { api.deleteFavorite(token, target.source, withExternalId(target).externalId) }.getOrDefault(false)
+        if (!ok) {
+            settings.setCachedFavorites(before)
+            _errors.tryEmit(Unit)
         }
     }
 
-    private fun withResolvedId(item: FavoriteItem): FavoriteItem =
-        if (item.externalId.isBlank()) item.copy(externalId = item.resolvedExternalId) else item
-
-    /** 服务端全量叠加本地 pending：add 覆盖入表、delete 移除，按 url 定位，收藏时刻倒序。 */
-    private fun applyPending(server: List<FavoriteItem>, pending: List<PendingFavoriteOp>): List<FavoriteItem> {
-        val map = LinkedHashMap<String, FavoriteItem>()
-        server.forEach { map[it.url] = it }
-        pending.forEach { op ->
-            when (op.op) {
-                "add" -> op.item?.let { map[it.url] = it }
-                "delete" -> map.remove(op.url)
-            }
-        }
-        return map.values.sortedByDescending { it.savedAt }
-    }
+    /**
+     * 服务端要求 external_id 非空。列表页 / 解读页给的条目都自带（来自 API），
+     * 缺失的只有 0.22.0 之前存下的存量收藏——一律用 url 顶上即可：
+     * 该字段在收藏这条链路上只做用户内唯一键，从不与 contents join，无需反解真实 id。
+     * 已登录时镜像来自服务端 GET，删除用的是服务端给的值，故存量行也一定删得掉。
+     */
+    private fun withExternalId(item: FavoriteItem): FavoriteItem =
+        if (item.externalId.isBlank()) item.copy(externalId = item.url) else item
 }
 
-/** 全局单例：注入全局 SettingsManager / TrendingApi / 登录态 token。 */
+/** 全局单例：注入全局 SettingsManager / TrendingApi，登录态每次现取。 */
 val globalFavoriteRepository by lazy {
-    FavoriteRepository(
-        settings = globalSettingsManager,
-        api = TrendingApi(),
-        tokenProvider = { globalAuthManager.getAccessToken() },
-    )
+    FavoriteRepository(settings = globalSettingsManager, api = TrendingApi())
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/FavoriteErrorHost.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/FavoriteErrorHost.kt
@@ -1,0 +1,39 @@
+package whl.trending.ai.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.favorites_action_failed
+import whl.trending.ai.data.repository.globalFavoriteRepository
+
+/**
+ * 全局收藏失败提示宿主：已登录时服务端是收藏的唯一真源，收藏/取消打不通接口就会回滚，
+ * 用户必须被告知这次操作没生效（否则只看到星星自己弹回去）。
+ *
+ * 用 Snackbar 而非弹窗：收藏是轻操作，失败也不阻塞任何流程，提示完即走。
+ * 放在 App 根部（与 SignInHintHost 平级），因为收藏入口散落在 Picks / Feed / Trending / 收藏列表四处，
+ * 逐页接 SnackbarHost 只要漏一处那页就静默失败。Box 只做定位，不拦截触摸。
+ */
+@Composable
+fun FavoriteErrorHost() {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val message = stringResource(Res.string.favorites_action_failed)
+
+    LaunchedEffect(Unit) {
+        globalFavoriteRepository.errors.collect {
+            snackbarHostState.showSnackbar(message)
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        SnackbarHost(hostState = snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/favorites/FavoriteListScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/favorites/FavoriteListScreen.kt
@@ -1,6 +1,5 @@
 package whl.trending.ai.ui.favorites
 
-import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.globalFavoriteRepository
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.ui.common.AiSummaryBox
@@ -9,7 +8,6 @@ import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.ai.ui.picks.SourceTag
 import whl.trending.ai.core.platform.trackEvent
 import androidx.compose.runtime.LaunchedEffect
-import kotlinx.coroutines.flow.first
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -68,11 +66,10 @@ fun FavoriteListScreen(
     onNavigateToDetail: (owner: String, repo: String) -> Unit = { _, _ -> },
     onOpenUrl: (url: String) -> Unit = {}
 ) {
-    val favorites by globalSettingsManager.favorites.collectAsState(emptyList())
+    val favorites by globalFavoriteRepository.favorites.collectAsState()
 
     LaunchedEffect(Unit) {
-        val items = globalSettingsManager.favorites.first()
-        trackEvent("favorite_list_view", mapOf("count" to items.size))
+        trackEvent("favorite_list_view", mapOf("count" to globalFavoriteRepository.currentFavorites().size))
     }
 
     TrendingScaffold(
@@ -117,7 +114,7 @@ fun FavoriteListScreen(
                     FavoriteCard(
                         item = item,
                         onClick = { handleFavoriteClick(item, onNavigateToDetail, onOpenUrl) },
-                        onRemove = { globalFavoriteRepository.remove(item.url) }
+                        onRemove = { globalFavoriteRepository.toggle(item) }
                     )
                     if (index < favorites.lastIndex) {
                         HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
@@ -38,7 +38,6 @@ import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.no_data
 import trendingai.shared.generated.resources.retry
 import whl.trending.ai.core.platform.trackItemClick
-import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.globalFavoriteRepository
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.data.model.FeedItem
@@ -131,8 +130,7 @@ fun FeedScreen(
             }
 
             else -> {
-                val favorites by globalSettingsManager.favorites.collectAsState(emptyList())
-                val favoriteUrls = remember(favorites) { favorites.map { it.url }.toSet() }
+                val favoriteUrls by globalFavoriteRepository.favoriteUrls.collectAsState()
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                     itemsIndexed(
                         uiState.items,
@@ -144,22 +142,18 @@ fun FeedScreen(
                             isFavorite = item.url in favoriteUrls,
                             onOpenUrl = onOpenUrl,
                             onToggleFavorite = {
-                                if (item.url in favoriteUrls) {
-                                    globalFavoriteRepository.remove(item.url)
-                                } else {
-                                    globalFavoriteRepository.add(
-                                        FavoriteItem(
-                                            url = item.url,
-                                            title = item.title,
-                                            source = item.source,
-                                            description = item.description,
-                                            summary = item.summary,
-                                            savedAt = Clock.System.now().toEpochMilliseconds(),
-                                            openUrl = item.openUrl,
-                                            externalId = item.externalId
-                                        )
+                                globalFavoriteRepository.toggle(
+                                    FavoriteItem(
+                                        url = item.url,
+                                        title = item.title,
+                                        source = item.source,
+                                        description = item.description,
+                                        summary = item.summary,
+                                        savedAt = Clock.System.now().toEpochMilliseconds(),
+                                        openUrl = item.openUrl,
+                                        externalId = item.externalId
                                     )
-                                }
+                                )
                             }
                         )
                         if (index < uiState.items.lastIndex) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
@@ -129,8 +129,7 @@ fun PicksScreen(
                         Text(text = stringResource(Res.string.picks_no_data))
                     }
                 } else {
-                    val favorites by globalSettingsManager.favorites.collectAsState(emptyList())
-                    val favoriteUrls = remember(favorites) { favorites.map { it.url }.toSet() }
+                    val favoriteUrls by globalFavoriteRepository.favoriteUrls.collectAsState()
                     // 初值同步读，避免已订阅/已关闭用户冷启动时横幅闪现一帧
                     val subscribedEmail by globalSettingsManager.subscribedEmail.collectAsState(
                         remember { globalSettingsManager.currentSubscribedEmail() }
@@ -208,7 +207,7 @@ private fun PicksList(
                 DebutCard(
                     item = item,
                     isFavorite = item.url in favoriteUrls,
-                    onToggleFavorite = { togglePickFavorite(item, favoriteUrls) },
+                    onToggleFavorite = { togglePickFavorite(item) },
                     onClick = { onItemClick(item, "debut") }
                 )
             }
@@ -224,7 +223,7 @@ private fun PicksList(
                 DeepDiveCard(
                     item = item,
                     isFavorite = item.url in favoriteUrls,
-                    onToggleFavorite = { togglePickFavorite(item, favoriteUrls) },
+                    onToggleFavorite = { togglePickFavorite(item) },
                     onClick = { onItemClick(item, "deep_dive") }
                 )
             }
@@ -489,23 +488,19 @@ private fun DebutCard(
     }
 }
 
-private fun togglePickFavorite(item: PickItem, favoriteUrls: Set<String>) {
-    if (item.url in favoriteUrls) {
-        globalFavoriteRepository.remove(item.url)
-    } else {
-        globalFavoriteRepository.add(
-            FavoriteItem(
-                url = item.url,
-                title = item.title,
-                source = item.source,
-                description = item.analysis?.core ?: item.description,
-                summary = item.analysis?.whyImportant ?: item.summary,
-                savedAt = Clock.System.now().toEpochMilliseconds(),
-                openUrl = item.openUrl,
-                externalId = item.externalId
-            )
+private fun togglePickFavorite(item: PickItem) {
+    globalFavoriteRepository.toggle(
+        FavoriteItem(
+            url = item.url,
+            title = item.title,
+            source = item.source,
+            description = item.analysis?.core ?: item.description,
+            summary = item.analysis?.whyImportant ?: item.summary,
+            savedAt = Clock.System.now().toEpochMilliseconds(),
+            openUrl = item.openUrl,
+            externalId = item.externalId
         )
-    }
+    )
 }
 
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
@@ -110,7 +110,6 @@ import whl.trending.ai.core.DateTimeUtils
 import whl.trending.ai.core.platform.shareText
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.core.platform.trackItemClick
-import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.globalFavoriteRepository
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.data.model.TrendingContributor
@@ -283,8 +282,7 @@ private fun RepoList(
             }
 
             else -> {
-                val favorites by globalSettingsManager.favorites.collectAsState(emptyList())
-                val favoriteUrls = remember(favorites) { favorites.map { it.url }.toSet() }
+                val favoriteUrls by globalFavoriteRepository.favoriteUrls.collectAsState()
                 LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
                 items(
                     count = displayRepos.size,
@@ -298,21 +296,17 @@ private fun RepoList(
                         isFavorite = repo.url in favoriteUrls,
                         onStar = onStarRepo?.let { star -> { star(repo) } },
                         onToggleFavorite = {
-                            if (repo.url in favoriteUrls) {
-                                globalFavoriteRepository.remove(repo.url)
-                            } else {
-                                globalFavoriteRepository.add(
-                                    FavoriteItem(
-                                        url = repo.url,
-                                        title = "${repo.author}/${repo.repoName}",
-                                        source = "github",
-                                        description = repo.description.takeIf { it.isNotBlank() },
-                                        summary = repo.aiSummaries.firstOrNull()?.content,
-                                        savedAt = Clock.System.now().toEpochMilliseconds(),
-                                        externalId = "${repo.author}/${repo.repoName}"
-                                    )
+                            globalFavoriteRepository.toggle(
+                                FavoriteItem(
+                                    url = repo.url,
+                                    title = "${repo.author}/${repo.repoName}",
+                                    source = "github",
+                                    description = repo.description.takeIf { it.isNotBlank() },
+                                    summary = repo.aiSummaries.firstOrNull()?.content,
+                                    savedAt = Clock.System.now().toEpochMilliseconds(),
+                                    externalId = "${repo.author}/${repo.repoName}"
                                 )
-                            }
+                            )
                         },
                         onClick = {
                             trackItemClick(

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/repository/FavoriteRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/repository/FavoriteRepositoryTest.kt
@@ -3,17 +3,23 @@ package whl.trending.ai.data.repository
 import com.russhwolf.settings.MapSettings
 import com.russhwolf.settings.ObservableSettings
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import whl.trending.ai.auth.AuthManager
+import whl.trending.ai.auth.AuthState
+import whl.trending.ai.auth.SignInMethod
 import whl.trending.ai.data.local.SettingsManager
 import whl.trending.ai.data.model.FavoriteItem
-import whl.trending.ai.data.model.PendingFavoriteOp
 import whl.trending.ai.data.remote.TrendingApi
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /** 内存版 TrendingApi：记录调用并维护一份「服务端」收藏，键为 source|externalId。 */
@@ -23,6 +29,7 @@ private class FakeApi : TrendingApi() {
     var batchCount = 0
     val puts = mutableListOf<FavoriteItem>()
     val deletes = mutableListOf<Pair<String, String>>()
+    var failWrites = false
     var failNextBatch = false
 
     private fun key(source: String, externalId: String) = "$source|$externalId"
@@ -37,12 +44,14 @@ private class FakeApi : TrendingApi() {
     }
 
     override suspend fun putFavorite(accessToken: String, item: FavoriteItem): Boolean {
+        if (failWrites) return false
         puts += item
         server[key(item.source, item.externalId)] = item
         return true
     }
 
     override suspend fun deleteFavorite(accessToken: String, source: String, externalId: String): Boolean {
+        if (failWrites) return false
         deletes += source to externalId
         server.remove(key(source, externalId))
         return true
@@ -56,12 +65,28 @@ private class FakeApi : TrendingApi() {
     }
 }
 
+/** 可切换登录态的 AuthManager；token 为 null 模拟已登录但取不到 token（离线）。 */
+private class FakeAuth(loggedIn: Boolean, private val token: String? = "tok") : AuthManager {
+    override val isSupported: Boolean = true
+    private val state = MutableStateFlow<AuthState>(if (loggedIn) AuthState.LoggedIn else AuthState.LoggedOut)
+    override val authState: StateFlow<AuthState> = state
+    override fun signIn(source: String) {}
+    override fun signIn(source: String, method: SignInMethod) {}
+    override fun signOut() {}
+    override suspend fun getAccessToken(): String? = token
+}
+
 class FavoriteRepositoryTest {
     private lateinit var settings: SettingsManager
     private lateinit var api: FakeApi
 
-    private fun repo(token: String? = "tok") =
-        FavoriteRepository(settings, api, tokenProvider = { token })
+    private fun TestScope.repo(auth: AuthManager) = FavoriteRepository(
+        settings = settings,
+        api = api,
+        authProvider = { auth },
+        scope = CoroutineScope(StandardTestDispatcher(testScheduler)),
+        track = { _, _ -> },
+    )
 
     private fun gh(name: String, ext: String = name) = FavoriteItem(
         url = "https://github.com/$name",
@@ -78,137 +103,140 @@ class FavoriteRepositoryTest {
     }
 
     @Test
-    fun 首次登录合并_本地全部batch上云并用服务端覆盖本地() = runTest {
-        settings.replaceFavorites(listOf(gh("a/b"), gh("c/d")))
+    fun 未登录_收藏与取消只落本地不打接口() = runTest {
+        val repo = repo(FakeAuth(loggedIn = false))
+
+        repo.toggle(gh("a/b"))
+        advanceUntilIdle()
+        assertEquals(listOf("a/b"), settings.currentLocalFavorites().map { it.externalId })
+        assertEquals(0, api.puts.size)
+
+        repo.toggle(gh("a/b")) // 再点一次 = 取消
+        advanceUntilIdle()
+        assertTrue(settings.currentLocalFavorites().isEmpty())
+        assertEquals(0, api.deletes.size)
+        assertTrue(settings.currentCachedFavorites().isEmpty()) // 未登录不碰镜像
+    }
+
+    @Test
+    fun 登录后sync_匿名收藏一次性导入并清空本地键() = runTest {
+        settings.setLocalFavorites(listOf(gh("a/b"), gh("c/d")))
         api.seedServer(gh("e/f")) // 云端已有的另一条
 
-        repo().sync("tok")
+        repo(FakeAuth(loggedIn = true)).sync()
 
         assertEquals(1, api.batchCount)
-        assertTrue(settings.favoritesMerged())
-        // 本地被服务端全量覆盖：合并后含云端已有 + 本地上推的三条
-        val local = settings.currentFavorites().map { it.externalId }.toSet()
-        assertEquals(setOf("a/b", "c/d", "e/f"), local)
+        assertTrue(settings.currentLocalFavorites().isEmpty()) // 导入成功即清空，不会二次导入
+        assertEquals(setOf("a/b", "c/d", "e/f"), settings.currentCachedFavorites().map { it.externalId }.toSet())
     }
 
     @Test
-    fun 首次合并_存量收藏无externalId时github从url回填() = runTest {
-        // 存量本地收藏：externalId 为空
-        settings.replaceFavorites(listOf(FavoriteItem(url = "https://github.com/foo/bar", title = "foo/bar", source = "github")))
-
-        repo().sync("tok")
-
-        // batch 上推的条目 externalId 已回填为 owner/repo
-        assertEquals("foo/bar", api.server.keys.first().removePrefix("github|"))
-    }
-
-    @Test
-    fun batch失败_不置merged也不覆盖本地() = runTest {
-        settings.replaceFavorites(listOf(gh("a/b")))
+    fun 导入失败_不清本地也不刷新镜像() = runTest {
+        settings.setLocalFavorites(listOf(gh("a/b")))
         api.failNextBatch = true
 
-        repo().sync("tok")
+        repo(FakeAuth(loggedIn = true)).sync()
 
-        assertFalse(settings.favoritesMerged())
-        assertEquals(0, api.getCount) // 未走到 GET
-        assertEquals(listOf("a/b"), settings.currentFavorites().map { it.externalId }) // 本地保留
+        assertEquals(listOf("a/b"), settings.currentLocalFavorites().map { it.externalId }) // 留着下次重来
+        assertEquals(0, api.getCount) // 未走到 GET，避免登录态读到不含这批条目的镜像
     }
 
     @Test
-    fun 已合并_删除跨设备传播_GET覆盖移除本地条目() = runTest {
-        // 已完成首次合并；本地有 X，云端已被别的设备删掉（服务端为空）
-        settings.setFavoritesMerged(true)
-        settings.replaceFavorites(listOf(gh("a/b")))
-        // api.server 为空
-
-        repo().sync("tok")
-
-        assertEquals(0, api.batchCount) // 已合并，不再 batch
-        assertTrue(settings.currentFavorites().isEmpty()) // X 被服务端全量覆盖移除
-    }
-
-    @Test
-    fun 已合并_在途pending的add在GET覆盖时被保留() = runTest {
-        settings.setFavoritesMerged(true)
-        // 服务端空，但本地有一条尚未 flush 成功的 add op
-        settings.setPendingFavoriteOps(
-            listOf(PendingFavoriteOp("add", "https://github.com/x/y", "github", "x/y", gh("x/y")))
+    fun 存量收藏无externalId_导入时用url顶上() = runTest {
+        settings.setLocalFavorites(
+            listOf(FavoriteItem(url = "https://news.ycombinator.com/item?id=1", title = "x", source = "hackernews"))
         )
 
-        repo().sync("tok")
+        repo(FakeAuth(loggedIn = true)).sync()
 
-        // GET 返回空，但 pending add 叠加回来，本地仍含 x/y
-        assertEquals(listOf("x/y"), settings.currentFavorites().map { it.externalId })
+        assertEquals("hackernews|https://news.ycombinator.com/item?id=1", api.server.keys.single())
     }
 
     @Test
-    fun 已合并_flush先推增量op再GET() = runTest {
-        settings.setFavoritesMerged(true)
-        settings.replaceFavorites(listOf(gh("a/b")))
-        settings.setPendingFavoriteOps(
-            listOf(PendingFavoriteOp("add", "https://github.com/a/b", "github", "a/b", gh("a/b")))
-        )
+    fun 已登录_删除跨设备传播_GET刷新镜像移除条目() = runTest {
+        settings.setCachedFavorites(listOf(gh("a/b"))) // 另一台设备已删，服务端为空
 
-        repo().sync("tok")
+        repo(FakeAuth(loggedIn = true)).sync()
 
-        assertEquals(1, api.puts.size) // pending add 被 flush
-        assertTrue(settings.getPendingFavoriteOps().isEmpty()) // flush 成功后出队
+        assertEquals(0, api.batchCount) // 本地键为空，无需导入
+        assertTrue(settings.currentCachedFavorites().isEmpty())
     }
 
     @Test
-    fun 匿名_token为null时sync直接返回不动本地() = runTest {
-        settings.replaceFavorites(listOf(gh("a/b")))
+    fun 已登录_收藏成功_镜像与服务端一致() = runTest {
+        val repo = repo(FakeAuth(loggedIn = true))
 
-        repo(token = null).sync(null)
+        repo.toggle(gh("a/b"))
+        advanceUntilIdle()
 
-        assertFalse(settings.favoritesMerged())
-        assertEquals(0, api.getCount)
-        assertEquals(0, api.batchCount)
-        assertEquals(listOf("a/b"), settings.currentFavorites().map { it.externalId })
+        assertEquals(listOf("a/b"), settings.currentCachedFavorites().map { it.externalId })
+        assertEquals(1, api.puts.size)
+        assertTrue(settings.currentLocalFavorites().isEmpty()) // 登录态绝不写本地键
     }
 
-    // 注：add()/remove() 的手势路径会触发 favorite_toggle 埋点（Aptabase），
-    // 在纯 JVM host-test 中未初始化会 NPE，故不在此单测；其本地写入 + 入队逻辑
-    // 由上面的「在途 pending 保留」「flush 增量」用例间接覆盖（构造同一 PendingFavoriteOp 形态）。
-
-    // 回归：requestSync 必须在仓库自有 scope 上把同步跑到底（拉取并覆盖本地），
-    // 而非绑定调用方（Compose composition）——否则登录后切屏会取消协程、拉取半途中断。
     @Test
-    fun requestSync_在独立scope上跑完整拉取覆盖() = runTest {
-        settings.setFavoritesMerged(true)
-        settings.replaceFavorites(emptyList())
+    fun 已登录_收藏失败_回滚镜像并发出错误() = runTest {
+        api.failWrites = true
+        val repo = repo(FakeAuth(loggedIn = true))
+        val errors = mutableListOf<Unit>()
+        val collector = CoroutineScope(StandardTestDispatcher(testScheduler))
+        collector.launchCollect(repo, errors)
+
+        repo.toggle(gh("a/b"))
+        advanceUntilIdle()
+
+        assertTrue(settings.currentCachedFavorites().isEmpty()) // 乐观写入已回滚
+        assertEquals(1, errors.size)
+        collector.cancel()
+    }
+
+    @Test
+    fun 已登录_取消失败_条目回到镜像() = runTest {
+        settings.setCachedFavorites(listOf(gh("a/b")))
+        api.failWrites = true
+        val repo = repo(FakeAuth(loggedIn = true))
+
+        repo.toggle(gh("a/b"))
+        advanceUntilIdle()
+
+        assertEquals(listOf("a/b"), settings.currentCachedFavorites().map { it.externalId })
+    }
+
+    @Test
+    fun 已登录但取不到token_视为失败不静默丢弃() = runTest {
+        val repo = repo(FakeAuth(loggedIn = true, token = null))
+
+        repo.toggle(gh("a/b"))
+        advanceUntilIdle()
+
+        assertTrue(settings.currentCachedFavorites().isEmpty())
+        assertTrue(settings.currentLocalFavorites().isEmpty()) // 不能偷偷落到本地键：登录态读的是镜像，用户会看不见
+    }
+
+    @Test
+    fun requestSync_在独立scope上跑完拉取() = runTest {
         api.seedServer(gh("a/b"), gh("c/d"))
-        val repo = FavoriteRepository(settings, api, tokenProvider = { "tok" }, scope = CoroutineScope(StandardTestDispatcher(testScheduler)))
+        val repo = repo(FakeAuth(loggedIn = true))
 
         repo.requestSync()
         advanceUntilIdle()
 
-        assertEquals(setOf("a/b", "c/d"), settings.currentFavorites().map { it.externalId }.toSet())
+        assertEquals(setOf("a/b", "c/d"), settings.currentCachedFavorites().map { it.externalId }.toSet())
     }
 
     @Test
-    fun requestSync_token为null时不动本地() = runTest {
-        settings.setFavoritesMerged(true)
-        settings.replaceFavorites(listOf(gh("x/y")))
-        val repo = FavoriteRepository(settings, api, tokenProvider = { null }, scope = CoroutineScope(StandardTestDispatcher(testScheduler)))
+    fun onSignOut_只清镜像不动匿名那份() = runTest {
+        settings.setCachedFavorites(listOf(gh("a/b")))
+        settings.setLocalFavorites(listOf(gh("x/y"))) // 尚未导入成功的匿名收藏
 
-        repo.requestSync()
-        advanceUntilIdle()
+        repo(FakeAuth(loggedIn = true)).onSignOut()
 
-        assertEquals(0, api.getCount)
-        assertEquals(listOf("x/y"), settings.currentFavorites().map { it.externalId })
+        assertTrue(settings.currentCachedFavorites().isEmpty())
+        assertEquals(listOf("x/y"), settings.currentLocalFavorites().map { it.externalId })
     }
+}
 
-    @Test
-    fun onSignOut_清空收藏与同步状态() = runTest {
-        settings.setFavoritesMerged(true)
-        settings.replaceFavorites(listOf(gh("a/b")))
-        settings.setPendingFavoriteOps(listOf(PendingFavoriteOp("delete", "u", "github", "a/b", null)))
-
-        repo().onSignOut()
-
-        assertTrue(settings.currentFavorites().isEmpty())
-        assertTrue(settings.getPendingFavoriteOps().isEmpty())
-        assertFalse(settings.favoritesMerged())
-    }
+/** 收集 errors 的小工具：避免在测试体里写一堆 launch/collect 噪音。 */
+private fun CoroutineScope.launchCollect(repo: FavoriteRepository, sink: MutableList<Unit>) {
+    launch { repo.errors.collect { sink += it } }
 }


### PR DESCRIPTION
## 背景

收藏原本是「本地优先 + 云端合并」的双真源：每次收藏/取消先落本地，再入队一条 pending op 后台 flush，打开时全量 GET 覆盖并把在途 op 叠回去。

数据只有几十条，却背着一整套增量同步协议的复杂度——pending 队列的入队/去重/flush/叠加、`merged` 标记、mutex 保护 prefs 的跨线程读改写，以及「flush 必须先于 GET」这类顺序约束。复杂度的根源是**双向**：本地是真源，云端也是真源，于是每次同步都要判断谁赢。

## 改成什么

接受「离线不支持收藏同步」这一功能裁剪后，反方向可以整个去掉：

| 状态 | 真源 | 写路径 |
|---|---|---|
| 未登录 | `prefs_favorites` | 纯本地、离线可用（与云同步上线前一致） |
| 登录那一刻 | — | batch 一次性上云 → 成功即清空本地键 |
| 已登录 | 服务端 | 乐观改镜像 `prefs_favorites_cache` → 打接口 → 失败原样回滚 + 提示 |

「local 非空」本身就是「还欠一次导入」的信号，导入失败不清空、下次 `sync()` 原样重来即可（batch 幂等），所以不需要任何状态位记账。

## 删掉的东西

- `PendingFavoriteOp` 模型 + `pushOp / enqueueLocked / flushPending / applyPending`
- `favoritesMerged` 标记及其「登出要清、换账号要清」的错配风险
- `FavoriteItem.resolvedExternalId` 的 github 反解与 `url:` 合成键（含 780f484 修过的那类穿透）。已登录时镜像来自服务端 GET、带着服务端的 `external_id`，删除用它必然删得掉；新增时各页面都自带 `externalId`，缺失的存量条目用 url 顶上即可。
- 「GET 覆盖前必须先 flush」的顺序约束——单向了，无所谓顺序

## 顺带清理

- 收藏埋点从 `SettingsManager` 移进 `FavoriteRepository`，存储层退回纯读写
- 三个列表页不再各自解析整份 JSON，统一读 `FavoriteRepository.favoriteUrls`
- 新增根部 `FavoriteErrorHost` 统一提示失败，四个收藏入口一并覆盖
- 一次性存储迁移：老 `favoritesMerged==true` 的那份直接搬进镜像键，避免升级后被当作待导入、把另一台设备已删的条目复活

## 影响面

**服务端与 D1 零改动** —— 现有 `GET / PUT / DELETE / batch` 四个端点语义正好对上，不需要新端点、不涉及部署顺序、不需要迁移。iOS 无登录态，恒走本地分支，行为不变。

## 验证

Pixel_9_2 模拟器逐条截图核对：

- 匿名收藏 → 只写 `prefs_favorites`，菜单切到 Unfavorite，收藏列表页正常
- GitHub 登录 → `prefs_favorites` 键消失，镜像含匿名期条目 + 云端已有 3 条
- 登录态收藏 → 杀进程重启走 GET 回来仍在，确认真上云
- 断网取消收藏 → 条目回滚 + Snackbar 弹出
- 登出 → 只清镜像，匿名那份不动

单测 11 例全绿（`FavoriteRepositoryTest`），Android + iOS 目标均编译通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mePww45oi3wbfCWGHJHAF

## Summary by Sourcery

将收藏功能重构为单一来源、单向同步的模型，明确区分本地存储与缓存存储，并采用乐观的服务器更新方式，移除待执行队列和合并状态。

New Features:
- 引入集中式的 `FavoriteRepository` API，在整个应用中暴露收藏项和收藏 URL 的数据流。
- 添加全局 `FavoriteErrorHost`，通过 Snackbar 展示收藏同步失败。
- 支持将匿名收藏批量导入到已登录账号，同时在用户登出时保留仅离线可用的收藏。

Bug Fixes:
- 当服务器写入或令牌获取失败时，通过回滚更改并显示错误，防止收藏操作静默失败。
- 通过将本地匿名收藏与按账号缓存的收藏分离，避免不同账号之间的收藏相互污染。
- 确保 `FavoriteRepository` 始终使用当前的 `AuthManager` 实例，以正确反映登录状态变化。

Enhancements:
- 通过移除双向合并协议、待执行操作队列和合并标记，简化收藏同步流程。
- 将收藏相关的埋点从 `SettingsManager` 移入 `FavoriteRepository`，让存储层保持为纯持久化层。
- 统一收藏的 JSON 解析逻辑，使列表页面消费 `FavoriteRepository.favoriteUrls`，而不是重新读取原始设置。
- 使 `externalId` 处理显式化，移除基于 URL 的反向解析，并使用 URL 作为旧条目的后备键。
- 添加一次性迁移，将之前已合并的收藏迁移到缓存键中，并清理废弃的同步键。

Tests:
- 扩展 `FavoriteRepository` 的测试范围，覆盖新的单向同步、错误处理、鉴权交互以及迁移逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor favorites to a single-source, one-way sync model with explicit local vs cached storage and optimistic server updates, removing the pending-op queue and merge state.

New Features:
- Introduce a centralized FavoriteRepository API that exposes flows for favorites and favorite URLs across the app.
- Add global FavoriteErrorHost to surface favorite sync failures via a Snackbar.
- Support batch import of anonymous favorites into the logged-in account while keeping offline-only favorites for signed-out users.

Bug Fixes:
- Prevent favorites from silently failing when server writes or token retrieval fail by rolling back changes and showing an error.
- Avoid favorites cross-contamination between accounts by separating local anonymous favorites from per-account cached favorites.
- Ensure FavoriteRepository always uses the current AuthManager instance so login state changes are reflected correctly.

Enhancements:
- Simplify favorites sync by removing the bidirectional merge protocol, pending operation queue, and merged flags.
- Move favorite tracking instrumentation from SettingsManager into FavoriteRepository, keeping storage as a pure persistence layer.
- Unify favorites JSON parsing so list pages consume FavoriteRepository.favoriteUrls instead of re-reading raw settings.
- Make externalId handling explicit by dropping URL-based reverse resolution and using URL as a fallback key for legacy entries.
- Add a one-off migration that moves previously merged favorites into the cache key and cleans obsolete sync keys.

Tests:
- Expand FavoriteRepository tests to cover the new one-way sync, error handling, auth interaction, and migration logic.

</details>