### PR TITLE
feat(digest): HN 解读页——三入口统一落点 + 预生成解读展示

### DIFF
--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -282,4 +282,10 @@
     <string name="feed_rules_vs_official_title">与 GitHub 官方动态的区别</string>
     <string name="feed_rules_vs_official_desc">GitHub 无官方动态接口，本页基于其公开 received_events 接口聚合。</string>
     <string name="feed_rules_limits">最近 30 天、最多 300 条，有 30 秒~6 小时延迟（GitHub 接口限制）。</string>
+    <string name="digest_read_original">阅读原文</string>
+    <string name="digest_hn_discussion">HN 讨论区</string>
+    <string name="digest_unavailable_title">该条目暂无 AI 解读</string>
+    <string name="digest_unavailable_desc">这条内容的公开信息还不足以生成可靠的解读。你可以通过上方按钮阅读原文或查看 HN 讨论。</string>
+    <string name="digest_generated_at">AI 生成于 %1$s · 内容可能滞后于最新讨论</string>
+    <string name="digest_load_failed">加载失败，请重试</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -282,4 +282,10 @@
     <string name="feed_rules_vs_official_title">vs. GitHub feed</string>
     <string name="feed_rules_vs_official_desc">GitHub has no official feed API; this page is aggregated from its public received_events endpoint.</string>
     <string name="feed_rules_limits">Last 30 days, up to 300 events, with a 30s–6h delay (GitHub API limits).</string>
+    <string name="digest_read_original">Read original</string>
+    <string name="digest_hn_discussion">HN discussion</string>
+    <string name="digest_unavailable_title">No AI digest for this item yet</string>
+    <string name="digest_unavailable_desc">Public information wasn\'t enough to generate a reliable digest. Use the buttons above to read the original or browse the HN discussion.</string>
+    <string name="digest_generated_at">AI-generated on %1$s · may lag behind the latest discussion</string>
+    <string name="digest_load_failed">Failed to load, please retry</string>
 </resources>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
@@ -13,6 +13,8 @@ import whl.trending.ai.ui.settings.AboutScreen
 import whl.trending.ai.ui.settings.AppSettingsScreen
 import whl.trending.ai.ui.settings.AppearanceScreen
 import whl.trending.ai.ui.settings.ColorLabScreen
+import whl.trending.ai.ui.digest.DigestPage
+import whl.trending.ai.ui.digest.DigestScreen
 import whl.trending.ai.ui.subscribe.SubscribeScreen
 import whl.trending.ai.ui.theme.TrendingTheme
 import whl.trending.ai.ui.webview.WebViewScreen
@@ -150,6 +152,9 @@ fun App() {
                                 onNavigateToSubscribe = {
                                     backStack.add(Subscribe)
                                 },
+                                onOpenDigest = { page ->
+                                    backStack.add(page)
+                                },
                             )
                         }
 
@@ -215,6 +220,9 @@ fun App() {
                                 },
                                 onOpenUrl = { url ->
                                     openExternalUrl(url, "")
+                                },
+                                onOpenDigest = { page ->
+                                    backStack.add(page)
                                 }
                             )
                         }
@@ -278,6 +286,16 @@ fun App() {
                                 onBack = { backStack.safePop() },
                                 onNavigateToChat = { context ->
                                     backStack.add(Chat(context))
+                                }
+                            )
+                        }
+
+                        is DigestPage -> NavEntry(key) {
+                            DigestScreen(
+                                page = key,
+                                onBack = { backStack.safePop() },
+                                onOpenUrl = { url ->
+                                    openExternalUrl(url, "")
                                 }
                             )
                         }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/DigestResponse.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/DigestResponse.kt
@@ -1,0 +1,19 @@
+package whl.trending.ai.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * GET /api/digest 响应。
+ * 命中：{success:true, markdown, created_at}；
+ * 未命中统一 404 {success:false, code:"digest_unavailable"}——服务端刻意不透出
+ * insufficient/refused 等细分原因，客户端也只需三态 UI，不要依赖 code 做进一步分支。
+ */
+@Serializable
+data class DigestResponse(
+    val success: Boolean = false,
+    val markdown: String? = null,
+    @SerialName("created_at")
+    val createdAt: String? = null,
+    val code: String? = null,
+)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -6,6 +6,7 @@ import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.data.model.FavoritesResponse
 import whl.trending.ai.data.model.FeedResponse
 import whl.trending.ai.data.model.ChatModelsResponse
+import whl.trending.ai.data.model.DigestResponse
 import whl.trending.ai.data.model.MeResponse
 import whl.trending.ai.data.model.ProRefreshResponse
 import whl.trending.ai.data.model.PicksResponse
@@ -91,6 +92,19 @@ open class TrendingApi {
             parameter("summary_lang", summaryLang)
         }
         return response.body<PicksResponse>()
+    }
+
+    /**
+     * 预生成解读（本期仅 hackernews）。未命中返回 404，但响应体仍是合法 JSON
+     * （success=false, code=digest_unavailable）——client 未开 expectSuccess，直接解析 body。
+     */
+    open suspend fun fetchDigest(source: String, externalId: String, lang: String): DigestResponse {
+        val response = client.get("$baseHost/api/digest") {
+            parameter("source", source)
+            parameter("external_id", externalId)
+            parameter("lang", lang)
+        }
+        return response.body<DigestResponse>()
     }
 
     open suspend fun fetchReadme(owner: String, repo: String): ReadmeResponse {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestMarkdown.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestMarkdown.kt
@@ -1,0 +1,156 @@
+package whl.trending.ai.ui.digest
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * digest 正文的受控子集 markdown 渲染。
+ *
+ * 不引第三方渲染库的依据：解读由我们自己的 prompt 生成，结构受控——
+ * 只有 ### 三级标题、段落、无序列表和粗体、斜体两种行内标记
+ * （引用评论用斜体，见后端 digest/prompt.js 的硬约束）。
+ * 子集之外的语法按纯文本降级展示，不报错不吞内容。
+ * chat 模块的 MarkdownText 基于 commonmark（Java 库），进不了 commonMain，不能复用。
+ */
+
+private sealed interface Block {
+    data class Heading(val text: String) : Block
+    data class Paragraph(val text: String) : Block
+    data class Bullets(val items: List<String>) : Block
+}
+
+private fun parseBlocks(markdown: String): List<Block> {
+    val blocks = mutableListOf<Block>()
+    val paragraph = StringBuilder()
+    val bullets = mutableListOf<String>()
+
+    fun flushParagraph() {
+        if (paragraph.isNotBlank()) blocks.add(Block.Paragraph(paragraph.toString().trim()))
+        paragraph.clear()
+    }
+
+    fun flushBullets() {
+        if (bullets.isNotEmpty()) blocks.add(Block.Bullets(bullets.toList()))
+        bullets.clear()
+    }
+
+    for (line in markdown.lines()) {
+        val trimmed = line.trim()
+        when {
+            trimmed.isEmpty() -> {
+                flushParagraph(); flushBullets()
+            }
+            trimmed.startsWith("#") -> {
+                flushParagraph(); flushBullets()
+                blocks.add(Block.Heading(trimmed.trimStart('#').trim()))
+            }
+            trimmed.startsWith("- ") || trimmed.startsWith("* ") -> {
+                flushParagraph()
+                bullets.add(trimmed.substring(2).trim())
+            }
+            else -> {
+                if (bullets.isNotEmpty()) {
+                    // 列表项换行续行：并入上一项
+                    bullets[bullets.lastIndex] = bullets.last() + " " + trimmed
+                } else {
+                    if (paragraph.isNotEmpty()) paragraph.append(' ')
+                    paragraph.append(trimmed)
+                }
+            }
+        }
+    }
+    flushParagraph(); flushBullets()
+    return blocks
+}
+
+/** 行内 **粗体** / *斜体*；未闭合的标记按字面输出 */
+internal fun parseInline(text: String): AnnotatedString = buildAnnotatedString {
+    var i = 0
+    while (i < text.length) {
+        when {
+            text.startsWith("**", i) -> {
+                val end = text.indexOf("**", i + 2)
+                if (end > i + 1) {
+                    withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
+                        append(text.substring(i + 2, end))
+                    }
+                    i = end + 2
+                } else {
+                    append(text[i]); i++
+                }
+            }
+            text[i] == '*' -> {
+                val end = text.indexOf('*', i + 1)
+                if (end > i) {
+                    withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
+                        append(text.substring(i + 1, end))
+                    }
+                    i = end + 1
+                } else {
+                    append(text[i]); i++
+                }
+            }
+            else -> {
+                append(text[i]); i++
+            }
+        }
+    }
+}
+
+@Composable
+fun DigestMarkdown(markdown: String, modifier: Modifier = Modifier) {
+    val blocks = remember(markdown) { parseBlocks(markdown) }
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        blocks.forEach { block ->
+            when (block) {
+                is Block.Heading -> Text(
+                    text = parseInline(block.text),
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(top = 10.dp)
+                )
+                is Block.Paragraph -> Text(
+                    text = parseInline(block.text),
+                    fontSize = 14.sp,
+                    lineHeight = 24.sp,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                is Block.Bullets -> Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
+                    block.items.forEach { item ->
+                        Row {
+                            Text(
+                                text = "•",
+                                fontSize = 14.sp,
+                                lineHeight = 24.sp,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(end = 8.dp)
+                            )
+                            Text(
+                                text = parseInline(item),
+                                fontSize = 14.sp,
+                                lineHeight = 24.sp,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestMarkdown.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestMarkdown.kt
@@ -28,13 +28,17 @@ import androidx.compose.ui.unit.sp
  * chat 模块的 MarkdownText 基于 commonmark（Java 库），进不了 commonMain，不能复用。
  */
 
-private sealed interface Block {
+internal sealed interface Block {
     data class Heading(val text: String) : Block
     data class Paragraph(val text: String) : Block
     data class Bullets(val items: List<String>) : Block
 }
 
-private fun parseBlocks(markdown: String): List<Block> {
+// ATX 标题要求「井号 + 空格」：不带空格的 "#1 ranked"、"#ai" 是正文不是标题。
+// 级别刻意不限（模型偶发 ##/# 时按标题渲染，优于把井号字面量端给用户）
+private val HEADING_REGEX = Regex("""^#{1,6}\s+(.+)""")
+
+internal fun parseBlocks(markdown: String): List<Block> {
     val blocks = mutableListOf<Block>()
     val paragraph = StringBuilder()
     val bullets = mutableListOf<String>()
@@ -51,13 +55,14 @@ private fun parseBlocks(markdown: String): List<Block> {
 
     for (line in markdown.lines()) {
         val trimmed = line.trim()
+        val heading = HEADING_REGEX.matchEntire(trimmed)
         when {
             trimmed.isEmpty() -> {
                 flushParagraph(); flushBullets()
             }
-            trimmed.startsWith("#") -> {
+            heading != null -> {
                 flushParagraph(); flushBullets()
-                blocks.add(Block.Heading(trimmed.trimStart('#').trim()))
+                blocks.add(Block.Heading(heading.groupValues[1].trim()))
             }
             trimmed.startsWith("- ") || trimmed.startsWith("* ") -> {
                 flushParagraph()

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestPage.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestPage.kt
@@ -1,0 +1,70 @@
+package whl.trending.ai.ui.digest
+
+import whl.trending.ai.data.model.FavoriteItem
+import whl.trending.ai.data.model.FeedItem
+import whl.trending.ai.data.model.PickItem
+
+/**
+ * HN 解读页路由参数（Nav3 backStack key）。
+ *
+ * 列表已有的数据全部带进来：头部（标题/热度）即时渲染不等网络；
+ * 收藏落库沿用与列表完全相同的字段（url 主键 + source/externalId 云同步键），
+ * 保证解读页收藏与列表收藏是同一条记录。
+ */
+data class DigestPage(
+    val source: String,
+    val externalId: String,
+    val title: String,
+    /** 原文链接（自建帖时与 [hnUrl] 相同） */
+    val url: String,
+    /** HN 讨论区链接 */
+    val hnUrl: String,
+    val score: Int = 0,
+    val commentCount: Int = 0,
+    val description: String? = null,
+    val summary: String? = null,
+) {
+    /** 自建帖（Ask HN / 纯讨论）：原文即讨论页，出路只显示一个按钮 */
+    val isSelfPost: Boolean
+        get() = url.isBlank() || url == hnUrl || url.contains("news.ycombinator.com")
+}
+
+fun hnDiscussionUrl(externalId: String): String =
+    "https://news.ycombinator.com/item?id=$externalId"
+
+fun FeedItem.toDigestPage(): DigestPage = DigestPage(
+    source = source,
+    externalId = externalId,
+    title = title,
+    url = url,
+    hnUrl = extra?.hnUrl?.takeIf { it.isNotBlank() } ?: hnDiscussionUrl(externalId),
+    score = score,
+    commentCount = commentCount,
+    description = description,
+    summary = summary,
+)
+
+fun PickItem.toDigestPage(): DigestPage = DigestPage(
+    source = source,
+    externalId = externalId,
+    title = title,
+    url = url,
+    hnUrl = hnDiscussionUrl(externalId),
+    score = score,
+    description = description,
+    summary = summary,
+)
+
+/**
+ * 存量收藏的 externalId 可能是空串或 `url:<url>` 合成键（见 [FavoriteItem.resolvedExternalId]）——
+ * 此时解读接口查不到（进「暂无解读」态），讨论区链接回退到收藏时记录的打开地址。
+ */
+fun FavoriteItem.toDigestPage(): DigestPage = DigestPage(
+    source = source,
+    externalId = resolvedExternalId,
+    title = title,
+    url = url,
+    hnUrl = externalId.takeIf { it.isNotBlank() }?.let { hnDiscussionUrl(it) } ?: targetUrl,
+    description = description,
+    summary = summary,
+)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestPage.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestPage.kt
@@ -56,15 +56,18 @@ fun PickItem.toDigestPage(): DigestPage = DigestPage(
 )
 
 /**
- * 存量收藏的 externalId 可能是空串或 `url:<url>` 合成键（见 [FavoriteItem.resolvedExternalId]）——
- * 此时解读接口查不到（进「暂无解读」态），讨论区链接回退到收藏时记录的打开地址。
+ * 存量收藏的 externalId 可能是空串或 `url:<url>` 合成键（见 [FavoriteItem.resolvedExternalId]），
+ * 且合成键会经云同步持久化——换设备拉取后本地 externalId 就是非空的合成值。
+ * 故讨论区链接只认**纯数字** id（HN story id 恒为数字），否则回退收藏时记录的打开地址；
+ * 解读接口查不到合成键会进「暂无解读」态，页面仍有可用出路。
  */
 fun FavoriteItem.toDigestPage(): DigestPage = DigestPage(
     source = source,
     externalId = resolvedExternalId,
     title = title,
     url = url,
-    hnUrl = externalId.takeIf { it.isNotBlank() }?.let { hnDiscussionUrl(it) } ?: targetUrl,
+    hnUrl = resolvedExternalId.takeIf { id -> id.isNotEmpty() && id.all(Char::isDigit) }
+        ?.let { hnDiscussionUrl(it) } ?: targetUrl,
     description = description,
     summary = summary,
 )

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestScreen.kt
@@ -1,0 +1,303 @@
+package whl.trending.ai.ui.digest
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.Forum
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlin.time.Clock
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.action_favorite
+import trendingai.shared.generated.resources.back
+import trendingai.shared.generated.resources.digest_generated_at
+import trendingai.shared.generated.resources.digest_hn_discussion
+import trendingai.shared.generated.resources.digest_load_failed
+import trendingai.shared.generated.resources.digest_read_original
+import trendingai.shared.generated.resources.digest_unavailable_desc
+import trendingai.shared.generated.resources.digest_unavailable_title
+import trendingai.shared.generated.resources.retry
+import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.model.FavoriteItem
+import whl.trending.ai.data.repository.globalFavoriteRepository
+import whl.trending.ai.ui.common.TrendingScaffold
+import whl.trending.ai.ui.common.TrendingTopAppBar
+
+private val HnOrange = Color(0xFFFF6600)
+
+/**
+ * HN 条目解读页：预生成 AI 解读的统一落点（Feed 列表 / Picks 深读 / 收藏三入口同此）。
+ *
+ * 设计要点（见父目录 hn-digest-实现方案.md §9 + 已确认 UI 草稿）：
+ * - 头部与出路按钮（阅读原文 / HN 讨论区）永远在首屏，任何状态下可用——解读是入口不是替代
+ * - 「暂无解读」是明确的占位态，不是空白页；无触发生成的语义，Error 只重试读取
+ * - 收藏与列表收藏同一条记录：url 主键 + (source, externalId) 云同步键
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DigestScreen(
+    page: DigestPage,
+    onBack: () -> Unit,
+    onOpenUrl: (url: String) -> Unit,
+    viewModel: DigestViewModel = viewModel(key = "${page.source}/${page.externalId}") {
+        DigestViewModel(page)
+    },
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        trackEvent("digest_open", mapOf("source" to page.source))
+    }
+
+    val favorites by globalSettingsManager.favorites.collectAsState(emptyList())
+    val isFavorite = remember(favorites) { favorites.any { it.url == page.url } }
+
+    TrendingScaffold(
+        topBar = {
+            TrendingTopAppBar(
+                title = {},
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(Res.string.back)
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = {
+                        if (isFavorite) {
+                            globalFavoriteRepository.remove(page.url)
+                        } else {
+                            globalFavoriteRepository.add(
+                                FavoriteItem(
+                                    url = page.url,
+                                    title = page.title,
+                                    source = page.source,
+                                    description = page.description,
+                                    summary = page.summary,
+                                    savedAt = Clock.System.now().toEpochMilliseconds(),
+                                    openUrl = page.hnUrl,
+                                    externalId = page.externalId
+                                )
+                            )
+                        }
+                    }) {
+                        Icon(
+                            if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                            contentDescription = stringResource(Res.string.action_favorite),
+                            tint = if (isFavorite) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp)
+        ) {
+            DigestHeader(page = page, onOpenUrl = onOpenUrl)
+            HorizontalDivider(modifier = Modifier.padding(top = 18.dp, bottom = 4.dp))
+            DigestBody(page = page, uiState = uiState, onRetry = viewModel::retry)
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun DigestHeader(page: DigestPage, onOpenUrl: (url: String) -> Unit) {
+    Text(
+        text = page.title,
+        fontSize = 19.sp,
+        fontWeight = FontWeight.SemiBold,
+        lineHeight = 26.sp,
+        color = MaterialTheme.colorScheme.onSurface
+    )
+    Row(
+        modifier = Modifier.padding(top = 10.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .background(HnOrange, RoundedCornerShape(4.dp))
+                .padding(horizontal = 6.dp, vertical = 2.dp)
+        ) {
+            Text(
+                text = "HN",
+                fontSize = 10.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.White
+            )
+        }
+        val meta = buildString {
+            if (page.score > 0) append("▲ ${page.score}")
+            if (page.commentCount > 0) {
+                if (isNotEmpty()) append(" · ")
+                append("💬 ${page.commentCount}")
+            }
+        }
+        if (meta.isNotEmpty()) {
+            Text(
+                text = meta,
+                fontSize = 12.5.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+    // 出路按钮：首屏常驻、正文之前——解读是入口不是替代
+    Row(
+        modifier = Modifier.padding(top = 14.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        if (!page.isSelfPost) {
+            FilledTonalButton(onClick = {
+                trackEvent("digest_read_original_click", mapOf("source" to page.source))
+                onOpenUrl(page.url)
+            }) {
+                Icon(
+                    Icons.Outlined.Description,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(modifier = Modifier.size(6.dp))
+                Text(stringResource(Res.string.digest_read_original))
+            }
+        }
+        FilledTonalButton(onClick = {
+            trackEvent("digest_hn_comments_click", mapOf("source" to page.source))
+            onOpenUrl(page.hnUrl)
+        }) {
+            Icon(
+                Icons.Outlined.Forum,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp)
+            )
+            Spacer(modifier = Modifier.size(6.dp))
+            Text(stringResource(Res.string.digest_hn_discussion))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun DigestBody(page: DigestPage, uiState: DigestUiState, onRetry: () -> Unit) {
+    when (uiState) {
+        is DigestUiState.Loading -> Box(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 48.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            LoadingIndicator()
+        }
+
+        is DigestUiState.Ready -> {
+            DigestMarkdown(
+                markdown = uiState.markdown,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+            uiState.createdAt?.takeIf { it.length >= 10 }?.let { createdAt ->
+                HorizontalDivider(modifier = Modifier.padding(top = 22.dp, bottom = 12.dp))
+                Text(
+                    text = stringResource(Res.string.digest_generated_at, createdAt.take(10)),
+                    fontSize = 11.5.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+
+        is DigestUiState.Unavailable -> PlaceholderCard(
+            title = stringResource(Res.string.digest_unavailable_title),
+            desc = stringResource(Res.string.digest_unavailable_desc),
+        )
+
+        is DigestUiState.Error -> PlaceholderCard(
+            title = stringResource(Res.string.digest_load_failed),
+            desc = null,
+        ) {
+            Button(onClick = onRetry) {
+                Text(stringResource(Res.string.retry))
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlaceholderCard(
+    title: String,
+    desc: String?,
+    action: (@Composable () -> Unit)? = null,
+) {
+    OutlinedCard(modifier = Modifier.fillMaxWidth().padding(top = 24.dp)) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 36.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Text(text = "📄", fontSize = 30.sp)
+            Text(
+                text = title,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center
+            )
+            if (desc != null) {
+                Text(
+                    text = desc,
+                    fontSize = 13.sp,
+                    lineHeight = 20.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
+            }
+            action?.invoke()
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestViewModel.kt
@@ -1,0 +1,60 @@
+package whl.trending.ai.ui.digest
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.remote.TrendingApi
+
+sealed interface DigestUiState {
+    data object Loading : DigestUiState
+    data class Ready(val markdown: String, val createdAt: String?) : DigestUiState
+
+    /** 服务端明确无解读（insufficient/refused/老条目/未覆盖，统一不区分）；无重试语义 */
+    data object Unavailable : DigestUiState
+
+    /** 网络失败；可重试（只重试读取，不存在触发生成） */
+    data object Error : DigestUiState
+}
+
+class DigestViewModel(
+    private val page: DigestPage,
+    private val api: TrendingApi = TrendingApi(),
+    private val settingsManager: SettingsManager = globalSettingsManager,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow<DigestUiState>(DigestUiState.Loading)
+    val uiState: StateFlow<DigestUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun retry() {
+        _uiState.value = DigestUiState.Loading
+        load()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            try {
+                // 语言跟「摘要语言」（summary_lang 口径），与列表内容语言一致；
+                // 不要用 AI 请求的界面语言口径，否则列表摘要和解读页会出现两种语言
+                val lang = settingsManager.currentContentLang()
+                val response = api.fetchDigest(page.source, page.externalId, lang)
+                _uiState.value = if (response.success && !response.markdown.isNullOrBlank()) {
+                    DigestUiState.Ready(response.markdown, response.createdAt)
+                } else {
+                    trackEvent("digest_unavailable_shown", mapOf("source" to page.source))
+                    DigestUiState.Unavailable
+                }
+            } catch (e: Exception) {
+                _uiState.value = DigestUiState.Error
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.SettingsManager
@@ -32,6 +33,17 @@ class DigestViewModel(
 
     init {
         load()
+
+        // 摘要语言切换后重载（对齐 FeedViewModel 的既有模式）。
+        // 必须有这层监听：viewModel(key) 的实例生命周期长于页面（返回不销毁），
+        // init 里的语言只是创建时刻的快照——没有它，切语言后重进「访问过的条目」
+        // 会端出旧语言的缓存内容。drop(1) 丢弃初始值，只响应真正的修改。
+        viewModelScope.launch {
+            settingsManager.summaryLanguage.drop(1).collect {
+                _uiState.value = DigestUiState.Loading
+                load()
+            }
+        }
     }
 
     fun retry() {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/favorites/FavoriteListScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/favorites/FavoriteListScreen.kt
@@ -7,6 +7,8 @@ import whl.trending.ai.ui.common.AiSummaryBox
 import whl.trending.ai.ui.common.TrendingScaffold
 import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.ai.ui.picks.SourceTag
+import whl.trending.ai.ui.digest.DigestPage
+import whl.trending.ai.ui.digest.toDigestPage
 import whl.trending.ai.core.platform.trackEvent
 import androidx.compose.runtime.LaunchedEffect
 import kotlinx.coroutines.flow.first
@@ -66,7 +68,8 @@ import trendingai.shared.generated.resources.favorites_removed
 fun FavoriteListScreen(
     onBack: () -> Unit,
     onNavigateToDetail: (owner: String, repo: String) -> Unit = { _, _ -> },
-    onOpenUrl: (url: String) -> Unit = {}
+    onOpenUrl: (url: String) -> Unit = {},
+    onOpenDigest: (DigestPage) -> Unit = {}
 ) {
     val favorites by globalSettingsManager.favorites.collectAsState(emptyList())
 
@@ -116,7 +119,7 @@ fun FavoriteListScreen(
                 ) { index, item ->
                     FavoriteCard(
                         item = item,
-                        onClick = { handleFavoriteClick(item, onNavigateToDetail, onOpenUrl) },
+                        onClick = { handleFavoriteClick(item, onNavigateToDetail, onOpenUrl, onOpenDigest) },
                         onRemove = { globalFavoriteRepository.remove(item.url) }
                     )
                     if (index < favorites.lastIndex) {
@@ -131,7 +134,8 @@ fun FavoriteListScreen(
 private fun handleFavoriteClick(
     item: FavoriteItem,
     onNavigateToDetail: (owner: String, repo: String) -> Unit,
-    onOpenUrl: (url: String) -> Unit
+    onOpenUrl: (url: String) -> Unit,
+    onOpenDigest: (DigestPage) -> Unit
 ) {
     if (item.source == "github") {
         val parts = item.url.removePrefix("https://github.com/").split("/")
@@ -139,6 +143,11 @@ private fun handleFavoriteClick(
             onNavigateToDetail(parts[0], parts[1])
             return
         }
+    }
+    // HN 条目进解读页（与列表同一落点）；存量收藏无 externalId 时解读页会展示「暂无解读」+ 原文入口
+    if (item.source == "hackernews") {
+        onOpenDigest(item.toDigestPage())
+        return
     }
     onOpenUrl(item.targetUrl)
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
@@ -47,6 +47,8 @@ import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.ui.common.AiSummaryBox
 import whl.trending.ai.ui.common.ItemActionMenu
 import whl.trending.ai.ui.common.aiShareText
+import whl.trending.ai.ui.digest.DigestPage
+import whl.trending.ai.ui.digest.toDigestPage
 import androidx.compose.runtime.remember
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -80,7 +82,8 @@ private const val HERO_MAX_RATIO = 3f
 fun FeedScreen(
     modifier: Modifier = Modifier,
     viewModel: FeedViewModel,
-    onOpenUrl: (url: String) -> Unit
+    onOpenUrl: (url: String) -> Unit,
+    onOpenDigest: (DigestPage) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val pullToRefreshState = rememberPullToRefreshState()
@@ -143,6 +146,7 @@ fun FeedScreen(
                             item = item,
                             isFavorite = item.url in favoriteUrls,
                             onOpenUrl = onOpenUrl,
+                            onOpenDigest = onOpenDigest,
                             onToggleFavorite = {
                                 if (item.url in favoriteUrls) {
                                     globalFavoriteRepository.remove(item.url)
@@ -178,6 +182,7 @@ private fun FeedItemCard(
     item: FeedItem,
     isFavorite: Boolean,
     onOpenUrl: (url: String) -> Unit,
+    onOpenDigest: (DigestPage) -> Unit,
     onToggleFavorite: () -> Unit
 ) {
     val heroImage = item.heroImageUrl(HERO_REQUEST_PX)
@@ -187,7 +192,12 @@ private fun FeedItemCard(
             rank = index + 1,
             title = item.title
         )
-        onOpenUrl(item.openUrl)
+        // HN 条目整卡点击进解读页（预生成、零等待），外链降级为解读页首屏出路按钮
+        if (item.source == "hackernews") {
+            onOpenDigest(item.toDigestPage())
+        } else {
+            onOpenUrl(item.openUrl)
+        }
     }
 
     Row(

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -79,6 +79,7 @@ import whl.trending.ai.ui.feed.FeedScreen
 import whl.trending.ai.ui.feed.FeedViewModel
 import whl.trending.ai.ui.picks.PicksScreen
 import whl.trending.ai.ui.picks.PicksViewModel
+import whl.trending.ai.ui.digest.DigestPage
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.ui.trending.TrendingScreen
 import whl.trending.ai.ui.trending.TrendingViewModel
@@ -101,7 +102,8 @@ fun HomeScreen(
     onNavigateToDetail: (owner: String, repo: String) -> Unit,
     onNavigateToChat: () -> Unit = {},
     onOpenUrl: (url: String) -> Unit = {},
-    onNavigateToSubscribe: () -> Unit = {}
+    onNavigateToSubscribe: () -> Unit = {},
+    onOpenDigest: (DigestPage) -> Unit = {}
 ) {
     // 冷启动进入设置页选的默认 tab；仅初始值，会话内切换与 rememberSaveable 恢复不受影响
     var selectedTabName by rememberSaveable {
@@ -294,7 +296,8 @@ fun HomeScreen(
             HomeTab.HackerNews -> FeedScreen(
                 modifier = Modifier.padding(innerPadding),
                 viewModel = hnViewModel!!,
-                onOpenUrl = onOpenUrl
+                onOpenUrl = onOpenUrl,
+                onOpenDigest = onOpenDigest
             )
             HomeTab.ProductHunt -> FeedScreen(
                 modifier = Modifier.padding(innerPadding),
@@ -306,7 +309,8 @@ fun HomeScreen(
                 onOpenUrl = onOpenUrl,
                 onNavigateToSubscribe = onNavigateToSubscribe,
                 modifier = Modifier.padding(innerPadding),
-                viewModel = picksViewModel!!
+                viewModel = picksViewModel!!,
+                onOpenDigest = onOpenDigest
             )
         }
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
@@ -67,6 +67,8 @@ import whl.trending.ai.core.platform.shareText
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.model.PickItem
 import whl.trending.ai.ui.common.ItemActionMenu
+import whl.trending.ai.ui.digest.DigestPage
+import whl.trending.ai.ui.digest.toDigestPage
 import whl.trending.ai.ui.common.aiShareText
 import androidx.compose.runtime.remember
 import kotlin.time.Clock
@@ -78,7 +80,8 @@ fun PicksScreen(
     onOpenUrl: (url: String) -> Unit,
     onNavigateToSubscribe: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: PicksViewModel
+    viewModel: PicksViewModel,
+    onOpenDigest: (DigestPage) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val pullToRefreshState = rememberPullToRefreshState()
@@ -151,7 +154,7 @@ fun PicksScreen(
                             trackEvent("picks_newsletter_banner_dismiss")
                             globalSettingsManager.setPicksNewsletterBannerDismissed(true)
                         },
-                        onItemClick = { item, section -> handleItemClick(item, section, onNavigateToDetail, onOpenUrl) },
+                        onItemClick = { item, section -> handleItemClick(item, section, onNavigateToDetail, onOpenUrl, onOpenDigest) },
                     )
                 }
             }
@@ -163,7 +166,8 @@ private fun handleItemClick(
     item: PickItem,
     section: String,
     onNavigateToDetail: (owner: String, repo: String) -> Unit,
-    onOpenUrl: (url: String) -> Unit
+    onOpenUrl: (url: String) -> Unit,
+    onOpenDigest: (DigestPage) -> Unit
 ) {
     trackItemClick(
         source = item.source,
@@ -177,6 +181,11 @@ private fun handleItemClick(
             onNavigateToDetail(parts[0], parts[1])
             return
         }
+    }
+    // HN 条目进解读页（与 Feed/收藏同一落点），外链从解读页首屏按钮出去
+    if (item.source == "hackernews" && item.externalId.isNotBlank()) {
+        onOpenDigest(item.toDigestPage())
+        return
     }
     onOpenUrl(item.openUrl)
 }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/digest/DigestMarkdownTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/digest/DigestMarkdownTest.kt
@@ -1,0 +1,49 @@
+package whl.trending.ai.ui.digest
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DigestMarkdownTest {
+
+    @Test
+    fun 标题要求井号加空格_任意级别均渲染为标题() {
+        val blocks = parseBlocks("### 讲了什么\n\n正文\n\n## 二级也算")
+        assertEquals(Block.Heading("讲了什么"), blocks[0])
+        assertEquals(Block.Paragraph("正文"), blocks[1])
+        assertEquals(Block.Heading("二级也算"), blocks[2])
+    }
+
+    @Test
+    fun 井号后无空格是正文不是标题_Sourcery审查回归() {
+        // "#1 ranked" / "#ai" 类正文行不得被误判为标题
+        val blocks = parseBlocks("#1 ranked on HN today\n\n#ai is trending")
+        assertEquals(
+            listOf<Block>(
+                Block.Paragraph("#1 ranked on HN today"),
+                Block.Paragraph("#ai is trending"),
+            ),
+            blocks,
+        )
+    }
+
+    @Test
+    fun 列表与续行合并() {
+        val blocks = parseBlocks("- 第一项\n- 第二项\n  换行续写\n\n段落")
+        assertEquals(Block.Bullets(listOf("第一项", "第二项 换行续写")), blocks[0])
+        assertEquals(Block.Paragraph("段落"), blocks[1])
+    }
+
+    @Test
+    fun 行内斜体与粗体解析_未闭合按字面输出() {
+        val italic = parseInline("引用 *a quote* 结束")
+        assertEquals("引用 a quote 结束", italic.text)
+        assertTrue(italic.spanStyles.isNotEmpty())
+
+        val bold = parseInline("**重点** 之后")
+        assertEquals("重点 之后", bold.text)
+
+        val unclosed = parseInline("5 * 3 = 15")
+        assertEquals("5 * 3 = 15", unclosed.text)
+    }
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/digest/DigestPageTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/digest/DigestPageTest.kt
@@ -1,0 +1,37 @@
+package whl.trending.ai.ui.digest
+
+import whl.trending.ai.data.model.FavoriteItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DigestPageTest {
+
+    private fun favorite(externalId: String) = FavoriteItem(
+        url = "https://example.com/article",
+        title = "t",
+        source = "hackernews",
+        openUrl = "https://news.ycombinator.com/item?id=123",
+        externalId = externalId,
+    )
+
+    @Test
+    fun 数字id_讨论区链接按id拼接() {
+        val page = favorite("123").toDigestPage()
+        assertEquals("https://news.ycombinator.com/item?id=123", page.hnUrl)
+    }
+
+    @Test
+    fun 合成键id_回退收藏时记录的打开地址_Sourcery审查回归() {
+        // 存量收藏经云同步后 externalId 可能是持久化的 `url:<url>` 合成键，
+        // 拼进 item?id= 会生成废链接，必须回退 targetUrl
+        val page = favorite("url:https://example.com/article").toDigestPage()
+        assertEquals("https://news.ycombinator.com/item?id=123", page.hnUrl)
+    }
+
+    @Test
+    fun 空id_解析出合成键仍回退打开地址() {
+        // externalId 空串时 resolvedExternalId 派生合成键（非数字）→ 同样走回退
+        val page = favorite("").toDigestPage()
+        assertEquals("https://news.ycombinator.com/item?id=123", page.hnUrl)
+    }
+}


### PR DESCRIPTION
## 概要

HN 解读预生成的 Phase 3（客户端呈现）。后端 Phase 1+2 已上线（github-ai-trending-api#29）：每天 30 条 HN 条目的中英双语解读已预生成在 `GET /api/digest`，本 PR 让用户点开即读。

设计文档：父目录 `hn-digest-实现方案.md` §9 + 已确认 UI 草稿 `hn-digest-解读页草稿.html`。

## 交互变化（核心）

**HN 条目的整卡点击接管默认落点**：Feed 列表 / Picks 深读卡 / 收藏列表三处点击 HN 条目，从跳外链改为进应用内解读页；原文与 HN 讨论区降级为解读页首屏的两个常驻按钮。顺带修正了三处入口原本就不一致的问题（Feed 开讨论页、Picks/收藏开原文）。

## 实现要点

- **`DigestScreen`（shared commonMain，双端可用）**：四态——Loading（M3 Expressive LoadingIndicator）/ Ready（markdown 正文 + 生成时间脚注）/ Unavailable（明确占位卡，非空白，无触发生成）/ Error（仅重试读取）；头部与出路按钮任何状态下常驻；自建帖（Ask HN）只显示「HN 讨论区」一个按钮
- **markdown 受控子集自渲**（`DigestMarkdown`）：### 标题/段落/无序列表/粗斜体，不引第三方库——解读由自家 prompt 生成、结构受控，子集外语法按纯文本降级；chat 模块的 commonmark 是 Java 库进不了 commonMain
- **语言口径**：跟 `summary_lang`（`currentContentLang()`），与列表内容语言一致——刻意不用 AI 请求的 `appLanguage` 口径
- **收藏同一性**：解读页收藏用条目原始 `url` 作主键 + `(source, externalId)` 云同步键，与列表收藏完全同源；`openUrl` 存讨论页地址，与 Feed 收藏行为一致
- **存量收藏兜底**：无 `externalId` 的旧收藏进解读页会得到「暂无解读」+ 可用的原文入口，不空白不崩溃
- **埋点**：`digest_open` / `digest_unavailable_shown` / `digest_read_original_click` / `digest_hn_comments_click`

## 验证

- `:androidApp:assembleDebug` 构建通过；`:shared:allTests` 全过（含 iOS target 编译）
- Pixel_9_2 模拟器实机验证：HN 列表 → 点击进解读页（生产数据即时加载）→ 四节正文/斜体引用/脚注渲染正确 → 收藏 toggle 生效 → 返回正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DK2eFV3LP3GejXPi3tP1bm

## Summary by Sourcery

引入应用内的 Hacker News 摘要页面，并将所有 HN 条目点击统一路由到这个预生成的 AI 摘要视图。

新功能：
- 添加 DigestScreen，用受控的 markdown 渲染预生成的 AI 摘要，包括加载中、就绪、不可用和错误等状态。
- 暴露新的 `/api/digest` 客户端端点和 `DigestResponse` 模型，用于从后端获取预生成的摘要。
- 在摘要页面上提供专用的 UI 操作，用于打开原始文章或 Hacker News 讨论，并带有语言和时间戳提示信息。

改进：
- 将来自 feed、picks 和 favorites 的 Hacker News 条目路由到摘要页面，而不是直接打开外部链接，从而统一条目行为。
- 对 favorites 进行对齐，使摘要页面上的收藏与列表收藏共享同一底层记录，并优雅处理缺少外部 ID 的旧版 HN 收藏。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an in-app Hacker News digest screen and route all HN item clicks to this unified, pre-generated AI digest view.

New Features:
- Add DigestScreen with controlled markdown rendering for pre-generated AI digests, including loading, ready, unavailable, and error states.
- Expose a new /api/digest client endpoint and DigestResponse model to fetch pre-generated digests from the backend.
- Provide dedicated UI actions on the digest page to open the original article or Hacker News discussion, with language and timestamp messaging.

Enhancements:
- Route Hacker News entries from feed, picks, and favorites into the digest page instead of directly opening external links, unifying entry behavior.
- Align favorites so digest-page favorites share the same underlying record as list favorites, with graceful handling of legacy HN favorites lacking external IDs.

</details>