### PR TITLE
feat(home): 首页改版——tab 重排 + 悬浮胶囊底栏，整体对齐 Echo Music

### DIFF
--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -115,7 +115,7 @@
     <string name="readme_no_content">该仓库暂无 README 文件。</string>
     <string name="privacy_policy">隐私政策</string>
     <string name="picks_title">Picks</string>
-    <string name="trending_title">热榜</string>
+    <string name="home_title">首页</string>
     <string name="chat_title">AI 对话</string>
     <string name="me_title">我的</string>
     <string name="hackernews_title">Hacker News</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -11,7 +11,6 @@
     <string name="theme_dark">深色</string>
     <string name="theme_amoled">纯黑</string>
     <string name="appearance">外观</string>
-    <string name="app_settings">应用设置</string>
     <string name="subscription_reminders">订阅与提醒</string>
     <string name="language_settings">应用语言</string>
     <string name="app_language_desc">界面显示语言</string>
@@ -235,7 +234,7 @@
     <string name="account_github_entry">GitHub 主页</string>
     <string name="account_github_entry_desc">贡献与关注动态</string>
     <string name="settings_group_general">通用</string>
-    <string name="app_settings_entry_desc">语言、默认首页、打开方式</string>
+    <string name="settings_entry_desc">外观、语言、通知、反馈</string>
     <string name="contrib_total">最近一年 %1$s 次贡献</string>
     <string name="contrib_less">少</string>
     <string name="contrib_more">多</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -37,8 +37,6 @@
     <string name="changelog">更新日志</string>
     <string name="version_up_to_date">已是最新</string>
     <string name="check_update_failed">检查失败，请稍后重试</string>
-    <string name="about_us">关于我们</string>
-    <string name="about_us_desc">了解更多关于 Trending AI 的信息</string>
     <string name="official_website">官网</string>
     <string name="contact_author">联系作者</string>
     <string name="donate">捐助我们</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -237,7 +237,7 @@
     <string name="account_github_entry">GitHub 主页</string>
     <string name="account_github_entry_desc">贡献与关注动态</string>
     <string name="settings_group_general">通用</string>
-    <string name="settings_entry_desc">外观、语言、通知、反馈</string>
+    <string name="more_label">更多</string>
     <string name="contrib_total">最近一年 %1$s 次贡献</string>
     <string name="contrib_less">少</string>
     <string name="contrib_more">多</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -115,6 +115,9 @@
     <string name="readme_no_content">该仓库暂无 README 文件。</string>
     <string name="privacy_policy">隐私政策</string>
     <string name="picks_title">Picks</string>
+    <string name="trending_title">热榜</string>
+    <string name="chat_title">AI 对话</string>
+    <string name="me_title">我的</string>
     <string name="hackernews_title">Hacker News</string>
     <string name="producthunt_title">Product Hunt</string>
     <string name="hackernews_placeholder">Hacker News 内容即将上线</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -115,7 +115,7 @@
     <string name="readme_no_content">No README found for this repository.</string>
     <string name="privacy_policy">Privacy Policy</string>
     <string name="picks_title">Picks</string>
-    <string name="trending_title">Trending</string>
+    <string name="home_title">Home</string>
     <string name="chat_title">AI Chat</string>
     <string name="me_title">Me</string>
     <string name="hackernews_title">Hacker News</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -37,8 +37,6 @@
     <string name="changelog">Changelog</string>
     <string name="version_up_to_date">Up to date</string>
     <string name="check_update_failed">Check failed, try again later</string>
-    <string name="about_us">About Us</string>
-    <string name="about_us_desc">Learn more about Trending AI</string>
     <string name="official_website">Official Website</string>
     <string name="contact_author">Contact Author</string>
     <string name="donate">Donate</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -115,6 +115,9 @@
     <string name="readme_no_content">No README found for this repository.</string>
     <string name="privacy_policy">Privacy Policy</string>
     <string name="picks_title">Picks</string>
+    <string name="trending_title">Trending</string>
+    <string name="chat_title">AI Chat</string>
+    <string name="me_title">Me</string>
     <string name="hackernews_title">Hacker News</string>
     <string name="producthunt_title">Product Hunt</string>
     <string name="hackernews_placeholder">Hacker News content coming soon</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -237,7 +237,7 @@
     <string name="account_github_entry">GitHub profile</string>
     <string name="account_github_entry_desc">Contributions &amp; network activity</string>
     <string name="settings_group_general">General</string>
-    <string name="settings_entry_desc">Appearance, language, notifications, feedback</string>
+    <string name="more_label">More</string>
     <string name="contrib_total">%1$s contributions in the last year</string>
     <string name="contrib_less">Less</string>
     <string name="contrib_more">More</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -11,7 +11,6 @@
     <string name="theme_dark">Dark</string>
     <string name="theme_amoled">AMOLED</string>
     <string name="appearance">Appearance</string>
-    <string name="app_settings">App Settings</string>
     <string name="subscription_reminders">Subscription &amp; Reminders</string>
     <string name="language_settings">App Language</string>
     <string name="app_language_desc">Interface display language</string>
@@ -235,7 +234,7 @@
     <string name="account_github_entry">GitHub profile</string>
     <string name="account_github_entry_desc">Contributions &amp; network activity</string>
     <string name="settings_group_general">General</string>
-    <string name="app_settings_entry_desc">Language, default tab, link opening</string>
+    <string name="settings_entry_desc">Appearance, language, notifications, feedback</string>
     <string name="contrib_total">%1$s contributions in the last year</string>
     <string name="contrib_less">Less</string>
     <string name="contrib_more">More</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
@@ -238,6 +238,7 @@ fun App() {
                                 onNavigateToAppearance = { backStack.add(Appearance) },
                                 onNavigateToSubscribe = { backStack.add(Subscribe) },
                                 onNavigateToFeedback = { backStack.add(Feedback) },
+                                onNavigateToAbout = { backStack.add(About) },
                             )
                         }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
@@ -7,7 +7,6 @@ import whl.trending.ai.ui.home.HomeScreen
 import whl.trending.ai.ui.profile.GithubProfileScreen
 import whl.trending.ai.ui.profile.GithubUserListMode
 import whl.trending.ai.ui.profile.GithubUserListScreen
-import whl.trending.ai.ui.profile.ProfileScreen
 import whl.trending.ai.ui.profile.RepoListScreen
 import whl.trending.ai.ui.settings.AboutScreen
 import whl.trending.ai.ui.settings.AppearanceScreen
@@ -57,7 +56,6 @@ data object Subscribe
 data class RepoDetail(val owner: String, val repo: String)
 data class WebPage(val url: String, val title: String)
 data object Favorites
-data object Profile
 data object GithubProfile
 data object ProfileFollowers
 data object ProfileFollowing
@@ -137,9 +135,6 @@ fun App() {
                         when (key) {
                         is Home -> NavEntry(key) {
                             HomeScreen(
-                                onNavigateToAccount = {
-                                    backStack.add(Profile)
-                                },
                                 onNavigateToDetail = { owner, repo ->
                                     backStack.add(RepoDetail(owner, repo))
                                 },
@@ -155,6 +150,10 @@ fun App() {
                                 onOpenDigest = { page ->
                                     backStack.add(page)
                                 },
+                                onNavigateToGithubProfile = { backStack.add(GithubProfile) },
+                                onNavigateToFavorites = { backStack.add(Favorites) },
+                                onNavigateToSettings = { backStack.add(Settings) },
+                                onNavigateToAbout = { backStack.add(About) },
                             )
                         }
 
@@ -224,16 +223,6 @@ fun App() {
                                 onOpenDigest = { page ->
                                     backStack.add(page)
                                 }
-                            )
-                        }
-
-                        is Profile -> NavEntry(key) {
-                            ProfileScreen(
-                                onBack = { backStack.safePop() },
-                                onNavigateToGithubProfile = { backStack.add(GithubProfile) },
-                                onNavigateToFavorites = { backStack.add(Favorites) },
-                                onNavigateToSettings = { backStack.add(Settings) },
-                                onNavigateToAbout = { backStack.add(About) },
                             )
                         }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
@@ -18,6 +18,9 @@ import whl.trending.ai.ui.subscribe.SubscribeScreen
 import whl.trending.ai.ui.theme.TrendingTheme
 import whl.trending.ai.ui.webview.WebViewScreen
 
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
@@ -117,19 +120,22 @@ fun App() {
                 NavDisplay(
                     backStack = backStack,
                     onBack = { backStack.safePop() },
-                    // Material 水平共享轴转场（Nav3 官方推荐写法，全局统一）：
-                    // 前进——新页从右滑入、旧页向左滑出；返回及预测式返回手势——反向。
+                    // 页面转场：新页沿前进方向滑入 1/8 屏、旧页往反方向滑出，各配 200ms 淡入淡出；
+                    // 返回及预测式返回手势反向。位移量与时长取自 Echo 的 NavHost
+                    // enter/exit/popEnter/popExitTransition——位移走默认 spring，只有淡化是 tween(200)。
+                    // 首页切 tab 的 AnimatedContent 用的是同一组参数，全 app 一套转场语言。
                     transitionSpec = {
-                        slideInHorizontally(initialOffsetX = { it }) togetherWith
-                            slideOutHorizontally(targetOffsetX = { -it })
+                        slideInHorizontally { it / 8 } + fadeIn(tween(200)) togetherWith
+                            slideOutHorizontally { -it / 8 } + fadeOut(tween(200))
                     },
                     popTransitionSpec = {
-                        slideInHorizontally(initialOffsetX = { -it }) togetherWith
-                            slideOutHorizontally(targetOffsetX = { it })
+                        slideInHorizontally { -it / 8 } + fadeIn(tween(200)) togetherWith
+                            slideOutHorizontally { it / 8 } + fadeOut(tween(200))
                     },
+                    // Nav3 特有：预测式返回手势。Echo 的 NavHost 没有对应物，与 pop 同参。
                     predictivePopTransitionSpec = {
-                        slideInHorizontally(initialOffsetX = { -it }) togetherWith
-                            slideOutHorizontally(targetOffsetX = { it })
+                        slideInHorizontally { -it / 8 } + fadeIn(tween(200)) togetherWith
+                            slideOutHorizontally { it / 8 } + fadeOut(tween(200))
                     },
                     entryProvider = { key ->
                         when (key) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
@@ -4,15 +4,15 @@ import whl.trending.ai.ui.detail.ReadmeScreen
 import whl.trending.ai.ui.favorites.FavoriteListScreen
 import whl.trending.ai.ui.feedback.FeedbackScreen
 import whl.trending.ai.ui.home.HomeScreen
-import whl.trending.ai.ui.profile.AccountScreen
 import whl.trending.ai.ui.profile.GithubProfileScreen
 import whl.trending.ai.ui.profile.GithubUserListMode
 import whl.trending.ai.ui.profile.GithubUserListScreen
+import whl.trending.ai.ui.profile.ProfileScreen
 import whl.trending.ai.ui.profile.RepoListScreen
 import whl.trending.ai.ui.settings.AboutScreen
-import whl.trending.ai.ui.settings.AppSettingsScreen
 import whl.trending.ai.ui.settings.AppearanceScreen
 import whl.trending.ai.ui.settings.ColorLabScreen
+import whl.trending.ai.ui.settings.SettingsScreen
 import whl.trending.ai.ui.digest.DigestPage
 import whl.trending.ai.ui.digest.DigestScreen
 import whl.trending.ai.ui.subscribe.SubscribeScreen
@@ -50,7 +50,7 @@ import whl.trending.ai.ui.common.WhatsNewHost
 data object Home
 data object Appearance
 data object ColorLab
-data object AppSettings
+data object Settings
 data object About
 data object Feedback
 data object Subscribe
@@ -228,21 +228,20 @@ fun App() {
                         }
 
                         is Profile -> NavEntry(key) {
-                            AccountScreen(
+                            ProfileScreen(
                                 onBack = { backStack.safePop() },
                                 onNavigateToGithubProfile = { backStack.add(GithubProfile) },
                                 onNavigateToFavorites = { backStack.add(Favorites) },
-                                onNavigateToFeedback = { backStack.add(Feedback) },
-                                onNavigateToSubscribe = { backStack.add(Subscribe) },
-                                onNavigateToAppearance = { backStack.add(Appearance) },
-                                onNavigateToAppSettings = { backStack.add(AppSettings) },
+                                onNavigateToSettings = { backStack.add(Settings) },
                                 onNavigateToAbout = { backStack.add(About) },
                             )
                         }
 
-                        is AppSettings -> NavEntry(key) {
-                            AppSettingsScreen(
+                        is Settings -> NavEntry(key) {
+                            SettingsScreen(
                                 onBack = { backStack.safePop() },
+                                onNavigateToAppearance = { backStack.add(Appearance) },
+                                onNavigateToSubscribe = { backStack.add(Subscribe) },
                                 onNavigateToFeedback = { backStack.add(Feedback) },
                             )
                         }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -44,7 +44,10 @@ const val DEFAULT_THEME_STYLE_STORAGE: String = "soft"
 const val DEFAULT_THEME_CONTRAST_STORAGE: String = "standard"
 
 /** 默认首页 tab 的持久化值（HomeTab.name），仅 SettingsManager 内部作缺省值使用 */
-private const val DEFAULT_HOME_TAB_NAME = "GitHub"
+private const val DEFAULT_HOME_TAB_NAME = "Trending"
+
+/** Trending tab 上次停留的子源（TrendingSource.name），仅 SettingsManager 内部作缺省值使用 */
+private const val DEFAULT_TRENDING_SOURCE_NAME = "GitHub"
 
 enum class AppLanguage(val isoCode: String?) {
     FOLLOW_SYSTEM(null),
@@ -130,6 +133,7 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val DAILY_PICKS_NOTIFICATION_KEY = "prefs_daily_picks_notification"
     private val PICKS_NEWSLETTER_BANNER_DISMISSED_KEY = "prefs_picks_newsletter_banner_dismissed"
     private val DEFAULT_HOME_TAB_KEY = "prefs_default_home_tab"
+    private val TRENDING_SOURCE_KEY = "prefs_trending_source"
 
     /**
      * 安装级匿名标识：首次访问时生成并持久化，之后保持不变（卸载重装才会重新生成）。
@@ -585,8 +589,9 @@ class SettingsManager(private val settings: ObservableSettings) {
     }
 
     /**
-     * 冷启动默认显示的首页 tab，存 ui 层 HomeTab 枚举的 name（如 "GitHub"、"Picks"）。
-     * data 层不依赖 ui 层枚举，只存取字符串；解析与回落由 HomeTab.fromNameOrDefault 负责。
+     * 冷启动默认显示的首页 tab，存 ui 层 HomeTab 枚举的 name（如 "Trending"、"Picks"）。
+     * data 层不依赖 ui 层枚举，只存取字符串；解析与回落由 HomeTab.defaultFromName 负责——
+     * 0.23 前存的是 "GitHub"/"HackerNews"/"ProductHunt"，解析时会落到 Trending。
      * 只决定初始值；会话内切 tab 不回写此设置。
      */
     val defaultHomeTab: Flow<String> = settings.getStringFlow(DEFAULT_HOME_TAB_KEY, DEFAULT_HOME_TAB_NAME)
@@ -595,6 +600,16 @@ class SettingsManager(private val settings: ObservableSettings) {
 
     fun setDefaultHomeTab(name: String) {
         settings.putString(DEFAULT_HOME_TAB_KEY, name)
+    }
+
+    /**
+     * Trending tab 上次停留的子源，存 ui 层 TrendingSource 枚举的 name。
+     * 与「默认首页」不同，这个值每次切子源都回写——用户上次看的是哪个源，下次冷启动就回哪。
+     */
+    fun currentTrendingSource(): String = settings.getString(TRENDING_SOURCE_KEY, DEFAULT_TRENDING_SOURCE_NAME)
+
+    fun setTrendingSource(name: String) {
+        settings.putString(TRENDING_SOURCE_KEY, name)
     }
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -44,9 +44,9 @@ const val DEFAULT_THEME_STYLE_STORAGE: String = "soft"
 const val DEFAULT_THEME_CONTRAST_STORAGE: String = "standard"
 
 /** 默认首页 tab 的持久化值（HomeTab.name），仅 SettingsManager 内部作缺省值使用 */
-private const val DEFAULT_HOME_TAB_NAME = "Trending"
+private const val DEFAULT_HOME_TAB_NAME = "Home"
 
-/** Trending tab 上次停留的子源（TrendingSource.name），仅 SettingsManager 内部作缺省值使用 */
+/** 首页上次停留的子源（TrendingSource.name），仅 SettingsManager 内部作缺省值使用 */
 private const val DEFAULT_TRENDING_SOURCE_NAME = "GitHub"
 
 enum class AppLanguage(val isoCode: String?) {
@@ -589,9 +589,10 @@ class SettingsManager(private val settings: ObservableSettings) {
     }
 
     /**
-     * 冷启动默认显示的首页 tab，存 ui 层 HomeTab 枚举的 name（如 "Trending"、"Picks"）。
+     * 冷启动默认显示的首页 tab，存 ui 层 HomeTab 枚举的 name（如 "Home"、"Picks"）。
      * data 层不依赖 ui 层枚举，只存取字符串；解析与回落由 HomeTab.defaultFromName 负责——
-     * 0.23 前存的是 "GitHub"/"HackerNews"/"ProductHunt"，解析时会落到 Trending。
+     * 历史上存过 "GitHub"/"HackerNews"/"ProductHunt"（0.23 前）与 "Trending"（本 tab 旧名），
+     * 都匹配不上，统一回落到 Home，落点与改名前一致。
      * 只决定初始值；会话内切 tab 不回写此设置。
      */
     val defaultHomeTab: Flow<String> = settings.getStringFlow(DEFAULT_HOME_TAB_KEY, DEFAULT_HOME_TAB_NAME)
@@ -603,7 +604,7 @@ class SettingsManager(private val settings: ObservableSettings) {
     }
 
     /**
-     * Trending tab 上次停留的子源，存 ui 层 TrendingSource 枚举的 name。
+     * 首页上次停留的子源，存 ui 层 TrendingSource 枚举的 name。
      * 与「默认首页」不同，这个值每次切子源都回写——用户上次看的是哪个源，下次冷启动就回哪。
      */
     fun currentTrendingSource(): String = settings.getString(TRENDING_SOURCE_KEY, DEFAULT_TRENDING_SOURCE_NAME)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/ContentBottomPadding.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/ContentBottomPadding.kt
@@ -1,0 +1,15 @@
+package whl.trending.ai.ui.common
+
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * 首页悬浮底栏挡住的高度（含系统导航栏 inset）。
+ *
+ * 底栏是浮在内容之上的胶囊，内容要从它下面穿过去才有 edge-to-edge 的观感；代价是列表最后
+ * 一条会被压住。各内容页把这个值加进 `contentPadding` 的底部，最后一条就能滚出来。
+ *
+ * 只有首页四个 tab 的内容需要消费它；其余页面拿到默认值 0，行为不变。
+ */
+val LocalContentBottomPadding = compositionLocalOf<Dp> { 0.dp }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
@@ -29,9 +29,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import whl.trending.ai.ui.common.LocalContentBottomPadding
 import androidx.compose.ui.unit.sp
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
@@ -136,7 +138,11 @@ fun FeedScreen(
             else -> {
                 val favorites by globalSettingsManager.favorites.collectAsState(emptyList())
                 val favoriteUrls = remember(favorites) { favorites.map { it.url }.toSet() }
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    // 末条要能从悬浮底栏下面滚出来
+                    contentPadding = PaddingValues(bottom = LocalContentBottomPadding.current),
+                ) {
                     itemsIndexed(
                         uiState.items,
                         key = { _, item -> "${item.source}_${item.externalId}" }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
@@ -1,5 +1,6 @@
 package whl.trending.ai.ui.home
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateColor
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
@@ -78,10 +79,14 @@ val FloatingBarBottomMargin: Dp = 12.dp
 /** 胶囊最大宽度，平板/大屏上不至于拉成一整条。对齐 Echo。 */
 private val BarMaxWidth: Dp = 480.dp
 
-/** 底栏一项。[selected] 为 false 且点击后不改变选中态的项（AI 对话）也走这里，见 [HomeTab.Chat]。 */
+/**
+ * 底栏一项。图标备实心/描边两态，选中切实心——与 Echo 的 `Screens.iconIdActive/Inactive` 同构。
+ * [selected] 为 false 且点击后不改变选中态的项（AI 对话）也走这里，见 [HomeTab.Chat]。
+ */
 internal data class HomeBarItem(
     val key: HomeTab,
-    val icon: ImageVector,
+    val iconSelected: ImageVector,
+    val iconUnselected: ImageVector,
     val label: String,
     val selected: Boolean,
     val onClick: () -> Unit,
@@ -185,8 +190,8 @@ private fun SlidingPillItems(items: List<HomeBarItem>) {
 }
 
 /**
- * 单项：只有图标。宽度由内容撑开（下限 48dp），选中时图标放大、颜色渐变，按下时整体缩一下。
- * 各段动画参数与 Echo 的 `FloatingNavigationToolbarItem` 相同。
+ * 单项：只有图标。宽度由内容撑开（下限 48dp），选中时图标 Crossfade 到实心态并放大、
+ * 颜色渐变，按下时整体缩一下。各段动画参数与 Echo 的 `FloatingNavigationToolbarItem` 相同。
  */
 @Composable
 private fun BarItem(item: HomeBarItem, modifier: Modifier = Modifier) {
@@ -238,12 +243,21 @@ private fun BarItem(item: HomeBarItem, modifier: Modifier = Modifier) {
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Icon(
-            imageVector = item.icon,
-            contentDescription = item.label,
-            tint = contentColor,
+        Crossfade(
+            targetState = item.selected,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioNoBouncy,
+                stiffness = Spring.StiffnessMediumLow,
+            ),
+            label = "iconCrossfade",
             modifier = Modifier.scale(iconScale),
-        )
+        ) { isSelected ->
+            Icon(
+                imageVector = if (isSelected) item.iconSelected else item.iconUnselected,
+                contentDescription = item.label,
+                tint = contentColor,
+            )
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
@@ -1,27 +1,32 @@
 package whl.trending.ai.ui.home
 
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColor
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.expandHorizontally
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.MoreHoriz
@@ -29,15 +34,14 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FloatingToolbarDefaults
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -46,6 +50,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
@@ -59,11 +66,17 @@ import trendingai.shared.generated.resources.about_us
 import trendingai.shared.generated.resources.more_label
 import trendingai.shared.generated.resources.settings
 
-/** 悬浮底栏胶囊本体的高度，不含系统导航栏 inset 与外边距。 */
-val FloatingBarHeight: Dp = 64.dp
+/**
+ * 悬浮底栏胶囊本体的高度，不含系统导航栏 inset 与外边距。
+ * 对齐 Echo 的 `FloatingToolbarHeight`（constants/Dimensions.kt）。
+ */
+val FloatingBarHeight: Dp = 72.dp
 
-/** 胶囊与屏幕底边、与内容之间的呼吸位。 */
+/** 胶囊与屏幕底边、与内容之间的呼吸位。对齐 Echo 的 `FloatingToolbarBottomPadding`。 */
 val FloatingBarBottomMargin: Dp = 12.dp
+
+/** 胶囊最大宽度，平板/大屏上不至于拉成一整条。对齐 Echo。 */
+private val BarMaxWidth: Dp = 480.dp
 
 /** 底栏一项。[selected] 为 false 且点击后不改变选中态的项（AI 对话）也走这里，见 [HomeTab.Chat]。 */
 internal data class HomeBarItem(
@@ -77,9 +90,10 @@ internal data class HomeBarItem(
 /**
  * 首页悬浮底栏：M3 Expressive 的胶囊工具栏 + 右侧一颗独立的「⋯」FAB。
  *
- * 选中态不是给单项加底色，而是一块跟着选中项滑动的药丸——位置与宽度都用 spring 追过去，
- * 切 tab 时能看出「同一块高亮移过去了」，而不是这边灭那边亮。选中项额外展开文字标签，
- * 未选中只留图标，四项加一颗 FAB 才塞得进一行。
+ * 实现照搬 Echo Music 的 `FloatingNavigationToolbar`：外层 [BoxWithConstraints] 撑满并居中，
+ * 工具栏用 `widthIn(max)` 收住宽度，FAB 放在工具栏自带的槽位里。
+ * 选中态是一块跟着选中项滑动的药丸（见 [SlidingPillItems]）；只有图标、没有文字标签
+ * ——Echo 那边 `showSelectedLabels` 写死为 false。
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -89,55 +103,69 @@ internal fun HomeFloatingBar(
     onOpenAbout: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // 不用工具栏自带的 FAB 槽位：那个槽位会把胶囊撑满整行、项挤在左边留一大片空白。
-    // 自己排成「胶囊（按内容宽度）+ 间隙 + 独立 FAB」，整体居中。
-    Row(
-        // 必须定高：不定的话 Row 会撑满父 Box，FAB 跟着拉成一根竖条、胶囊被垂直居中
-        modifier = modifier.height(FloatingBarHeight),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    BoxWithConstraints(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
     ) {
         HorizontalFloatingToolbar(
             expanded = true,
-            modifier = Modifier.fillMaxHeight(),
+            floatingActionButton = { OverflowFab(onOpenSettings = onOpenSettings, onOpenAbout = onOpenAbout) },
+            modifier = Modifier.widthIn(max = BarMaxWidth),
+            colors = FloatingToolbarDefaults.standardFloatingToolbarColors(
+                toolbarContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+            ),
+            animationSpec = FloatingToolbarDefaults.animationSpec(),
         ) {
             SlidingPillItems(items)
         }
-        OverflowFab(onOpenSettings = onOpenSettings, onOpenAbout = onOpenAbout)
     }
 }
 
-/** 图标行 + 底下那块滑动药丸。药丸画在 Row 之下同一个 Box 里，靠测量到的位置/宽度定位。 */
+/**
+ * 图标行 + 底下那块滑动药丸。药丸单独占一层 [Modifier.matchParentSize]，不参与
+ * [IntrinsicSize] 测量；位置与宽度取自各项 [onGloballyPositioned] 报回来的实测值。
+ */
 @Composable
 private fun SlidingPillItems(items: List<HomeBarItem>) {
     val density = LocalDensity.current
-    val widths = remember { mutableStateMapOf<HomeTab, Dp>() }
-    val positions = remember { mutableStateMapOf<HomeTab, Dp>() }
+    val itemWidths = remember { mutableStateMapOf<HomeTab, Dp>() }
+    val itemPositions = remember { mutableStateMapOf<HomeTab, Dp>() }
 
     val active = items.firstOrNull { it.selected }
-    val targetWidth = active?.let { widths[it.key] } ?: 0.dp
-    val targetOffset = active?.let { positions[it.key] } ?: 0.dp
+    val targetWidth = active?.let { itemWidths[it.key] } ?: 0.dp
+    val targetPosition = active?.let { itemPositions[it.key] } ?: 0.dp
 
-    val pillSpring = spring<Dp>(
-        dampingRatio = Spring.DampingRatioNoBouncy,
-        stiffness = Spring.StiffnessMediumLow,
+    val slidingPillWidth by animateDpAsState(
+        targetValue = targetWidth,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessMediumLow,
+        ),
+        label = "pillWidth",
     )
-    val pillWidth by animateDpAsState(targetWidth, pillSpring, label = "pillWidth")
-    val pillOffset by animateDpAsState(targetOffset, pillSpring, label = "pillOffset")
+    val slidingPillOffset by animateDpAsState(
+        targetValue = targetPosition,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessMediumLow,
+        ),
+        label = "pillOffset",
+    )
 
     Box(modifier = Modifier.height(IntrinsicSize.Min)) {
-        if (targetWidth > 0.dp) {
-            Box(
-                modifier = Modifier
-                    .offset(x = pillOffset)
-                    .width(pillWidth)
-                    .fillMaxHeight()
-                    .padding(vertical = 6.dp)
-                    .background(
-                        color = MaterialTheme.colorScheme.secondaryContainer,
-                        shape = CircleShape,
-                    )
-            )
+        Box(modifier = Modifier.matchParentSize()) {
+            if (targetWidth > 0.dp) {
+                Box(
+                    modifier = Modifier
+                        .offset(x = slidingPillOffset)
+                        .width(slidingPillWidth)
+                        .fillMaxHeight()
+                        .background(
+                            color = MaterialTheme.colorScheme.secondaryContainer,
+                            shape = RoundedCornerShape(24.dp),
+                        )
+                )
+            }
         }
 
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -146,8 +174,8 @@ private fun SlidingPillItems(items: List<HomeBarItem>) {
                     item = item,
                     modifier = Modifier.onGloballyPositioned { coordinates ->
                         with(density) {
-                            widths[item.key] = coordinates.size.width.toDp()
-                            positions[item.key] = coordinates.positionInParent().x.toDp()
+                            itemWidths[item.key] = coordinates.size.width.toDp()
+                            itemPositions[item.key] = coordinates.positionInParent().x.toDp()
                         }
                     },
                 )
@@ -156,43 +184,66 @@ private fun SlidingPillItems(items: List<HomeBarItem>) {
     }
 }
 
+/**
+ * 单项：只有图标。宽度由内容撑开（下限 48dp），选中时图标放大、颜色渐变，按下时整体缩一下。
+ * 各段动画参数与 Echo 的 `FloatingNavigationToolbarItem` 相同。
+ */
 @Composable
 private fun BarItem(item: HomeBarItem, modifier: Modifier = Modifier) {
-    val contentColor = if (item.selected) {
-        MaterialTheme.colorScheme.onSecondaryContainer
-    } else {
-        MaterialTheme.colorScheme.onSurfaceVariant
+    val shape = RoundedCornerShape(24.dp)
+    val transition = updateTransition(targetState = item.selected, label = "navItem_${item.key.name}")
+
+    val contentColor by transition.animateColor(
+        transitionSpec = { spring(stiffness = Spring.StiffnessMedium) },
+        label = "contentColor",
+    ) { isSelected ->
+        if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer
+        else MaterialTheme.colorScheme.onSurfaceVariant
     }
+
+    val iconScale by transition.animateFloat(
+        transitionSpec = {
+            spring(
+                dampingRatio = Spring.DampingRatioMediumBouncy,
+                stiffness = Spring.StiffnessMediumLow,
+            )
+        },
+        label = "iconScale",
+    ) { isSelected -> if (isSelected) 1.12f else 1.0f }
+
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val pressScale by animateFloatAsState(
+        targetValue = if (isPressed) 0.91f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium,
+        ),
+        label = "pressScale",
+    )
+
     Row(
         modifier = modifier
-            .height(FloatingBarHeight)
-            .selectable(
-                selected = item.selected,
+            .scale(pressScale)
+            .clip(shape)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = LocalIndication.current,
                 role = Role.Tab,
-                // 药丸自己就是选中反馈，再叠一圈 ripple 会糊成一团
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
                 onClick = item.onClick,
             )
-            .padding(horizontal = 16.dp),
+            .widthIn(min = 48.dp)
+            // Echo 在展示文字标签时把水平 padding 撑到 16dp；标签关掉后它取的就是这个 12dp
+            .padding(horizontal = 12.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        CompositionLocalProvider(LocalContentColor provides contentColor) {
-            Icon(item.icon, contentDescription = item.label)
-            // 只有选中项展开文字：四项都带标签会撑爆一行，全不带又认不出来
-            AnimatedVisibility(
-                visible = item.selected,
-                enter = fadeIn() + expandHorizontally(),
-                exit = fadeOut() + shrinkHorizontally(),
-            ) {
-                Text(
-                    text = item.label,
-                    style = MaterialTheme.typography.labelLarge,
-                    color = contentColor,
-                )
-            }
-        }
+        Icon(
+            imageVector = item.icon,
+            contentDescription = item.label,
+            tint = contentColor,
+            modifier = Modifier.scale(iconScale),
+        )
     }
 }
 
@@ -203,11 +254,13 @@ private fun OverflowFab(onOpenSettings: () -> Unit, onOpenAbout: () -> Unit) {
     var expanded by rememberSaveable { mutableStateOf(false) }
 
     Box {
-        androidx.compose.material3.FloatingToolbarDefaults.VibrantFloatingActionButton(
+        FloatingToolbarDefaults.VibrantFloatingActionButton(
             onClick = { expanded = !expanded },
-            // 默认是圆角方形；这里要的是一颗独立的圆，和胶囊区分开
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            // Echo 用的是默认形状——androidx 版默认就是圆；CMP 这版默认是圆角方形，
+            // 显式传 CircleShape 才能得到与 Echo 相同的外观。
             shape = CircleShape,
-            modifier = Modifier.size(FloatingBarHeight),
         ) {
             Icon(Icons.Default.MoreHoriz, contentDescription = stringResource(Res.string.more_label))
         }
@@ -215,7 +268,9 @@ private fun OverflowFab(onOpenSettings: () -> Unit, onOpenAbout: () -> Unit) {
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
-            shape = MaterialTheme.shapes.large,
+            shape = RoundedCornerShape(24.dp),
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.96f),
+            tonalElevation = 8.dp,
         ) {
             OverflowMenuItem(
                 text = stringResource(Res.string.settings),
@@ -254,6 +309,9 @@ private fun OverflowMenuItem(text: String, icon: ImageVector, onClick: () -> Uni
                 }
             }
         },
-        colors = MenuDefaults.itemColors(),
+        colors = MenuDefaults.itemColors(
+            textColor = MaterialTheme.colorScheme.onSurface,
+            leadingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        ),
     )
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
@@ -63,7 +63,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
-import trendingai.shared.generated.resources.about_us
+import trendingai.shared.generated.resources.about
 import trendingai.shared.generated.resources.more_label
 import trendingai.shared.generated.resources.settings
 
@@ -261,7 +261,7 @@ private fun BarItem(item: HomeBarItem, modifier: Modifier = Modifier) {
     }
 }
 
-/** 「⋯」扩展菜单：设置 / 关于我们。图标各自套一层圆形 tonal 底，与 M3 菜单的分量匹配。 */
+/** 「⋯」扩展菜单：设置 / 关于。图标各自套一层圆形 tonal 底，与 M3 菜单的分量匹配。 */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun OverflowFab(onOpenSettings: () -> Unit, onOpenAbout: () -> Unit) {
@@ -295,7 +295,7 @@ private fun OverflowFab(onOpenSettings: () -> Unit, onOpenAbout: () -> Unit) {
                 },
             )
             OverflowMenuItem(
-                text = stringResource(Res.string.about_us),
+                text = stringResource(Res.string.about),
                 icon = Icons.Default.Info,
                 onClick = {
                     expanded = false

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
@@ -1,0 +1,259 @@
+package whl.trending.ai.ui.home
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.MoreHoriz
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.HorizontalFloatingToolbar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.about_us
+import trendingai.shared.generated.resources.more_label
+import trendingai.shared.generated.resources.settings
+
+/** 悬浮底栏胶囊本体的高度，不含系统导航栏 inset 与外边距。 */
+val FloatingBarHeight: Dp = 64.dp
+
+/** 胶囊与屏幕底边、与内容之间的呼吸位。 */
+val FloatingBarBottomMargin: Dp = 12.dp
+
+/** 底栏一项。[selected] 为 false 且点击后不改变选中态的项（AI 对话）也走这里，见 [HomeTab.Chat]。 */
+internal data class HomeBarItem(
+    val key: HomeTab,
+    val icon: ImageVector,
+    val label: String,
+    val selected: Boolean,
+    val onClick: () -> Unit,
+)
+
+/**
+ * 首页悬浮底栏：M3 Expressive 的胶囊工具栏 + 右侧一颗独立的「⋯」FAB。
+ *
+ * 选中态不是给单项加底色，而是一块跟着选中项滑动的药丸——位置与宽度都用 spring 追过去，
+ * 切 tab 时能看出「同一块高亮移过去了」，而不是这边灭那边亮。选中项额外展开文字标签，
+ * 未选中只留图标，四项加一颗 FAB 才塞得进一行。
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun HomeFloatingBar(
+    items: List<HomeBarItem>,
+    onOpenSettings: () -> Unit,
+    onOpenAbout: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // 不用工具栏自带的 FAB 槽位：那个槽位会把胶囊撑满整行、项挤在左边留一大片空白。
+    // 自己排成「胶囊（按内容宽度）+ 间隙 + 独立 FAB」，整体居中。
+    Row(
+        // 必须定高：不定的话 Row 会撑满父 Box，FAB 跟着拉成一根竖条、胶囊被垂直居中
+        modifier = modifier.height(FloatingBarHeight),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        HorizontalFloatingToolbar(
+            expanded = true,
+            modifier = Modifier.fillMaxHeight(),
+        ) {
+            SlidingPillItems(items)
+        }
+        OverflowFab(onOpenSettings = onOpenSettings, onOpenAbout = onOpenAbout)
+    }
+}
+
+/** 图标行 + 底下那块滑动药丸。药丸画在 Row 之下同一个 Box 里，靠测量到的位置/宽度定位。 */
+@Composable
+private fun SlidingPillItems(items: List<HomeBarItem>) {
+    val density = LocalDensity.current
+    val widths = remember { mutableStateMapOf<HomeTab, Dp>() }
+    val positions = remember { mutableStateMapOf<HomeTab, Dp>() }
+
+    val active = items.firstOrNull { it.selected }
+    val targetWidth = active?.let { widths[it.key] } ?: 0.dp
+    val targetOffset = active?.let { positions[it.key] } ?: 0.dp
+
+    val pillSpring = spring<Dp>(
+        dampingRatio = Spring.DampingRatioNoBouncy,
+        stiffness = Spring.StiffnessMediumLow,
+    )
+    val pillWidth by animateDpAsState(targetWidth, pillSpring, label = "pillWidth")
+    val pillOffset by animateDpAsState(targetOffset, pillSpring, label = "pillOffset")
+
+    Box(modifier = Modifier.height(IntrinsicSize.Min)) {
+        if (targetWidth > 0.dp) {
+            Box(
+                modifier = Modifier
+                    .offset(x = pillOffset)
+                    .width(pillWidth)
+                    .fillMaxHeight()
+                    .padding(vertical = 6.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.secondaryContainer,
+                        shape = CircleShape,
+                    )
+            )
+        }
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            items.forEach { item ->
+                BarItem(
+                    item = item,
+                    modifier = Modifier.onGloballyPositioned { coordinates ->
+                        with(density) {
+                            widths[item.key] = coordinates.size.width.toDp()
+                            positions[item.key] = coordinates.positionInParent().x.toDp()
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BarItem(item: HomeBarItem, modifier: Modifier = Modifier) {
+    val contentColor = if (item.selected) {
+        MaterialTheme.colorScheme.onSecondaryContainer
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Row(
+        modifier = modifier
+            .height(FloatingBarHeight)
+            .selectable(
+                selected = item.selected,
+                role = Role.Tab,
+                // 药丸自己就是选中反馈，再叠一圈 ripple 会糊成一团
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = item.onClick,
+            )
+            .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        CompositionLocalProvider(LocalContentColor provides contentColor) {
+            Icon(item.icon, contentDescription = item.label)
+            // 只有选中项展开文字：四项都带标签会撑爆一行，全不带又认不出来
+            AnimatedVisibility(
+                visible = item.selected,
+                enter = fadeIn() + expandHorizontally(),
+                exit = fadeOut() + shrinkHorizontally(),
+            ) {
+                Text(
+                    text = item.label,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = contentColor,
+                )
+            }
+        }
+    }
+}
+
+/** 「⋯」扩展菜单：设置 / 关于我们。图标各自套一层圆形 tonal 底，与 M3 菜单的分量匹配。 */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun OverflowFab(onOpenSettings: () -> Unit, onOpenAbout: () -> Unit) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+
+    Box {
+        androidx.compose.material3.FloatingToolbarDefaults.VibrantFloatingActionButton(
+            onClick = { expanded = !expanded },
+            // 默认是圆角方形；这里要的是一颗独立的圆，和胶囊区分开
+            shape = CircleShape,
+            modifier = Modifier.size(FloatingBarHeight),
+        ) {
+            Icon(Icons.Default.MoreHoriz, contentDescription = stringResource(Res.string.more_label))
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            shape = MaterialTheme.shapes.large,
+        ) {
+            OverflowMenuItem(
+                text = stringResource(Res.string.settings),
+                icon = Icons.Default.Settings,
+                onClick = {
+                    expanded = false
+                    onOpenSettings()
+                },
+            )
+            OverflowMenuItem(
+                text = stringResource(Res.string.about_us),
+                icon = Icons.Default.Info,
+                onClick = {
+                    expanded = false
+                    onOpenAbout()
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun OverflowMenuItem(text: String, icon: ImageVector, onClick: () -> Unit) {
+    DropdownMenuItem(
+        text = { Text(text) },
+        onClick = onClick,
+        leadingIcon = {
+            Surface(
+                modifier = Modifier.size(40.dp),
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(icon, contentDescription = null)
+                }
+            }
+        },
+        colors = MenuDefaults.itemColors(),
+    )
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -7,17 +7,22 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.AutoAwesome
@@ -37,9 +42,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.RichTooltip
 import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
@@ -56,6 +62,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalViewConfiguration
@@ -101,7 +108,7 @@ import kotlin.time.Clock
 /**
  * 首页骨架：底栏四项（Trending / Picks / AI 对话 / 我的）。
  *
- * Trending 内含 GitHub / Hacker News / Product Hunt 三个子源，用 [PrimaryTabRow] 切换——
+ * Trending 内含 GitHub / Hacker News / Product Hunt 三个子源，用 [SecondaryTabRow] 切换——
  * 只点击、不横滑：三个源各自有下拉刷新与横向可滚内容，再叠一层横向手势会互相抢。
  *
  * AI 对话是入口不是落点：点它直接推全屏聊天页，底栏选中态仍留在原 tab（见 [HomeTab.Chat]）。
@@ -414,13 +421,39 @@ fun HomeScreen(
     }
 }
 
-/** Trending 的三源子 tab。文案用各源全称，图标交给顶栏——一行三项不必再塞图标。 */
+/**
+ * Trending 的三源子 tab。文案用各源全称，图标交给顶栏——一行三项不必再塞图标。
+ *
+ * 样式照搬 Echo 搜索页的内部 tab（`SearchScreen` 的 Explore / Echo Chart / Album）：
+ * [SecondaryTabRow] + 透明底，指示器不是整宽下划线，而是一条 32dp 宽、3dp 高、
+ * 上缘带圆角的短横条，居中在选中项下方。切内容同样是硬切，Echo 那边也没有转场。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun TrendingSourceTabs(
     selected: TrendingSource,
     onSelect: (TrendingSource) -> Unit,
 ) {
-    PrimaryTabRow(selectedTabIndex = selected.ordinal) {
+    SecondaryTabRow(
+        selectedTabIndex = selected.ordinal,
+        containerColor = Color.Transparent,
+        indicator = {
+            Box(
+                modifier = Modifier
+                    .tabIndicatorOffset(selected.ordinal)
+                    .fillMaxWidth(),
+                contentAlignment = Alignment.BottomCenter,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(32.dp)
+                        .height(3.dp)
+                        .clip(RoundedCornerShape(topStart = 3.dp, topEnd = 3.dp))
+                        .background(MaterialTheme.colorScheme.primary)
+                )
+            }
+        },
+    ) {
         TrendingSource.entries.forEach { source ->
             val label = when (source) {
                 TrendingSource.GitHub -> "GitHub"
@@ -430,7 +463,9 @@ private fun TrendingSourceTabs(
             Tab(
                 selected = source == selected,
                 onClick = { onSelect(source) },
-                text = { Text(label, style = MaterialTheme.typography.titleSmall) },
+                selectedContentColor = MaterialTheme.colorScheme.primary,
+                unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                text = { Text(label) },
             )
         }
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -104,9 +104,9 @@ import whl.trending.ai.ui.trending.TrendingViewModel
 import kotlin.time.Clock
 
 /**
- * 首页骨架：底栏四项（Trending / Picks / AI 对话 / 我的）。
+ * 首页骨架：底栏四项（首页 / Picks / AI 对话 / 我的）。
  *
- * Trending 内含 GitHub / Hacker News / Product Hunt 三个子源，用 [SecondaryTabRow] 切换——
+ * 首页内含 GitHub / Hacker News / Product Hunt 三个子源，用 [SecondaryTabRow] 切换——
  * 只点击、不横滑：三个源各自有下拉刷新与横向可滚内容，再叠一层横向手势会互相抢。
  *
  * AI 对话是入口不是落点：点它直接推全屏聊天页，底栏选中态仍留在原 tab（见 [HomeTab.Chat]）。
@@ -158,11 +158,11 @@ fun HomeScreen(
     val picksUiState = picksViewModel?.uiState?.collectAsState()?.value
 
     // HN / PH 同样按需创建；提升到这里是为了 bottomBar 双击刷新能拿到同一实例
-    val onTrendingTab = selectedTab == HomeTab.Trending
-    val hnViewModel: FeedViewModel? = if (onTrendingTab && selectedSource == TrendingSource.HackerNews) {
+    val onHomeTab = selectedTab == HomeTab.Home
+    val hnViewModel: FeedViewModel? = if (onHomeTab && selectedSource == TrendingSource.HackerNews) {
         viewModel(key = "hackernews") { FeedViewModel("hackernews") }
     } else null
-    val phViewModel: FeedViewModel? = if (onTrendingTab && selectedSource == TrendingSource.ProductHunt) {
+    val phViewModel: FeedViewModel? = if (onHomeTab && selectedSource == TrendingSource.ProductHunt) {
         viewModel(key = "producthunt") { FeedViewModel("producthunt") }
     } else null
 
@@ -180,7 +180,7 @@ fun HomeScreen(
     TrendingScaffold(
         topBar = {
             when (selectedTab) {
-                HomeTab.Trending -> when (selectedSource) {
+                HomeTab.Home -> when (selectedSource) {
                     TrendingSource.GitHub -> TrendingTopBar(
                         selectedPeriod = trendingUiState.selectedPeriod,
                         selectedLanguage = trendingUiState.selectedLanguage,
@@ -255,7 +255,7 @@ fun HomeScreen(
                 mapOf("tab" to selectedTab.name.lowercase()),
             )
             when (selectedTab) {
-                HomeTab.Trending -> when (selectedSource) {
+                HomeTab.Home -> when (selectedSource) {
                     TrendingSource.GitHub -> trendingViewModel.fetchData(isRefresh = true)
                     TrendingSource.HackerNews -> hnViewModel?.refresh()
                     TrendingSource.ProductHunt -> phViewModel?.refresh()
@@ -284,12 +284,12 @@ fun HomeScreen(
         val barItems = buildList {
             add(
                 HomeBarItem(
-                    key = HomeTab.Trending,
+                    key = HomeTab.Home,
                     iconSelected = Icons.Filled.Home,
                     iconUnselected = Icons.Outlined.Home,
                     label = stringResource(Res.string.home_title),
-                    selected = selectedTab == HomeTab.Trending,
-                    onClick = { switchTo(HomeTab.Trending) },
+                    selected = selectedTab == HomeTab.Home,
+                    onClick = { switchTo(HomeTab.Home) },
                 )
             )
             add(
@@ -356,7 +356,7 @@ fun HomeScreen(
                     // 而外面的实例是「当前选中才创建」，此刻已是 null，直接用会崩。
                     // viewModel() 取的是同一个 ViewModelStore 里的同一实例，不会多创建。
                     when (tab) {
-                        HomeTab.Trending -> Column(modifier = contentModifier) {
+                        HomeTab.Home -> Column(modifier = contentModifier) {
                             TrendingSourceTabs(
                                 selected = selectedSource,
                                 onSelect = { source ->

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -6,6 +6,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -23,8 +26,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.RichTooltip
 import androidx.compose.material3.Tab
@@ -34,6 +35,7 @@ import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -72,6 +74,7 @@ import whl.trending.ai.chat.globalChatScreen
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.ChatModelsProvider
+import whl.trending.ai.ui.common.LocalContentBottomPadding
 import whl.trending.ai.ui.common.TrendingScaffold
 import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.ai.ui.digest.DigestPage
@@ -217,128 +220,160 @@ fun HomeScreen(
                 HomeTab.Chat -> Unit
             }
         },
-        bottomBar = {
-            // 双击当前 tab 触发下拉刷新（#38）：仅当两次点击都落在已选中的 tab 上才算，
-            // 双击未选中的 tab 只切换不刷新（切换会重置计时）
-            val doubleTapMillis = LocalViewConfiguration.current.doubleTapTimeoutMillis
-            var lastTapTime by remember { mutableStateOf(0L) }
-            val refreshCurrentTab = {
-                trackEvent(
-                    "tab_double_tap_refresh",
-                    mapOf("tab" to selectedTab.name.lowercase()),
-                )
-                when (selectedTab) {
-                    HomeTab.Trending -> when (selectedSource) {
-                        TrendingSource.GitHub -> trendingViewModel.fetchData(isRefresh = true)
-                        TrendingSource.HackerNews -> hnViewModel?.refresh()
-                        TrendingSource.ProductHunt -> phViewModel?.refresh()
-                    }
-                    HomeTab.Picks -> picksViewModel?.refresh()
-                    // 「我的」自带下拉刷新，Chat 不是落点：都不参与双击刷新
-                    HomeTab.Me, HomeTab.Chat -> Unit
+        // 底栏是浮在内容之上的胶囊，不占 Scaffold 的 bottomBar 槽位——占了内容就被顶上去，
+        // 拿不到「内容从底栏下面穿过去」的观感。
+    ) { innerPadding ->
+        // 只取顶部：底部留给悬浮底栏自己算（见 LocalContentBottomPadding），
+        // 内容层不做底部 padding，列表才能滚到底栏之下。
+        val contentModifier = Modifier.padding(top = innerPadding.calculateTopPadding())
+        val barBottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+        val contentBottomPadding = barBottomInset + FloatingBarHeight + FloatingBarBottomMargin * 2
+
+        val doubleTapMillis = LocalViewConfiguration.current.doubleTapTimeoutMillis
+        var lastTapTime by remember { mutableStateOf(0L) }
+        // 双击当前 tab 触发下拉刷新（#38）：仅当两次点击都落在已选中的 tab 上才算，
+        // 双击未选中的 tab 只切换不刷新（切换会重置计时）
+        val refreshCurrentTab = {
+            trackEvent(
+                "tab_double_tap_refresh",
+                mapOf("tab" to selectedTab.name.lowercase()),
+            )
+            when (selectedTab) {
+                HomeTab.Trending -> when (selectedSource) {
+                    TrendingSource.GitHub -> trendingViewModel.fetchData(isRefresh = true)
+                    TrendingSource.HackerNews -> hnViewModel?.refresh()
+                    TrendingSource.ProductHunt -> phViewModel?.refresh()
                 }
+                HomeTab.Picks -> picksViewModel?.refresh()
+                // 「我的」自带下拉刷新，Chat 不是落点：都不参与双击刷新
+                HomeTab.Me, HomeTab.Chat -> Unit
             }
-            val switchTo = { tab: HomeTab ->
-                if (selectedTab != tab) {
-                    trackEvent("tab_switch", mapOf("tab" to tab.name.lowercase()))
-                    selectedTabName = tab.name
-                    lastTapTime = 0L
+        }
+        val switchTo = { tab: HomeTab ->
+            if (selectedTab != tab) {
+                trackEvent("tab_switch", mapOf("tab" to tab.name.lowercase()))
+                selectedTabName = tab.name
+                lastTapTime = 0L
+            } else {
+                val now = Clock.System.now().toEpochMilliseconds()
+                if (now - lastTapTime <= doubleTapMillis) {
+                    refreshCurrentTab()
+                    lastTapTime = 0L // 已触发一次，三连击不重复刷新
                 } else {
-                    val now = Clock.System.now().toEpochMilliseconds()
-                    if (now - lastTapTime <= doubleTapMillis) {
-                        refreshCurrentTab()
-                        lastTapTime = 0L // 已触发一次，三连击不重复刷新
-                    } else {
-                        lastTapTime = now
-                    }
+                    lastTapTime = now
                 }
             }
-            NavigationBar {
-                NavigationBarItem(
+        }
+
+        val barItems = buildList {
+            add(
+                HomeBarItem(
+                    key = HomeTab.Trending,
+                    icon = Icons.AutoMirrored.Filled.TrendingUp,
+                    label = stringResource(Res.string.trending_title),
                     selected = selectedTab == HomeTab.Trending,
                     onClick = { switchTo(HomeTab.Trending) },
-                    icon = { Icon(Icons.AutoMirrored.Filled.TrendingUp, contentDescription = null) },
-                    label = { Text(stringResource(Res.string.trending_title)) }
                 )
-                NavigationBarItem(
+            )
+            add(
+                HomeBarItem(
+                    key = HomeTab.Picks,
+                    icon = Icons.Default.Star,
+                    label = stringResource(Res.string.picks_title),
                     selected = selectedTab == HomeTab.Picks,
                     onClick = { switchTo(HomeTab.Picks) },
-                    icon = { Icon(Icons.Default.Star, contentDescription = null) },
-                    label = { Text(stringResource(Res.string.picks_title)) }
                 )
-                // 聊天未接入的平台（iOS）隐藏该项，底栏退化成三项
-                if (globalChatScreen != null) {
-                    NavigationBarItem(
+            )
+            // 聊天未接入的平台（iOS）隐藏该项，底栏退化成三项
+            if (globalChatScreen != null) {
+                add(
+                    HomeBarItem(
+                        key = HomeTab.Chat,
+                        icon = Icons.Default.AutoAwesome,
+                        label = stringResource(Res.string.chat_title),
                         // 选中态不给它：点击只是推一页，回来后仍在原 tab
                         selected = false,
                         onClick = {
                             trackEvent("tab_switch", mapOf("tab" to HomeTab.Chat.name.lowercase()))
                             onNavigateToChat()
                         },
-                        icon = { Icon(Icons.Default.AutoAwesome, contentDescription = null) },
-                        label = { Text(stringResource(Res.string.chat_title)) }
                     )
-                }
-                NavigationBarItem(
+                )
+            }
+            add(
+                HomeBarItem(
+                    key = HomeTab.Me,
+                    icon = Icons.Default.AccountCircle,
+                    label = stringResource(Res.string.me_title),
                     selected = selectedTab == HomeTab.Me,
                     onClick = { switchTo(HomeTab.Me) },
-                    icon = { Icon(Icons.Default.AccountCircle, contentDescription = null) },
-                    label = { Text(stringResource(Res.string.me_title)) }
                 )
-            }
+            )
         }
-    ) { innerPadding ->
-        when (selectedTab) {
-            HomeTab.Trending -> Column(modifier = Modifier.padding(innerPadding)) {
-                TrendingSourceTabs(
-                    selected = selectedSource,
-                    onSelect = { source ->
-                        if (source != selectedSource) {
-                            trackEvent(
-                                "trending_source_switch",
-                                mapOf("source" to source.name.lowercase()),
+
+        Box(modifier = Modifier.fillMaxSize()) {
+            CompositionLocalProvider(LocalContentBottomPadding provides contentBottomPadding) {
+                when (selectedTab) {
+                    HomeTab.Trending -> Column(modifier = contentModifier) {
+                        TrendingSourceTabs(
+                            selected = selectedSource,
+                            onSelect = { source ->
+                                if (source != selectedSource) {
+                                    trackEvent(
+                                        "trending_source_switch",
+                                        mapOf("source" to source.name.lowercase()),
+                                    )
+                                    selectedSourceName = source.name
+                                    globalSettingsManager.setTrendingSource(source.name)
+                                }
+                            },
+                        )
+                        when (selectedSource) {
+                            TrendingSource.GitHub -> TrendingScreen(
+                                onNavigateToDetail = onNavigateToDetail,
+                                showFilterSheet = showFilterSheet,
+                                onDismissFilterSheet = { showFilterSheet = false },
+                                showHistorySheet = showHistorySheet,
+                                onDismissHistorySheet = { showHistorySheet = false },
+                                viewModel = trendingViewModel
                             )
-                            selectedSourceName = source.name
-                            globalSettingsManager.setTrendingSource(source.name)
+                            TrendingSource.HackerNews -> FeedScreen(
+                                viewModel = hnViewModel!!,
+                                onOpenUrl = onOpenUrl,
+                                onOpenDigest = onOpenDigest
+                            )
+                            TrendingSource.ProductHunt -> FeedScreen(
+                                viewModel = phViewModel!!,
+                                onOpenUrl = onOpenUrl
+                            )
                         }
-                    },
-                )
-                when (selectedSource) {
-                    TrendingSource.GitHub -> TrendingScreen(
+                    }
+                    HomeTab.Picks -> PicksScreen(
                         onNavigateToDetail = onNavigateToDetail,
-                        showFilterSheet = showFilterSheet,
-                        onDismissFilterSheet = { showFilterSheet = false },
-                        showHistorySheet = showHistorySheet,
-                        onDismissHistorySheet = { showHistorySheet = false },
-                        viewModel = trendingViewModel
-                    )
-                    TrendingSource.HackerNews -> FeedScreen(
-                        viewModel = hnViewModel!!,
                         onOpenUrl = onOpenUrl,
+                        onNavigateToSubscribe = onNavigateToSubscribe,
+                        modifier = contentModifier,
+                        viewModel = picksViewModel!!,
                         onOpenDigest = onOpenDigest
                     )
-                    TrendingSource.ProductHunt -> FeedScreen(
-                        viewModel = phViewModel!!,
-                        onOpenUrl = onOpenUrl
+                    HomeTab.Me -> ProfileScreen(
+                        modifier = contentModifier,
+                        onNavigateToGithubProfile = onNavigateToGithubProfile,
+                        onNavigateToFavorites = onNavigateToFavorites,
                     )
+                    HomeTab.Chat -> Unit
                 }
             }
-            HomeTab.Picks -> PicksScreen(
-                onNavigateToDetail = onNavigateToDetail,
-                onOpenUrl = onOpenUrl,
-                onNavigateToSubscribe = onNavigateToSubscribe,
-                modifier = Modifier.padding(innerPadding),
-                viewModel = picksViewModel!!,
-                onOpenDigest = onOpenDigest
+
+            HomeFloatingBar(
+                items = barItems,
+                onOpenSettings = onNavigateToSettings,
+                onOpenAbout = onNavigateToAbout,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = barBottomInset + FloatingBarBottomMargin),
             )
-            HomeTab.Me -> ProfileScreen(
-                modifier = Modifier.padding(innerPadding),
-                onNavigateToGithubProfile = onNavigateToGithubProfile,
-                onNavigateToFavorites = onNavigateToFavorites,
-                onNavigateToSettings = onNavigateToSettings,
-                onNavigateToAbout = onNavigateToAbout,
-            )
-            HomeTab.Chat -> Unit
         }
     }
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -12,13 +12,17 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.TrendingUp
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.FiberNew
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Whatshot
+import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material.icons.outlined.StarOutline
+import androidx.compose.material.icons.outlined.Whatshot
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledIconToggleButton
@@ -269,7 +273,8 @@ fun HomeScreen(
             add(
                 HomeBarItem(
                     key = HomeTab.Trending,
-                    icon = Icons.AutoMirrored.Filled.TrendingUp,
+                    iconSelected = Icons.Filled.Whatshot,
+                    iconUnselected = Icons.Outlined.Whatshot,
                     label = stringResource(Res.string.trending_title),
                     selected = selectedTab == HomeTab.Trending,
                     onClick = { switchTo(HomeTab.Trending) },
@@ -278,7 +283,8 @@ fun HomeScreen(
             add(
                 HomeBarItem(
                     key = HomeTab.Picks,
-                    icon = Icons.Default.Star,
+                    iconSelected = Icons.Filled.Star,
+                    iconUnselected = Icons.Outlined.StarOutline,
                     label = stringResource(Res.string.picks_title),
                     selected = selectedTab == HomeTab.Picks,
                     onClick = { switchTo(HomeTab.Picks) },
@@ -289,7 +295,8 @@ fun HomeScreen(
                 add(
                     HomeBarItem(
                         key = HomeTab.Chat,
-                        icon = Icons.Default.AutoAwesome,
+                        iconSelected = Icons.Filled.AutoAwesome,
+                        iconUnselected = Icons.Outlined.AutoAwesome,
                         label = stringResource(Res.string.chat_title),
                         // 选中态不给它：点击只是推一页，回来后仍在原 tab
                         selected = false,
@@ -303,7 +310,8 @@ fun HomeScreen(
             add(
                 HomeBarItem(
                     key = HomeTab.Me,
-                    icon = Icons.Default.AccountCircle,
+                    iconSelected = Icons.Filled.AccountCircle,
+                    iconUnselected = Icons.Outlined.AccountCircle,
                     label = stringResource(Res.string.me_title),
                     selected = selectedTab == HomeTab.Me,
                     onClick = { switchTo(HomeTab.Me) },

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -24,17 +24,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.ChatBubble
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.FiberNew
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.Whatshot
-import androidx.compose.material.icons.outlined.AccountCircle
-import androidx.compose.material.icons.outlined.AutoAwesome
-import androidx.compose.material.icons.outlined.StarOutline
-import androidx.compose.material.icons.outlined.Whatshot
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.outlined.ChatBubbleOutline
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledIconToggleButton
@@ -287,8 +285,8 @@ fun HomeScreen(
             add(
                 HomeBarItem(
                     key = HomeTab.Trending,
-                    iconSelected = Icons.Filled.Whatshot,
-                    iconUnselected = Icons.Outlined.Whatshot,
+                    iconSelected = Icons.Filled.Home,
+                    iconUnselected = Icons.Outlined.Home,
                     label = stringResource(Res.string.trending_title),
                     selected = selectedTab == HomeTab.Trending,
                     onClick = { switchTo(HomeTab.Trending) },
@@ -297,8 +295,8 @@ fun HomeScreen(
             add(
                 HomeBarItem(
                     key = HomeTab.Picks,
-                    iconSelected = Icons.Filled.Star,
-                    iconUnselected = Icons.Outlined.StarOutline,
+                    iconSelected = KidStarFilled,
+                    iconUnselected = KidStarOutlined,
                     label = stringResource(Res.string.picks_title),
                     selected = selectedTab == HomeTab.Picks,
                     onClick = { switchTo(HomeTab.Picks) },
@@ -309,8 +307,10 @@ fun HomeScreen(
                 add(
                     HomeBarItem(
                         key = HomeTab.Chat,
-                        iconSelected = Icons.Filled.AutoAwesome,
-                        iconUnselected = Icons.Outlined.AutoAwesome,
+                        iconSelected = Icons.Filled.ChatBubble,
+                        // Outlined.ChatBubble 仍是实心气泡，空心的那个叫 ChatBubbleOutline；
+                        // Chat 永远不进选中态，露出的就是这一个
+                        iconUnselected = Icons.Outlined.ChatBubbleOutline,
                         label = stringResource(Res.string.chat_title),
                         // 选中态不给它：点击只是推一页，回来后仍在原 tab
                         selected = false,
@@ -324,8 +324,8 @@ fun HomeScreen(
             add(
                 HomeBarItem(
                     key = HomeTab.Me,
-                    iconSelected = Icons.Filled.AccountCircle,
-                    iconUnselected = Icons.Outlined.AccountCircle,
+                    iconSelected = Icons.Filled.Person,
+                    iconUnselected = Icons.Outlined.Person,
                     label = stringResource(Res.string.me_title),
                     selected = selectedTab == HomeTab.Me,
                     onClick = { switchTo(HomeTab.Me) },

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -1,5 +1,12 @@
 package whl.trending.ai.ui.home
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -321,55 +328,76 @@ fun HomeScreen(
 
         Box(modifier = Modifier.fillMaxSize()) {
             CompositionLocalProvider(LocalContentBottomPadding provides contentBottomPadding) {
-                when (selectedTab) {
-                    HomeTab.Trending -> Column(modifier = contentModifier) {
-                        TrendingSourceTabs(
-                            selected = selectedSource,
-                            onSelect = { source ->
-                                if (source != selectedSource) {
-                                    trackEvent(
-                                        "trending_source_switch",
-                                        mapOf("source" to source.name.lowercase()),
-                                    )
-                                    selectedSourceName = source.name
-                                    globalSettingsManager.setTrendingSource(source.name)
-                                }
-                            },
-                        )
-                        when (selectedSource) {
-                            TrendingSource.GitHub -> TrendingScreen(
-                                onNavigateToDetail = onNavigateToDetail,
-                                showFilterSheet = showFilterSheet,
-                                onDismissFilterSheet = { showFilterSheet = false },
-                                showHistorySheet = showHistorySheet,
-                                onDismissHistorySheet = { showHistorySheet = false },
-                                viewModel = trendingViewModel
-                            )
-                            TrendingSource.HackerNews -> FeedScreen(
-                                viewModel = hnViewModel!!,
-                                onOpenUrl = onOpenUrl,
-                                onOpenDigest = onOpenDigest
-                            )
-                            TrendingSource.ProductHunt -> FeedScreen(
-                                viewModel = phViewModel!!,
-                                onOpenUrl = onOpenUrl
-                            )
+                // 切 tab 的方向性转场：新页从前进方向滑入 1/8 屏、旧页往反方向滑出，各配 200ms
+                // 淡入淡出。位移量、时长与方向判定照搬 Echo 的 NavHost enter/exitTransition；
+                // 差别只在承载方式——它的 tab 是 NavHost 目的地，我们的 tab 是状态，等价物是
+                // AnimatedContent。
+                AnimatedContent(
+                    targetState = selectedTab,
+                    transitionSpec = {
+                        if (targetState.ordinal > initialState.ordinal) {
+                            slideInHorizontally { it / 8 } + fadeIn(tween(200)) togetherWith
+                                slideOutHorizontally { -it / 8 } + fadeOut(tween(200))
+                        } else {
+                            slideInHorizontally { -it / 8 } + fadeIn(tween(200)) togetherWith
+                                slideOutHorizontally { it / 8 } + fadeOut(tween(200))
                         }
+                    },
+                    label = "homeTabContent",
+                ) { tab ->
+                    // 各页在这里自取 ViewModel，不用外面那几个可空的：转场期间旧页仍在组合树里，
+                    // 而外面的实例是「当前选中才创建」，此刻已是 null，直接用会崩。
+                    // viewModel() 取的是同一个 ViewModelStore 里的同一实例，不会多创建。
+                    when (tab) {
+                        HomeTab.Trending -> Column(modifier = contentModifier) {
+                            TrendingSourceTabs(
+                                selected = selectedSource,
+                                onSelect = { source ->
+                                    if (source != selectedSource) {
+                                        trackEvent(
+                                            "trending_source_switch",
+                                            mapOf("source" to source.name.lowercase()),
+                                        )
+                                        selectedSourceName = source.name
+                                        globalSettingsManager.setTrendingSource(source.name)
+                                    }
+                                },
+                            )
+                            when (selectedSource) {
+                                TrendingSource.GitHub -> TrendingScreen(
+                                    onNavigateToDetail = onNavigateToDetail,
+                                    showFilterSheet = showFilterSheet,
+                                    onDismissFilterSheet = { showFilterSheet = false },
+                                    showHistorySheet = showHistorySheet,
+                                    onDismissHistorySheet = { showHistorySheet = false },
+                                    viewModel = trendingViewModel
+                                )
+                                TrendingSource.HackerNews -> FeedScreen(
+                                    viewModel = viewModel(key = "hackernews") { FeedViewModel("hackernews") },
+                                    onOpenUrl = onOpenUrl,
+                                    onOpenDigest = onOpenDigest
+                                )
+                                TrendingSource.ProductHunt -> FeedScreen(
+                                    viewModel = viewModel(key = "producthunt") { FeedViewModel("producthunt") },
+                                    onOpenUrl = onOpenUrl
+                                )
+                            }
+                        }
+                        HomeTab.Picks -> PicksScreen(
+                            onNavigateToDetail = onNavigateToDetail,
+                            onOpenUrl = onOpenUrl,
+                            onNavigateToSubscribe = onNavigateToSubscribe,
+                            modifier = contentModifier,
+                            viewModel = viewModel { PicksViewModel() },
+                            onOpenDigest = onOpenDigest
+                        )
+                        HomeTab.Me -> ProfileScreen(
+                            modifier = contentModifier,
+                            onNavigateToGithubProfile = onNavigateToGithubProfile,
+                            onNavigateToFavorites = onNavigateToFavorites,
+                        )
+                        HomeTab.Chat -> Unit
                     }
-                    HomeTab.Picks -> PicksScreen(
-                        onNavigateToDetail = onNavigateToDetail,
-                        onOpenUrl = onOpenUrl,
-                        onNavigateToSubscribe = onNavigateToSubscribe,
-                        modifier = contentModifier,
-                        viewModel = picksViewModel!!,
-                        onOpenDigest = onOpenDigest
-                    )
-                    HomeTab.Me -> ProfileScreen(
-                        modifier = contentModifier,
-                        onNavigateToGithubProfile = onNavigateToGithubProfile,
-                        onNavigateToFavorites = onNavigateToFavorites,
-                    )
-                    HomeTab.Chat -> Unit
                 }
             }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -2,37 +2,37 @@ package whl.trending.ai.ui.home
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.TrendingUp
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.AutoAwesome
-import androidx.compose.material.icons.filled.FiberNew
 import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.FiberNew
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.automirrored.filled.TrendingUp
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.LoadingIndicator
-import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FilledIconToggleButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.FilledIconToggleButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.RichTooltip
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -42,74 +42,80 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import coil3.compose.AsyncImage
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
-import trendingai.shared.generated.resources.picks_title
-import trendingai.shared.generated.resources.hackernews_title
-import trendingai.shared.generated.resources.producthunt_title
 import trendingai.shared.generated.resources.app_name
-import trendingai.shared.generated.resources.filter_new_only
-import trendingai.shared.generated.resources.new_only_hint
-import trendingai.shared.generated.resources.icon_producthunt_dark
-import trendingai.shared.generated.resources.icon_producthunt_light
 import trendingai.shared.generated.resources.batch_am
 import trendingai.shared.generated.resources.batch_pm
+import trendingai.shared.generated.resources.chat_title
+import trendingai.shared.generated.resources.filter_new_only
+import trendingai.shared.generated.resources.hackernews_title
 import trendingai.shared.generated.resources.history_trending
+import trendingai.shared.generated.resources.icon_producthunt_dark
+import trendingai.shared.generated.resources.icon_producthunt_light
+import trendingai.shared.generated.resources.new_only_hint
 import trendingai.shared.generated.resources.period_daily
 import trendingai.shared.generated.resources.period_monthly
 import trendingai.shared.generated.resources.period_weekly
-import trendingai.shared.generated.resources.account_title
-import whl.trending.ai.auth.AuthState
-import whl.trending.ai.auth.globalAuthManager
+import trendingai.shared.generated.resources.picks_title
+import trendingai.shared.generated.resources.producthunt_title
+import trendingai.shared.generated.resources.me_title
+import trendingai.shared.generated.resources.trending_title
 import whl.trending.ai.chat.globalChatScreen
+import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.ChatModelsProvider
 import whl.trending.ai.ui.common.TrendingScaffold
 import whl.trending.ai.ui.common.TrendingTopAppBar
+import whl.trending.ai.ui.digest.DigestPage
 import whl.trending.ai.ui.feed.FeedScreen
 import whl.trending.ai.ui.feed.FeedViewModel
 import whl.trending.ai.ui.picks.PicksScreen
 import whl.trending.ai.ui.picks.PicksViewModel
-import whl.trending.ai.ui.digest.DigestPage
-import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.ui.profile.ProfileScreen
 import whl.trending.ai.ui.trending.TrendingScreen
 import whl.trending.ai.ui.trending.TrendingViewModel
 import kotlin.time.Clock
 
-enum class HomeTab {
-    GitHub, HackerNews, ProductHunt, Picks;
-
-    companion object {
-        /** 解析持久化的 tab name；非法值（枚举改名、脏数据）回落 GitHub */
-        fun fromNameOrDefault(name: String): HomeTab =
-            entries.firstOrNull { it.name == name } ?: GitHub
-    }
-}
-
+/**
+ * 首页骨架：底栏四项（Trending / Picks / AI 对话 / 我的）。
+ *
+ * Trending 内含 GitHub / Hacker News / Product Hunt 三个子源，用 [PrimaryTabRow] 切换——
+ * 只点击、不横滑：三个源各自有下拉刷新与横向可滚内容，再叠一层横向手势会互相抢。
+ *
+ * AI 对话是入口不是落点：点它直接推全屏聊天页，底栏选中态仍留在原 tab（见 [HomeTab.Chat]）。
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
-    onNavigateToAccount: () -> Unit,
     onNavigateToDetail: (owner: String, repo: String) -> Unit,
     onNavigateToChat: () -> Unit = {},
     onOpenUrl: (url: String) -> Unit = {},
     onNavigateToSubscribe: () -> Unit = {},
-    onOpenDigest: (DigestPage) -> Unit = {}
+    onOpenDigest: (DigestPage) -> Unit = {},
+    onNavigateToGithubProfile: () -> Unit = {},
+    onNavigateToFavorites: () -> Unit = {},
+    onNavigateToSettings: () -> Unit = {},
+    onNavigateToAbout: () -> Unit = {},
 ) {
     // 冷启动进入设置页选的默认 tab；仅初始值，会话内切换与 rememberSaveable 恢复不受影响
     var selectedTabName by rememberSaveable {
-        mutableStateOf(HomeTab.fromNameOrDefault(globalSettingsManager.currentDefaultHomeTab()).name)
+        mutableStateOf(HomeTab.defaultFromName(globalSettingsManager.currentDefaultHomeTab()).name)
     }
     val selectedTab = HomeTab.fromNameOrDefault(selectedTabName)
+
+    // 子源与 tab 不同：每次切换都回写，冷启动回到上次看的那个源
+    var selectedSourceName by rememberSaveable {
+        mutableStateOf(TrendingSource.fromNameOrDefault(globalSettingsManager.currentTrendingSource()).name)
+    }
+    val selectedSource = TrendingSource.fromNameOrDefault(selectedSourceName)
 
     // 组合树外的切 tab 请求（通知点击深链等）：置位状态可跨冷启动等到这里再消费
     LaunchedEffect(Unit) {
@@ -133,20 +139,17 @@ fun HomeScreen(
     val picksUiState = picksViewModel?.uiState?.collectAsState()?.value
 
     // HN / PH 同样按需创建；提升到这里是为了 bottomBar 双击刷新能拿到同一实例
-    val hnViewModel: FeedViewModel? = if (selectedTab == HomeTab.HackerNews) {
+    val onTrendingTab = selectedTab == HomeTab.Trending
+    val hnViewModel: FeedViewModel? = if (onTrendingTab && selectedSource == TrendingSource.HackerNews) {
         viewModel(key = "hackernews") { FeedViewModel("hackernews") }
     } else null
-    val phViewModel: FeedViewModel? = if (selectedTab == HomeTab.ProductHunt) {
+    val phViewModel: FeedViewModel? = if (onTrendingTab && selectedSource == TrendingSource.ProductHunt) {
         viewModel(key = "producthunt") { FeedViewModel("producthunt") }
     } else null
 
-    val authManager = globalAuthManager
-    val authState by authManager.authState.collectAsState()
-    val userAvatarUrl by globalSettingsManager.userAvatarUrl.collectAsState(null)
-
     // syncMe（建档 + 头像/GitHub 身份/isPro 缓存）不在此触发——已随收藏同步一起挂在 App 根部
-    // （见 App.kt）：登录常发生在账户页，Home 的 LaunchedEffect 彼时已随 NavEntry 销毁，
-    // 挂这里会漏掉「账户页登录」主路径（isPro 不回写，Pro 用户被当免费档，2026-08-03 必现修复）。
+    // （见 App.kt）：登录常发生在「我的」tab，Home 的 LaunchedEffect 彼时仍在，但登录也可能
+    // 发生在被推到栈顶的子页，挂这里会漏掉那条路径（isPro 不回写，Pro 用户被当免费档）。
 
     // 预热聊天模型目录：让选择器 chip 在用户首次进入 chat 前就绪，避免冷首拉导致 chip 迟迟不出现。
     LaunchedEffect(Unit) {
@@ -158,72 +161,60 @@ fun HomeScreen(
     TrendingScaffold(
         topBar = {
             when (selectedTab) {
-                HomeTab.GitHub -> TrendingTopBar(
-                    selectedPeriod = trendingUiState.selectedPeriod,
-                    selectedLanguage = trendingUiState.selectedLanguage,
-                    selectedDate = trendingUiState.selectedDate,
-                    selectedBatch = trendingUiState.selectedBatch,
-                    newOnly = trendingUiState.newOnly,
-                    onToggleNewOnly = { trendingViewModel.toggleNewOnly() },
-                                onTitleClick = { showFilterSheet = true },
-                    onHistoryClick = { showHistorySheet = true },
-                    authState = authState,
-                    userAvatarUrl = userAvatarUrl,
-                    onNavigateToAccount = onNavigateToAccount,
+                HomeTab.Trending -> when (selectedSource) {
+                    TrendingSource.GitHub -> TrendingTopBar(
+                        selectedPeriod = trendingUiState.selectedPeriod,
+                        selectedLanguage = trendingUiState.selectedLanguage,
+                        selectedDate = trendingUiState.selectedDate,
+                        selectedBatch = trendingUiState.selectedBatch,
+                        newOnly = trendingUiState.newOnly,
+                        onToggleNewOnly = { trendingViewModel.toggleNewOnly() },
+                        onTitleClick = { showFilterSheet = true },
+                        onHistoryClick = { showHistorySheet = true },
+                    )
+                    TrendingSource.HackerNews -> {
+                        val isDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
+                        FeedTopBar(
+                            title = stringResource(Res.string.hackernews_title),
+                            navigationIcon = {
+                                Icon(
+                                    imageVector = hackerNewsIcon(if (isDark) HackerNewsOrange else Color.Black),
+                                    contentDescription = "Hacker News",
+                                    modifier = Modifier.size(24.dp),
+                                    tint = Color.Unspecified
+                                )
+                            },
+                        )
+                    }
+                    TrendingSource.ProductHunt -> {
+                        val isDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
+                        FeedTopBar(
+                            title = stringResource(Res.string.producthunt_title),
+                            navigationIcon = {
+                                Icon(
+                                    painter = painterResource(
+                                        if (isDark) Res.drawable.icon_producthunt_dark
+                                        else Res.drawable.icon_producthunt_light
+                                    ),
+                                    contentDescription = "Product Hunt",
+                                    modifier = Modifier.size(24.dp),
+                                    tint = Color.Unspecified
+                                )
+                            },
+                        )
+                    }
+                }
+                HomeTab.Picks -> PicksTopBar(date = picksUiState?.picks?.metadata?.date)
+                HomeTab.Me -> TrendingTopAppBar(
+                    title = {
+                        Text(
+                            text = stringResource(Res.string.me_title),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                    },
                 )
-                HomeTab.Picks -> PicksTopBar(
-                    date = picksUiState?.picks?.metadata?.date,
-                                authState = authState,
-                    userAvatarUrl = userAvatarUrl,
-                    onNavigateToAccount = onNavigateToAccount,
-                )
-                HomeTab.HackerNews -> {
-                    val isDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
-                    FeedTopBar(
-                        title = stringResource(Res.string.hackernews_title),
-                        navigationIcon = {
-                            Icon(
-                                imageVector = hackerNewsIcon(if (isDark) HackerNewsOrange else Color.Black),
-                                contentDescription = "Hacker News",
-                                modifier = Modifier.size(24.dp),
-                                tint = Color.Unspecified
-                            )
-                        },
-                                        authState = authState,
-                        userAvatarUrl = userAvatarUrl,
-                        onNavigateToAccount = onNavigateToAccount,
-                    )
-                }
-                HomeTab.ProductHunt -> {
-                    val isDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
-                    FeedTopBar(
-                        title = stringResource(Res.string.producthunt_title),
-                        navigationIcon = {
-                            Icon(
-                                painter = painterResource(
-                                    if (isDark) Res.drawable.icon_producthunt_dark
-                                    else Res.drawable.icon_producthunt_light
-                                ),
-                                contentDescription = "Product Hunt",
-                                modifier = Modifier.size(24.dp),
-                                tint = Color.Unspecified
-                            )
-                        },
-                                        authState = authState,
-                        userAvatarUrl = userAvatarUrl,
-                        onNavigateToAccount = onNavigateToAccount,
-                    )
-                }
-            }
-        },
-        floatingActionButton = {
-            if (globalChatScreen != null) {
-                FloatingActionButton(onClick = onNavigateToChat) {
-                    Icon(
-                        imageVector = Icons.Default.AutoAwesome,
-                        contentDescription = "AI Assistant"
-                    )
-                }
+                // 选中态永不为 Chat（点击即推聊天页），这里只是穷尽 when
+                HomeTab.Chat -> Unit
             }
         },
         bottomBar = {
@@ -232,12 +223,19 @@ fun HomeScreen(
             val doubleTapMillis = LocalViewConfiguration.current.doubleTapTimeoutMillis
             var lastTapTime by remember { mutableStateOf(0L) }
             val refreshCurrentTab = {
-                trackEvent("tab_double_tap_refresh", mapOf("tab" to selectedTab.name.lowercase()))
+                trackEvent(
+                    "tab_double_tap_refresh",
+                    mapOf("tab" to selectedTab.name.lowercase()),
+                )
                 when (selectedTab) {
-                    HomeTab.GitHub -> trendingViewModel.fetchData(isRefresh = true)
-                    HomeTab.HackerNews -> hnViewModel?.refresh()
-                    HomeTab.ProductHunt -> phViewModel?.refresh()
+                    HomeTab.Trending -> when (selectedSource) {
+                        TrendingSource.GitHub -> trendingViewModel.fetchData(isRefresh = true)
+                        TrendingSource.HackerNews -> hnViewModel?.refresh()
+                        TrendingSource.ProductHunt -> phViewModel?.refresh()
+                    }
                     HomeTab.Picks -> picksViewModel?.refresh()
+                    // 「我的」自带下拉刷新，Chat 不是落点：都不参与双击刷新
+                    HomeTab.Me, HomeTab.Chat -> Unit
                 }
             }
             val switchTo = { tab: HomeTab ->
@@ -257,53 +255,74 @@ fun HomeScreen(
             }
             NavigationBar {
                 NavigationBarItem(
-                    selected = selectedTab == HomeTab.GitHub,
-                    onClick = { switchTo(HomeTab.GitHub) },
-                    icon = { Icon(Icons.AutoMirrored.Filled.TrendingUp, contentDescription = "GitHub") },
-                    label = { Text("GitHub") }
-                )
-                NavigationBarItem(
-                    selected = selectedTab == HomeTab.HackerNews,
-                    onClick = { switchTo(HomeTab.HackerNews) },
-                    icon = { Icon(HackerNewsYIcon, contentDescription = stringResource(Res.string.hackernews_title)) },
-                    label = { Text("HN") }
-                )
-                NavigationBarItem(
-                    selected = selectedTab == HomeTab.ProductHunt,
-                    onClick = { switchTo(HomeTab.ProductHunt) },
-                    icon = { Icon(ProductHuntPIcon, contentDescription = stringResource(Res.string.producthunt_title)) },
-                    label = { Text("PH") }
+                    selected = selectedTab == HomeTab.Trending,
+                    onClick = { switchTo(HomeTab.Trending) },
+                    icon = { Icon(Icons.AutoMirrored.Filled.TrendingUp, contentDescription = null) },
+                    label = { Text(stringResource(Res.string.trending_title)) }
                 )
                 NavigationBarItem(
                     selected = selectedTab == HomeTab.Picks,
                     onClick = { switchTo(HomeTab.Picks) },
-                    icon = { Icon(Icons.Default.Star, contentDescription = stringResource(Res.string.picks_title)) },
+                    icon = { Icon(Icons.Default.Star, contentDescription = null) },
                     label = { Text(stringResource(Res.string.picks_title)) }
+                )
+                // 聊天未接入的平台（iOS）隐藏该项，底栏退化成三项
+                if (globalChatScreen != null) {
+                    NavigationBarItem(
+                        // 选中态不给它：点击只是推一页，回来后仍在原 tab
+                        selected = false,
+                        onClick = {
+                            trackEvent("tab_switch", mapOf("tab" to HomeTab.Chat.name.lowercase()))
+                            onNavigateToChat()
+                        },
+                        icon = { Icon(Icons.Default.AutoAwesome, contentDescription = null) },
+                        label = { Text(stringResource(Res.string.chat_title)) }
+                    )
+                }
+                NavigationBarItem(
+                    selected = selectedTab == HomeTab.Me,
+                    onClick = { switchTo(HomeTab.Me) },
+                    icon = { Icon(Icons.Default.AccountCircle, contentDescription = null) },
+                    label = { Text(stringResource(Res.string.me_title)) }
                 )
             }
         }
     ) { innerPadding ->
         when (selectedTab) {
-            HomeTab.GitHub -> TrendingScreen(
-                onNavigateToDetail = onNavigateToDetail,
-                showFilterSheet = showFilterSheet,
-                onDismissFilterSheet = { showFilterSheet = false },
-                showHistorySheet = showHistorySheet,
-                onDismissHistorySheet = { showHistorySheet = false },
-                modifier = Modifier.padding(innerPadding),
-                viewModel = trendingViewModel
-            )
-            HomeTab.HackerNews -> FeedScreen(
-                modifier = Modifier.padding(innerPadding),
-                viewModel = hnViewModel!!,
-                onOpenUrl = onOpenUrl,
-                onOpenDigest = onOpenDigest
-            )
-            HomeTab.ProductHunt -> FeedScreen(
-                modifier = Modifier.padding(innerPadding),
-                viewModel = phViewModel!!,
-                onOpenUrl = onOpenUrl
-            )
+            HomeTab.Trending -> Column(modifier = Modifier.padding(innerPadding)) {
+                TrendingSourceTabs(
+                    selected = selectedSource,
+                    onSelect = { source ->
+                        if (source != selectedSource) {
+                            trackEvent(
+                                "trending_source_switch",
+                                mapOf("source" to source.name.lowercase()),
+                            )
+                            selectedSourceName = source.name
+                            globalSettingsManager.setTrendingSource(source.name)
+                        }
+                    },
+                )
+                when (selectedSource) {
+                    TrendingSource.GitHub -> TrendingScreen(
+                        onNavigateToDetail = onNavigateToDetail,
+                        showFilterSheet = showFilterSheet,
+                        onDismissFilterSheet = { showFilterSheet = false },
+                        showHistorySheet = showHistorySheet,
+                        onDismissHistorySheet = { showHistorySheet = false },
+                        viewModel = trendingViewModel
+                    )
+                    TrendingSource.HackerNews -> FeedScreen(
+                        viewModel = hnViewModel!!,
+                        onOpenUrl = onOpenUrl,
+                        onOpenDigest = onOpenDigest
+                    )
+                    TrendingSource.ProductHunt -> FeedScreen(
+                        viewModel = phViewModel!!,
+                        onOpenUrl = onOpenUrl
+                    )
+                }
+            }
             HomeTab.Picks -> PicksScreen(
                 onNavigateToDetail = onNavigateToDetail,
                 onOpenUrl = onOpenUrl,
@@ -312,9 +331,38 @@ fun HomeScreen(
                 viewModel = picksViewModel!!,
                 onOpenDigest = onOpenDigest
             )
+            HomeTab.Me -> ProfileScreen(
+                modifier = Modifier.padding(innerPadding),
+                onNavigateToGithubProfile = onNavigateToGithubProfile,
+                onNavigateToFavorites = onNavigateToFavorites,
+                onNavigateToSettings = onNavigateToSettings,
+                onNavigateToAbout = onNavigateToAbout,
+            )
+            HomeTab.Chat -> Unit
         }
     }
+}
 
+/** Trending 的三源子 tab。文案用各源全称，图标交给顶栏——一行三项不必再塞图标。 */
+@Composable
+private fun TrendingSourceTabs(
+    selected: TrendingSource,
+    onSelect: (TrendingSource) -> Unit,
+) {
+    PrimaryTabRow(selectedTabIndex = selected.ordinal) {
+        TrendingSource.entries.forEach { source ->
+            val label = when (source) {
+                TrendingSource.GitHub -> "GitHub"
+                TrendingSource.HackerNews -> stringResource(Res.string.hackernews_title)
+                TrendingSource.ProductHunt -> stringResource(Res.string.producthunt_title)
+            }
+            Tab(
+                selected = source == selected,
+                onClick = { onSelect(source) },
+                text = { Text(label, style = MaterialTheme.typography.titleSmall) },
+            )
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -328,9 +376,6 @@ private fun TrendingTopBar(
     onToggleNewOnly: () -> Unit,
     onTitleClick: () -> Unit,
     onHistoryClick: () -> Unit,
-    authState: AuthState,
-    userAvatarUrl: String?,
-    onNavigateToAccount: () -> Unit,
 ) {
     val periodLabel = when (selectedPeriod) {
         "daily" -> stringResource(Res.string.period_daily)
@@ -420,44 +465,13 @@ private fun TrendingTopBar(
             IconButton(onClick = onHistoryClick) {
                 Icon(Icons.Default.DateRange, contentDescription = stringResource(Res.string.history_trending))
             }
-            AccountAction(authState, userAvatarUrl, onNavigateToAccount)
         }
     )
 }
 
-/**
- * 顶栏账户入口：统一账户中心（Hub）的唯一入口，各 tab 顶栏共用。已登录且有头像显示头像，
- * 登录中显示加载态，其余（含未登录 / iOS 未接入）显示账户图标——点击一律进 Hub（内含设置与登录引导）。
- */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Composable
-private fun AccountAction(authState: AuthState, userAvatarUrl: String?, onClick: () -> Unit) {
-    IconButton(onClick = onClick, enabled = authState !is AuthState.LoggingIn) {
-        when {
-            authState is AuthState.LoggedIn && userAvatarUrl != null -> AsyncImage(
-                model = userAvatarUrl,
-                contentDescription = stringResource(Res.string.account_title),
-                modifier = Modifier.size(28.dp).clip(CircleShape)
-            )
-            authState is AuthState.LoggingIn -> LoadingIndicator(
-                modifier = Modifier.size(24.dp)
-            )
-            else -> Icon(
-                Icons.Default.AccountCircle,
-                contentDescription = stringResource(Res.string.account_title)
-            )
-        }
-    }
-}
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun PicksTopBar(
-    date: String?,
-    authState: AuthState,
-    userAvatarUrl: String?,
-    onNavigateToAccount: () -> Unit,
-) {
+private fun PicksTopBar(date: String?) {
     TrendingTopAppBar(
         title = {
             Column {
@@ -475,9 +489,6 @@ private fun PicksTopBar(
                 )
             }
         },
-        actions = {
-            AccountAction(authState, userAvatarUrl, onNavigateToAccount)
-        }
     )
 }
 
@@ -486,9 +497,6 @@ private fun PicksTopBar(
 private fun FeedTopBar(
     title: String,
     navigationIcon: @Composable () -> Unit,
-    authState: AuthState,
-    userAvatarUrl: String?,
-    onNavigateToAccount: () -> Unit,
 ) {
     TrendingTopAppBar(
         title = {
@@ -502,8 +510,5 @@ private fun FeedTopBar(
                 navigationIcon()
             }
         },
-        actions = {
-            AccountAction(authState, userAvatarUrl, onNavigateToAccount)
-        }
     )
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -85,7 +85,7 @@ import trendingai.shared.generated.resources.period_weekly
 import trendingai.shared.generated.resources.picks_title
 import trendingai.shared.generated.resources.producthunt_title
 import trendingai.shared.generated.resources.me_title
-import trendingai.shared.generated.resources.trending_title
+import trendingai.shared.generated.resources.home_title
 import whl.trending.ai.chat.globalChatScreen
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
@@ -287,7 +287,7 @@ fun HomeScreen(
                     key = HomeTab.Trending,
                     iconSelected = Icons.Filled.Home,
                     iconUnselected = Icons.Outlined.Home,
-                    label = stringResource(Res.string.trending_title),
+                    label = stringResource(Res.string.home_title),
                     selected = selectedTab == HomeTab.Trending,
                     onClick = { switchTo(HomeTab.Trending) },
                 )

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -412,10 +412,13 @@ fun HomeScreen(
                 items = barItems,
                 onOpenSettings = onNavigateToSettings,
                 onOpenAbout = onNavigateToAbout,
+                // 定高与内容底部留白同源（contentBottomPadding 也按它算），两者不能各算各的。
+                // 高度加在调用处而非组件内部，与 Echo 在 MainActivity 的写法一致。
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .padding(horizontal = 16.dp)
-                    .padding(bottom = barBottomInset + FloatingBarBottomMargin),
+                    .padding(bottom = barBottomInset + FloatingBarBottomMargin)
+                    .height(FloatingBarHeight),
             )
         }
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeTab.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeTab.kt
@@ -7,28 +7,29 @@ package whl.trending.ai.ui.home
  * 成为 [selectedTab][HomeScreen] 的取值，也不出现在「默认首页」可选项里（见 [defaultFromName]）。
  */
 enum class HomeTab {
-    Trending, Picks, Chat, Me;
+    Home, Picks, Chat, Me;
 
     companion object {
         /**
-         * 解析持久化的 tab name；非法值（枚举改名、脏数据）回落 [Trending]。
+         * 解析持久化的 tab name；非法值（枚举改名、脏数据）回落 [Home]。
          *
-         * 0.23 之前底栏是 GitHub / HackerNews / ProductHunt / Picks 四项，旧值里的三个源
-         * 名在此一并落到 Trending——它们现在是 Trending 的子源，语义上正是同一个落点。
+         * 存量值一律靠这条回落收口，不写迁移代码——回落目标就是第一个 tab 本身，落点不变：
+         * 0.23 之前的 "GitHub"/"HackerNews"/"ProductHunt"（现为 Home 的三个子源）、
+         * 0.23 的 "Trending"（本 tab 改名前的旧名），全都落到 Home。"Picks"/"Me" 名字没变，正常匹配。
          */
         fun fromNameOrDefault(name: String): HomeTab =
-            entries.firstOrNull { it.name == name } ?: Trending
+            entries.firstOrNull { it.name == name } ?: Home
 
         /** 可作为冷启动落点的 tab：[Chat] 只是入口，选它没有「停在那一页」的语义 */
         val defaultCandidates: List<HomeTab> get() = entries.filter { it != Chat }
 
         /** 按「默认首页」设置解析落点：在 [fromNameOrDefault] 基础上把 [Chat] 也视为非法 */
         fun defaultFromName(name: String): HomeTab =
-            fromNameOrDefault(name).takeIf { it != Chat } ?: Trending
+            fromNameOrDefault(name).takeIf { it != Chat } ?: Home
     }
 }
 
-/** Trending tab 内的三个数据源子 tab，仅点击切换、不支持横向滑动。 */
+/** 首页内的三个数据源子 tab，仅点击切换、不支持横向滑动。 */
 enum class TrendingSource {
     GitHub, HackerNews, ProductHunt;
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeTab.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeTab.kt
@@ -1,0 +1,40 @@
+package whl.trending.ai.ui.home
+
+/**
+ * 底栏一级 tab。
+ *
+ * [Chat] 是入口而非落点：点它直接推全屏聊天页，底栏选中态仍留在原 tab，因此它永远不会
+ * 成为 [selectedTab][HomeScreen] 的取值，也不出现在「默认首页」可选项里（见 [defaultFromName]）。
+ */
+enum class HomeTab {
+    Trending, Picks, Chat, Me;
+
+    companion object {
+        /**
+         * 解析持久化的 tab name；非法值（枚举改名、脏数据）回落 [Trending]。
+         *
+         * 0.23 之前底栏是 GitHub / HackerNews / ProductHunt / Picks 四项，旧值里的三个源
+         * 名在此一并落到 Trending——它们现在是 Trending 的子源，语义上正是同一个落点。
+         */
+        fun fromNameOrDefault(name: String): HomeTab =
+            entries.firstOrNull { it.name == name } ?: Trending
+
+        /** 可作为冷启动落点的 tab：[Chat] 只是入口，选它没有「停在那一页」的语义 */
+        val defaultCandidates: List<HomeTab> get() = entries.filter { it != Chat }
+
+        /** 按「默认首页」设置解析落点：在 [fromNameOrDefault] 基础上把 [Chat] 也视为非法 */
+        fun defaultFromName(name: String): HomeTab =
+            fromNameOrDefault(name).takeIf { it != Chat } ?: Trending
+    }
+}
+
+/** Trending tab 内的三个数据源子 tab，仅点击切换、不支持横向滑动。 */
+enum class TrendingSource {
+    GitHub, HackerNews, ProductHunt;
+
+    companion object {
+        /** 解析持久化的子源 name；非法值回落 [GitHub] */
+        fun fromNameOrDefault(name: String): TrendingSource =
+            entries.firstOrNull { it.name == name } ?: GitHub
+    }
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/KidStarIcons.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/KidStarIcons.kt
@@ -1,0 +1,48 @@
+package whl.trending.ai.ui.home
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.addPathNodes
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.unit.dp
+
+/**
+ * Material Symbols 的 kid_star（圆角星）实心/描边两态，用于底栏 Picks 项。
+ *
+ * Compose 自带的经典 Material Icons 集没有这个图标（只有 Star / StarOutline 那种尖角星），
+ * 所以按 [BrandIcons] 的做法自绘：path 原样取自 google/material-design-icons 仓库的
+ * `symbols/web/kid_star/materialsymbolsoutlined` 24px 版本，颜色交给 `Icon` 的 tint。
+ *
+ * Symbols 的 viewBox 是 `0 -960 960 960`——y 落在 -960..0，直接喂给 ImageVector 会整个跑到
+ * 画布外，因此把路径包进一个 `translationY = 960` 的 group 搬回 0..960。
+ */
+private const val KID_STAR_FILLED_PATH =
+    "m305-704 112-145q12-16 28.5-23.5T480-880q18 0 34.5 7.5T543-849l112 145 170 57q26 8 41 " +
+        "29.5t15 47.5q0 12-3.5 24T866-523L756-367l4 164q1 35-23 59t-56 24q-2 0-22-3l-179-50-179 " +
+        "50q-5 2-11 2.5t-11 .5q-32 0-56-24t-23-59l4-165L95-523q-8-11-11.5-23T80-570q0-25 " +
+        "14.5-46.5T135-647l170-57Z"
+
+private const val KID_STAR_OUTLINED_PATH =
+    "m305-704 112-145q12-16 28.5-23.5T480-880q18 0 34.5 7.5T543-849l112 145 170 57q26 8 41 " +
+        "29.5t15 47.5q0 12-3.5 24T866-523L756-367l4 164q1 35-23 59t-56 24q-2 0-22-3l-179-50-179 " +
+        "50q-5 2-11 2.5t-11 .5q-32 0-56-24t-23-59l4-165L95-523q-8-11-11.5-23T80-570q0-25 " +
+        "14.5-46.5T135-647l170-57Zm49 69-194 64 124 179-4 191 200-55 200 56-4-192 124-177-194-66-126-165-126 " +
+        "165Zm126 135Z"
+
+private fun kidStar(pathData: String): ImageVector = ImageVector.Builder(
+    defaultWidth = 24.dp,
+    defaultHeight = 24.dp,
+    viewportWidth = 960f,
+    viewportHeight = 960f,
+).apply {
+    group(translationY = 960f) {
+        addPath(pathData = addPathNodes(pathData), fill = SolidColor(Color.Black))
+    }
+}.build()
+
+/** kid_star 实心态（选中）。 */
+val KidStarFilled: ImageVector by lazy { kidStar(KID_STAR_FILLED_PATH) }
+
+/** kid_star 描边态（未选中）。 */
+val KidStarOutlined: ImageVector by lazy { kidStar(KID_STAR_OUTLINED_PATH) }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -46,6 +47,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import whl.trending.ai.ui.common.LocalContentBottomPadding
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.picks_label_action
@@ -203,7 +205,9 @@ private fun PicksList(
 ) {
     LazyColumn(
         modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(0.dp)
+        verticalArrangement = Arrangement.spacedBy(0.dp),
+        // 末条要能从悬浮底栏下面滚出来
+        contentPadding = PaddingValues(bottom = LocalContentBottomPadding.current),
     ) {
         // Newsletter 订阅入口（已订阅或手动关闭后隐藏）：把埋在设置深处的订阅提到每日回访的主场景
         if (showNewsletterBanner) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -19,8 +19,6 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -49,18 +47,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import whl.trending.ai.ui.common.LocalContentBottomPadding
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
-import trendingai.shared.generated.resources.about_us
 import trendingai.shared.generated.resources.account_github_entry
 import trendingai.shared.generated.resources.account_github_entry_desc
 import trendingai.shared.generated.resources.account_link_github
@@ -87,8 +86,6 @@ import trendingai.shared.generated.resources.profile_quota_reset_soon
 import trendingai.shared.generated.resources.profile_followers
 import trendingai.shared.generated.resources.profile_repos
 import trendingai.shared.generated.resources.profile_retry
-import trendingai.shared.generated.resources.settings
-import trendingai.shared.generated.resources.settings_entry_desc
 import trendingai.shared.generated.resources.sign_in
 import trendingai.shared.generated.resources.sign_out
 import trendingai.shared.generated.resources.sign_out_confirm
@@ -106,10 +103,9 @@ import whl.trending.ai.data.model.QuotaResponse
  * 个人中心：只讲「你是谁、你还剩多少额度、你收藏了什么」。
  *
  * 从上到下：身份区（含未登录引导）→ 套餐 & 用量（含升级 CTA）→ GitHub 主页入口卡
- * （仅 GitHub 用户）→ 收藏 / 设置 / 关于我们 三个入口 → 退出登录。
+ * （仅 GitHub 用户）→ 收藏 → 退出登录。
  *
- * 应用偏好已全部迁到 [SettingsScreen]，这里只留一个入口——本页与设置页各自单一职责，
- * 后续设置与关于挪进底栏扩展菜单时，本页只需摘掉这两行。
+ * 应用偏好全部在 [SettingsScreen]，入口挂在底栏的「⋯」扩展菜单上，本页不再重复。
  *
  * 本页是「我的」tab 的内容，不自带脚手架与顶栏：顶栏由 [HomeScreen] 统一提供，
  * 底栏要一直在，页面内套 Scaffold 会出现两层顶栏。
@@ -124,8 +120,6 @@ fun ProfileScreen(
     modifier: Modifier = Modifier,
     onNavigateToGithubProfile: () -> Unit,
     onNavigateToFavorites: () -> Unit = {},
-    onNavigateToSettings: () -> Unit = {},
-    onNavigateToAbout: () -> Unit = {},
 ) {
     val viewModel: ProfileViewModel = viewModel { ProfileViewModel() }
     val uiState by viewModel.uiState.collectAsState()
@@ -206,7 +200,10 @@ fun ProfileScreen(
         },
         modifier = modifier.fillMaxSize(),
     ) {
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(bottom = LocalContentBottomPadding.current),
+        ) {
             if (authSupported) {
                 // ① 身份区
                 item(key = "account_header") {
@@ -253,7 +250,8 @@ fun ProfileScreen(
                 item(key = "divider_top") { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
             }
 
-            // ④ 入口区：收藏 / 设置 / 关于我们
+            // ④ 收藏入口。设置与关于我们不在这里——它们挂在底栏的「⋯」扩展菜单上，
+                // 两处都放会变成同一个入口的两个按钮。
             item(key = "favorites") {
                 ListItem(
                     headlineContent = { Text(stringResource(Res.string.favorites)) },
@@ -261,30 +259,6 @@ fun ProfileScreen(
                     modifier = Modifier.clickable {
                         trackEvent("settings_favorites")
                         onNavigateToFavorites()
-                    }
-                )
-            }
-            item(key = "settings_entry") {
-                ListItem(
-                    headlineContent = { Text(stringResource(Res.string.settings)) },
-                    supportingContent = { Text(stringResource(Res.string.settings_entry_desc)) },
-                    leadingContent = { Icon(Icons.Default.Settings, null) },
-                    trailingContent = {
-                        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
-                    },
-                    modifier = Modifier.clickable {
-                        trackEvent("profile_open_settings")
-                        onNavigateToSettings()
-                    }
-                )
-            }
-            item(key = "about_us") {
-                ListItem(
-                    headlineContent = { Text(stringResource(Res.string.about_us)) },
-                    leadingContent = { Icon(Icons.Default.Info, null) },
-                    modifier = Modifier.clickable {
-                        trackEvent("settings_about")
-                        onNavigateToAbout()
                     }
                 )
             }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.AccountCircle
@@ -29,7 +28,6 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
@@ -76,10 +74,8 @@ import trendingai.shared.generated.resources.account_signed_out_prompt
 import trendingai.shared.generated.resources.account_signed_out_title
 import trendingai.shared.generated.resources.account_signin_for_more
 import trendingai.shared.generated.resources.account_tier_free
-import trendingai.shared.generated.resources.account_title
 import trendingai.shared.generated.resources.account_upgrade_cta
 import trendingai.shared.generated.resources.account_upgrade_hint
-import trendingai.shared.generated.resources.back
 import trendingai.shared.generated.resources.cancel
 import trendingai.shared.generated.resources.favorites
 import trendingai.shared.generated.resources.profile_load_failed
@@ -105,8 +101,6 @@ import whl.trending.ai.core.ProSponsor
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.QuotaResponse
-import whl.trending.ai.ui.common.TrendingScaffold
-import whl.trending.ai.ui.common.TrendingTopAppBar
 
 /**
  * 个人中心：只讲「你是谁、你还剩多少额度、你收藏了什么」。
@@ -115,7 +109,10 @@ import whl.trending.ai.ui.common.TrendingTopAppBar
  * （仅 GitHub 用户）→ 收藏 / 设置 / 关于我们 三个入口 → 退出登录。
  *
  * 应用偏好已全部迁到 [SettingsScreen]，这里只留一个入口——本页与设置页各自单一职责，
- * 后续「我的」升为一级 tab 时，设置与关于会挪进底栏扩展菜单，本页只需摘掉这两行。
+ * 后续设置与关于挪进底栏扩展菜单时，本页只需摘掉这两行。
+ *
+ * 本页是「我的」tab 的内容，不自带脚手架与顶栏：顶栏由 [HomeScreen] 统一提供，
+ * 底栏要一直在，页面内套 Scaffold 会出现两层顶栏。
  *
  * 未登录用户同样可达：身份区显示登录引导、用量区显示匿名额度——不像旧个人主页那样
  * 对邮箱/匿名用户只剩空壳。GitHub 开发者档案（贡献图 + 动态流）降为
@@ -124,7 +121,7 @@ import whl.trending.ai.ui.common.TrendingTopAppBar
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ProfileScreen(
-    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
     onNavigateToGithubProfile: () -> Unit,
     onNavigateToFavorites: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
@@ -194,140 +191,127 @@ fun ProfileScreen(
         )
     }
 
-    TrendingScaffold(
-        topBar = {
-            TrendingTopAppBar(
-                title = { Text(stringResource(Res.string.account_title)) },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(Res.string.back))
-                    }
-                },
+    PullToRefreshBox(
+        // 未接入登录的平台（iOS）：身份/额度区块都已隐藏，下拉刷新会拉
+        // profile/quota 却无任何可见变化——短路成 no-op，避免无谓网络开销。
+        isRefreshing = authSupported && uiState.isRefreshing,
+        state = pullToRefreshState,
+        onRefresh = { if (authSupported) viewModel.refresh() },
+        indicator = {
+            PullToRefreshDefaults.LoadingIndicator(
+                state = pullToRefreshState,
+                isRefreshing = uiState.isRefreshing,
+                modifier = Modifier.align(Alignment.TopCenter),
             )
         },
-    ) { padding ->
-        PullToRefreshBox(
-            // 未接入登录的平台（iOS）：身份/额度区块都已隐藏，下拉刷新会拉
-            // profile/quota 却无任何可见变化——短路成 no-op，避免无谓网络开销。
-            isRefreshing = authSupported && uiState.isRefreshing,
-            state = pullToRefreshState,
-            onRefresh = { if (authSupported) viewModel.refresh() },
-            indicator = {
-                PullToRefreshDefaults.LoadingIndicator(
-                    state = pullToRefreshState,
-                    isRefreshing = uiState.isRefreshing,
-                    modifier = Modifier.align(Alignment.TopCenter),
-                )
-            },
-            modifier = Modifier.fillMaxSize().padding(padding),
-        ) {
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                if (authSupported) {
-                    // ① 身份区
-                    item(key = "account_header") {
-                        AccountHeader(
-                            uiState = uiState,
-                            isPro = isPro,
-                            onSignIn = { globalAuthManager.signIn("account_hub") },
-                            onRetry = { viewModel.load() },
-                        )
-                    }
-
-                    // ② 套餐 & 用量
-                    item(key = "plan_card") {
-                        PlanUsageCard(
-                            quota = uiState.quota,
-                            quotaError = uiState.quotaError,
-                            loggedIn = uiState.loggedIn,
-                            isPro = isPro,
-                            onUpgrade = {
-                                // 没有 GitHub 身份就直奔赞助页 = 让用户白花钱，先引导关联
-                                if (uiState.user?.githubUserId == null) showLinkGithubDialog = true
-                                else ProSponsor.openSponsorPage(ProSponsor.SOURCE_ACCOUNT)
-                            },
-                            onSignIn = { globalAuthManager.signIn("account_hub") },
-                        )
-                    }
-
-                    // ③ GitHub 区：已关联给主页入口，未关联给关联入口。
-                    // 两处条件刻意不对称——githubUserId 是「是否已关联」的权威（Pro 判定同源），
-                    // githubLogin 才是能展示的名字。中间态（有 id 无 login，资料未同步）两块都不显示，
-                    // 好过让已关联的用户看到「关联 GitHub」或让主页卡显示 @null。
-                    if (uiState.user?.githubLogin != null) {
-                        item(key = "github_entry") {
-                            GithubEntryCard(uiState = uiState, onClick = onNavigateToGithubProfile)
-                        }
-                    } else if (uiState.loggedIn && uiState.user?.githubUserId == null) {
-                        item(key = "link_github") {
-                            LinkGithubCard(onClick = {
-                                AccountLink.openLinkGithubPage(AccountLink.SOURCE_ACCOUNT)
-                            })
-                        }
-                    }
-
-                    item(key = "divider_top") { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
-                }
-
-                // ④ 入口区：收藏 / 设置 / 关于我们
-                item(key = "favorites") {
-                    ListItem(
-                        headlineContent = { Text(stringResource(Res.string.favorites)) },
-                        leadingContent = { Icon(Icons.Default.Favorite, null) },
-                        modifier = Modifier.clickable {
-                            trackEvent("settings_favorites")
-                            onNavigateToFavorites()
-                        }
+        modifier = modifier.fillMaxSize(),
+    ) {
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            if (authSupported) {
+                // ① 身份区
+                item(key = "account_header") {
+                    AccountHeader(
+                        uiState = uiState,
+                        isPro = isPro,
+                        onSignIn = { globalAuthManager.signIn("account_hub") },
+                        onRetry = { viewModel.load() },
                     )
                 }
-                item(key = "settings_entry") {
-                    ListItem(
-                        headlineContent = { Text(stringResource(Res.string.settings)) },
-                        supportingContent = { Text(stringResource(Res.string.settings_entry_desc)) },
-                        leadingContent = { Icon(Icons.Default.Settings, null) },
-                        trailingContent = {
-                            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+
+                // ② 套餐 & 用量
+                item(key = "plan_card") {
+                    PlanUsageCard(
+                        quota = uiState.quota,
+                        quotaError = uiState.quotaError,
+                        loggedIn = uiState.loggedIn,
+                        isPro = isPro,
+                        onUpgrade = {
+                            // 没有 GitHub 身份就直奔赞助页 = 让用户白花钱，先引导关联
+                            if (uiState.user?.githubUserId == null) showLinkGithubDialog = true
+                            else ProSponsor.openSponsorPage(ProSponsor.SOURCE_ACCOUNT)
                         },
-                        modifier = Modifier.clickable {
-                            trackEvent("profile_open_settings")
-                            onNavigateToSettings()
-                        }
-                    )
-                }
-                item(key = "about_us") {
-                    ListItem(
-                        headlineContent = { Text(stringResource(Res.string.about_us)) },
-                        leadingContent = { Icon(Icons.Default.Info, null) },
-                        modifier = Modifier.clickable {
-                            trackEvent("settings_about")
-                            onNavigateToAbout()
-                        }
+                        onSignIn = { globalAuthManager.signIn("account_hub") },
                     )
                 }
 
-                // ⑤ 退出登录（仅登录用户）
-                if (uiState.loggedIn) {
-                    item(key = "sign_out") {
-                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-                        ListItem(
-                            headlineContent = {
-                                Text(
-                                    stringResource(Res.string.sign_out),
-                                    color = MaterialTheme.colorScheme.error,
-                                )
-                            },
-                            leadingContent = {
-                                Icon(
-                                    Icons.AutoMirrored.Filled.Logout,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.error,
-                                )
-                            },
-                            modifier = Modifier.clickable { showSignOutDialog = true }
-                        )
+                // ③ GitHub 区：已关联给主页入口，未关联给关联入口。
+                // 两处条件刻意不对称——githubUserId 是「是否已关联」的权威（Pro 判定同源），
+                // githubLogin 才是能展示的名字。中间态（有 id 无 login，资料未同步）两块都不显示，
+                // 好过让已关联的用户看到「关联 GitHub」或让主页卡显示 @null。
+                if (uiState.user?.githubLogin != null) {
+                    item(key = "github_entry") {
+                        GithubEntryCard(uiState = uiState, onClick = onNavigateToGithubProfile)
+                    }
+                } else if (uiState.loggedIn && uiState.user?.githubUserId == null) {
+                    item(key = "link_github") {
+                        LinkGithubCard(onClick = {
+                            AccountLink.openLinkGithubPage(AccountLink.SOURCE_ACCOUNT)
+                        })
                     }
                 }
-                item(key = "bottom_spacer") { Spacer(Modifier.height(24.dp)) }
+
+                item(key = "divider_top") { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
             }
+
+            // ④ 入口区：收藏 / 设置 / 关于我们
+            item(key = "favorites") {
+                ListItem(
+                    headlineContent = { Text(stringResource(Res.string.favorites)) },
+                    leadingContent = { Icon(Icons.Default.Favorite, null) },
+                    modifier = Modifier.clickable {
+                        trackEvent("settings_favorites")
+                        onNavigateToFavorites()
+                    }
+                )
+            }
+            item(key = "settings_entry") {
+                ListItem(
+                    headlineContent = { Text(stringResource(Res.string.settings)) },
+                    supportingContent = { Text(stringResource(Res.string.settings_entry_desc)) },
+                    leadingContent = { Icon(Icons.Default.Settings, null) },
+                    trailingContent = {
+                        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+                    },
+                    modifier = Modifier.clickable {
+                        trackEvent("profile_open_settings")
+                        onNavigateToSettings()
+                    }
+                )
+            }
+            item(key = "about_us") {
+                ListItem(
+                    headlineContent = { Text(stringResource(Res.string.about_us)) },
+                    leadingContent = { Icon(Icons.Default.Info, null) },
+                    modifier = Modifier.clickable {
+                        trackEvent("settings_about")
+                        onNavigateToAbout()
+                    }
+                )
+            }
+
+            // ⑤ 退出登录（仅登录用户）
+            if (uiState.loggedIn) {
+                item(key = "sign_out") {
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                    ListItem(
+                        headlineContent = {
+                            Text(
+                                stringResource(Res.string.sign_out),
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        },
+                        leadingContent = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.Logout,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error,
+                            )
+                        },
+                        modifier = Modifier.clickable { showSignOutDialog = true }
+                    )
+                }
+            }
+            item(key = "bottom_spacer") { Spacer(Modifier.height(24.dp)) }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -19,13 +19,9 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Feedback
 import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.Notifications
-import androidx.compose.material.icons.filled.Palette
-import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -40,10 +36,6 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -56,7 +48,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -69,7 +60,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.about_us
@@ -89,17 +79,9 @@ import trendingai.shared.generated.resources.account_tier_free
 import trendingai.shared.generated.resources.account_title
 import trendingai.shared.generated.resources.account_upgrade_cta
 import trendingai.shared.generated.resources.account_upgrade_hint
-import trendingai.shared.generated.resources.app_settings
-import trendingai.shared.generated.resources.app_settings_entry_desc
-import trendingai.shared.generated.resources.appearance
 import trendingai.shared.generated.resources.back
 import trendingai.shared.generated.resources.cancel
-import trendingai.shared.generated.resources.daily_picks_notification
 import trendingai.shared.generated.resources.favorites
-import trendingai.shared.generated.resources.feedback
-import trendingai.shared.generated.resources.notification_permission_denied
-import trendingai.shared.generated.resources.open_system_settings
-import trendingai.shared.generated.resources.personalization
 import trendingai.shared.generated.resources.profile_load_failed
 import trendingai.shared.generated.resources.profile_quota_error
 import trendingai.shared.generated.resources.profile_quota_exhausted
@@ -110,73 +92,58 @@ import trendingai.shared.generated.resources.profile_followers
 import trendingai.shared.generated.resources.profile_repos
 import trendingai.shared.generated.resources.profile_retry
 import trendingai.shared.generated.resources.settings
-import trendingai.shared.generated.resources.settings_group_general
+import trendingai.shared.generated.resources.settings_entry_desc
 import trendingai.shared.generated.resources.sign_in
 import trendingai.shared.generated.resources.sign_out
 import trendingai.shared.generated.resources.sign_out_confirm
-import trendingai.shared.generated.resources.subscribe_title
-import trendingai.shared.generated.resources.subscription_reminders
 import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.minutes
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.core.DateTimeUtils
 import whl.trending.ai.core.AccountLink
 import whl.trending.ai.core.ProSponsor
-import whl.trending.ai.core.platform.openAppSettings
 import whl.trending.ai.core.platform.trackEvent
-import whl.trending.ai.data.local.ThemeMode
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.QuotaResponse
-import whl.trending.ai.notification.globalDailyPicksNotifier
-import whl.trending.ai.ui.settings.themeModeText
 import whl.trending.ai.ui.common.TrendingScaffold
 import whl.trending.ai.ui.common.TrendingTopAppBar
 
 /**
- * 账户中心（统一 Hub）：应用「关于我」的唯一入口，替代原独立的个人主页 + 设置页。
+ * 个人中心：只讲「你是谁、你还剩多少额度、你收藏了什么」。
  *
  * 从上到下：身份区（含未登录引导）→ 套餐 & 用量（含升级 CTA）→ GitHub 主页入口卡
- * （仅 GitHub 用户）→ 设置分组（个性化 / 订阅提醒 / 通用）→ 退出登录。
- * 低频应用偏好（语言/默认首页/打开方式）折叠进「应用设置」子页 [AppSettingsScreen]。
+ * （仅 GitHub 用户）→ 收藏 / 设置 / 关于我们 三个入口 → 退出登录。
  *
- * 未登录用户同样可达：身份区显示登录引导、用量区显示匿名额度、设置分组照常可用——
- * 不再像旧个人主页那样对邮箱/匿名用户只剩空壳。GitHub 开发者档案（贡献图 + 动态流）
- * 降为 [GithubProfileScreen] 子页，动态数据由共享的 [ProfileViewModel] 承载。
+ * 应用偏好已全部迁到 [SettingsScreen]，这里只留一个入口——本页与设置页各自单一职责，
+ * 后续「我的」升为一级 tab 时，设置与关于会挪进底栏扩展菜单，本页只需摘掉这两行。
+ *
+ * 未登录用户同样可达：身份区显示登录引导、用量区显示匿名额度——不像旧个人主页那样
+ * 对邮箱/匿名用户只剩空壳。GitHub 开发者档案（贡献图 + 动态流）降为
+ * [GithubProfileScreen] 子页，动态数据由共享的 [ProfileViewModel] 承载。
  */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun AccountScreen(
+fun ProfileScreen(
     onBack: () -> Unit,
     onNavigateToGithubProfile: () -> Unit,
     onNavigateToFavorites: () -> Unit = {},
-    onNavigateToFeedback: () -> Unit = {},
-    onNavigateToSubscribe: () -> Unit = {},
-    onNavigateToAppearance: () -> Unit = {},
-    onNavigateToAppSettings: () -> Unit = {},
+    onNavigateToSettings: () -> Unit = {},
     onNavigateToAbout: () -> Unit = {},
 ) {
     val viewModel: ProfileViewModel = viewModel { ProfileViewModel() }
     val uiState by viewModel.uiState.collectAsState()
-    // 未接入登录的平台（iOS NoopAuthManager）：Hub 退化为纯设置页——身份/额度/GitHub/登录
-    // 都无意义，隐藏这些动态区块，只留设置分组（等同旧的独立设置页）。
+    // 未接入登录的平台（iOS NoopAuthManager）：身份/额度/GitHub/登录都无意义，
+    // 隐藏这些动态区块，本页退化成「收藏 + 设置 + 关于」三个入口。
     val authSupported = globalAuthManager.isSupported
     LaunchedEffect(Unit) { if (authSupported) viewModel.load() }
 
     val isPro by globalSettingsManager.isPro.collectAsState(
         initial = globalSettingsManager.currentIsPro()
     )
-    val themeMode by globalSettingsManager.themeMode.collectAsState(ThemeMode.FOLLOW_SYSTEM)
-    val dailyPicksNotificationEnabled by globalSettingsManager.dailyPicksNotificationEnabled.collectAsState(
-        remember { globalSettingsManager.currentDailyPicksNotificationEnabled() }
-    )
 
     var showSignOutDialog by remember { mutableStateOf(false) }
     var showLinkGithubDialog by remember { mutableStateOf(false) }
 
-    val snackbarHostState = remember { SnackbarHostState() }
-    val settingsScope = rememberCoroutineScope()
-    val permissionDeniedMsg = stringResource(Res.string.notification_permission_denied)
-    val openSystemSettingsLabel = stringResource(Res.string.open_system_settings)
     val pullToRefreshState = rememberPullToRefreshState()
 
     if (showSignOutDialog) {
@@ -230,9 +197,7 @@ fun AccountScreen(
     TrendingScaffold(
         topBar = {
             TrendingTopAppBar(
-                title = {
-                    Text(stringResource(if (authSupported) Res.string.account_title else Res.string.settings))
-                },
+                title = { Text(stringResource(Res.string.account_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(Res.string.back))
@@ -240,10 +205,9 @@ fun AccountScreen(
                 },
             )
         },
-        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { padding ->
         PullToRefreshBox(
-            // 未接入登录的平台（iOS）：Hub 是纯设置页，身份/额度区块都已隐藏，下拉刷新会拉
+            // 未接入登录的平台（iOS）：身份/额度区块都已隐藏，下拉刷新会拉
             // profile/quota 却无任何可见变化——短路成 no-op，避免无谓网络开销。
             isRefreshing = authSupported && uiState.isRefreshing,
             state = pullToRefreshState,
@@ -304,24 +268,7 @@ fun AccountScreen(
                     item(key = "divider_top") { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
                 }
 
-                // ④ 设置分组：个性化
-                item(key = "group_personalization") { SettingsHeader(stringResource(Res.string.personalization)) }
-                item(key = "appearance") {
-                    ListItem(
-                        headlineContent = { Text(stringResource(Res.string.appearance)) },
-                        leadingContent = { Icon(Icons.Default.Palette, null) },
-                        trailingContent = {
-                            Text(
-                                text = themeModeText(themeMode),
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        },
-                        modifier = Modifier.clickable {
-                            trackEvent("settings_appearance")
-                            onNavigateToAppearance()
-                        }
-                    )
-                }
+                // ④ 入口区：收藏 / 设置 / 关于我们
                 item(key = "favorites") {
                     ListItem(
                         headlineContent = { Text(stringResource(Res.string.favorites)) },
@@ -332,82 +279,17 @@ fun AccountScreen(
                         }
                     )
                 }
-                item(key = "divider_1") { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
-
-                // 订阅提醒
-                item(key = "group_subscription") { SettingsHeader(stringResource(Res.string.subscription_reminders)) }
-                item(key = "subscribe") {
+                item(key = "settings_entry") {
                     ListItem(
-                        headlineContent = { Text(stringResource(Res.string.subscribe_title)) },
-                        leadingContent = { Icon(Icons.Default.Email, null) },
-                        modifier = Modifier.clickable {
-                            trackEvent("settings_subscribe")
-                            onNavigateToSubscribe()
-                        }
-                    )
-                }
-                if (globalDailyPicksNotifier.isSupported) {
-                    item(key = "daily_picks_notification") {
-                        ListItem(
-                            headlineContent = { Text(stringResource(Res.string.daily_picks_notification)) },
-                            leadingContent = { Icon(Icons.Default.Notifications, null) },
-                            trailingContent = {
-                                Switch(
-                                    checked = dailyPicksNotificationEnabled,
-                                    onCheckedChange = { enabled ->
-                                        trackEvent(
-                                            "settings_daily_picks_notification",
-                                            mapOf("enabled" to enabled.toString())
-                                        )
-                                        if (enabled) {
-                                            settingsScope.launch {
-                                                val granted = globalDailyPicksNotifier.enable()
-                                                globalSettingsManager.setDailyPicksNotificationEnabled(granted)
-                                                if (!granted) {
-                                                    val result = snackbarHostState.showSnackbar(
-                                                        message = permissionDeniedMsg,
-                                                        actionLabel = openSystemSettingsLabel,
-                                                    )
-                                                    if (result == SnackbarResult.ActionPerformed) {
-                                                        openAppSettings()
-                                                    }
-                                                }
-                                            }
-                                        } else {
-                                            globalDailyPicksNotifier.disable()
-                                            globalSettingsManager.setDailyPicksNotificationEnabled(false)
-                                        }
-                                    }
-                                )
-                            }
-                        )
-                    }
-                }
-                item(key = "divider_2") { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
-
-                // 通用：应用设置（低频偏好折叠进子页）+ 反馈 + 关于
-                item(key = "group_general") { SettingsHeader(stringResource(Res.string.settings_group_general)) }
-                item(key = "app_settings_entry") {
-                    ListItem(
-                        headlineContent = { Text(stringResource(Res.string.app_settings)) },
-                        supportingContent = { Text(stringResource(Res.string.app_settings_entry_desc)) },
-                        leadingContent = { Icon(Icons.Default.Tune, null) },
+                        headlineContent = { Text(stringResource(Res.string.settings)) },
+                        supportingContent = { Text(stringResource(Res.string.settings_entry_desc)) },
+                        leadingContent = { Icon(Icons.Default.Settings, null) },
                         trailingContent = {
                             Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
                         },
                         modifier = Modifier.clickable {
-                            trackEvent("settings_app_settings")
-                            onNavigateToAppSettings()
-                        }
-                    )
-                }
-                item(key = "feedback") {
-                    ListItem(
-                        headlineContent = { Text(stringResource(Res.string.feedback)) },
-                        leadingContent = { Icon(Icons.Default.Feedback, null) },
-                        modifier = Modifier.clickable {
-                            trackEvent("settings_feedback")
-                            onNavigateToFeedback()
+                            trackEvent("profile_open_settings")
+                            onNavigateToSettings()
                         }
                     )
                 }
@@ -782,15 +664,5 @@ private fun GithubEntryCard(uiState: ProfileUiState, onClick: () -> Unit) {
         },
         colors = ListItemDefaults.colors(containerColor = androidx.compose.ui.graphics.Color.Transparent),
         modifier = Modifier.clickable { onClick() },
-    )
-}
-
-@Composable
-fun SettingsHeader(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelLarge,
-        color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
     )
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/AboutScreen.kt
@@ -54,7 +54,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
-import trendingai.shared.generated.resources.about_us
+import trendingai.shared.generated.resources.about
 import trendingai.shared.generated.resources.app_name
 import trendingai.shared.generated.resources.back
 import trendingai.shared.generated.resources.changelog
@@ -92,7 +92,7 @@ fun AboutScreen(
     TrendingScaffold(
         topBar = {
             TrendingTopAppBar(
-                title = { Text(stringResource(Res.string.about_us)) },
+                title = { Text(stringResource(Res.string.about)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(Res.string.back))

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Feedback
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.OpenInBrowser
@@ -52,6 +53,7 @@ import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.app_language_desc
+import trendingai.shared.generated.resources.about
 import trendingai.shared.generated.resources.appearance
 import trendingai.shared.generated.resources.back
 import trendingai.shared.generated.resources.cancel
@@ -114,11 +116,11 @@ import whl.trending.ai.ui.home.HomeTab
  * 设置页：应用偏好的唯一落点，从账户页（后续版本为「我的」tab 的扩展菜单）进入。
  *
  * 分三组：个性化（外观 / 界面语言 / 摘要语言 / 默认首页）、订阅与提醒（邮件订阅 / 每日推送）、
- * 通用（外链打开方式 / 反馈）。
+ * 通用（外链打开方式 / 反馈 / 关于）。
  *
  * 这一页同时收掉了原来的「应用设置」子页——账户中心拆分后设置不再与身份、额度混排，
- * 四个低频偏好可以直接平铺，不必再折叠一层。「关于我们」不在这里：它与「设置」并列，
- * 同为账户页的独立入口。
+ * 四个低频偏好可以直接平铺，不必再折叠一层。「关于」在通用组末尾，与底栏「⋯」菜单里的那一项指向同一页——
+ * 菜单是快捷入口，这里是完整清单。
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -127,6 +129,7 @@ fun SettingsScreen(
     onNavigateToAppearance: () -> Unit = {},
     onNavigateToSubscribe: () -> Unit = {},
     onNavigateToFeedback: () -> Unit = {},
+    onNavigateToAbout: () -> Unit = {},
 ) {
     val isIos = isIosPlatform()
     val themeMode by globalSettingsManager.themeMode.collectAsState(ThemeMode.FOLLOW_SYSTEM)
@@ -411,6 +414,17 @@ fun SettingsScreen(
                     modifier = Modifier.clickable {
                         trackEvent("settings_feedback")
                         onNavigateToFeedback()
+                    }
+                )
+            }
+            // 关于页同时挂在底栏的「⋯」菜单上——那里是快捷入口，这里是设置的完整清单
+            item(key = "about") {
+                ListItem(
+                    headlineContent = { Text(stringResource(Res.string.about)) },
+                    leadingContent = { Icon(Icons.Default.Info, null) },
+                    modifier = Modifier.clickable {
+                        trackEvent("settings_about")
+                        onNavigateToAbout()
                     }
                 )
             }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -13,21 +13,29 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Feedback
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.OpenInBrowser
+import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -44,12 +52,14 @@ import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.app_language_desc
-import trendingai.shared.generated.resources.app_settings
+import trendingai.shared.generated.resources.appearance
 import trendingai.shared.generated.resources.back
 import trendingai.shared.generated.resources.cancel
 import trendingai.shared.generated.resources.close
+import trendingai.shared.generated.resources.daily_picks_notification
 import trendingai.shared.generated.resources.default_home_tab
 import trendingai.shared.generated.resources.default_home_tab_desc
+import trendingai.shared.generated.resources.feedback
 import trendingai.shared.generated.resources.feedback_email_invalid
 import trendingai.shared.generated.resources.feedback_email_placeholder
 import trendingai.shared.generated.resources.feedback_error
@@ -59,11 +69,17 @@ import trendingai.shared.generated.resources.language_option_chinese
 import trendingai.shared.generated.resources.language_option_english
 import trendingai.shared.generated.resources.language_option_follow_system
 import trendingai.shared.generated.resources.language_settings
+import trendingai.shared.generated.resources.notification_permission_denied
 import trendingai.shared.generated.resources.open_links_in_browser
 import trendingai.shared.generated.resources.open_links_in_browser_desc
 import trendingai.shared.generated.resources.open_system_settings
+import trendingai.shared.generated.resources.personalization
 import trendingai.shared.generated.resources.picks_title
 import trendingai.shared.generated.resources.producthunt_title
+import trendingai.shared.generated.resources.settings
+import trendingai.shared.generated.resources.settings_group_general
+import trendingai.shared.generated.resources.subscribe_title
+import trendingai.shared.generated.resources.subscription_reminders
 import trendingai.shared.generated.resources.summary_lang_capture_identity_note
 import trendingai.shared.generated.resources.summary_lang_capture_label
 import trendingai.shared.generated.resources.summary_lang_capture_message
@@ -84,35 +100,54 @@ import whl.trending.ai.core.platform.openAppSettings
 import whl.trending.ai.core.platform.trackEvent
 import whl.trending.ai.data.local.AppLanguage
 import whl.trending.ai.data.local.SummaryLanguage
+import whl.trending.ai.data.local.ThemeMode
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.remote.ApiException
 import whl.trending.ai.data.repository.TrendingRepository
+import whl.trending.ai.notification.globalDailyPicksNotifier
 import whl.trending.ai.ui.common.TrendingScaffold
 import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.ai.ui.home.HomeTab
 
 /**
- * 应用设置子页：从账户 Hub 的「应用设置」入口进入。承接原设置页「应用设置」组——
- * 界面语言 / 摘要语言 / 默认首页 / 外链打开方式，都是低频、工具性偏好，从 Hub 折叠到此处
- * 以缩短 Hub 主列表。摘要语言的意图采集 + 赞助流程一并随「摘要语言」项收在这里。
+ * 设置页：应用偏好的唯一落点，从账户页（后续版本为「我的」tab 的扩展菜单）进入。
+ *
+ * 分三组：个性化（外观 / 界面语言 / 摘要语言 / 默认首页）、订阅与提醒（邮件订阅 / 每日推送）、
+ * 通用（外链打开方式 / 反馈）。
+ *
+ * 这一页同时收掉了原来的「应用设置」子页——账户中心拆分后设置不再与身份、额度混排，
+ * 四个低频偏好可以直接平铺，不必再折叠一层。「关于我们」不在这里：它与「设置」并列，
+ * 同为账户页的独立入口。
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AppSettingsScreen(
+fun SettingsScreen(
     onBack: () -> Unit,
+    onNavigateToAppearance: () -> Unit = {},
+    onNavigateToSubscribe: () -> Unit = {},
     onNavigateToFeedback: () -> Unit = {},
 ) {
     val isIos = isIosPlatform()
+    val themeMode by globalSettingsManager.themeMode.collectAsState(ThemeMode.FOLLOW_SYSTEM)
     val appLanguage by globalSettingsManager.appLanguage.collectAsState(AppLanguage.FOLLOW_SYSTEM)
     val summaryLanguage by globalSettingsManager.summaryLanguage.collectAsState(SummaryLanguage.FOLLOW_SYSTEM)
     val openLinksInCustomTab by globalSettingsManager.openLinksInCustomTab.collectAsState(true)
     val defaultHomeTab by globalSettingsManager.defaultHomeTab.collectAsState(
         remember { globalSettingsManager.currentDefaultHomeTab() }
     )
+    val dailyPicksNotificationEnabled by globalSettingsManager.dailyPicksNotificationEnabled.collectAsState(
+        remember { globalSettingsManager.currentDailyPicksNotificationEnabled() }
+    )
     val authState by globalAuthManager.authState.collectAsState()
     val isLoggedIn = authState is AuthState.LoggedIn
+
     var showSummaryLanguageDialog by remember { mutableStateOf(false) }
     var showLangCaptureDialog by remember { mutableStateOf(false) }
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    val settingsScope = rememberCoroutineScope()
+    val permissionDeniedMsg = stringResource(Res.string.notification_permission_denied)
+    val openSystemSettingsLabel = stringResource(Res.string.open_system_settings)
 
     if (showSummaryLanguageDialog) {
         AlertDialog(
@@ -151,7 +186,7 @@ fun AppSettingsScreen(
     TrendingScaffold(
         topBar = {
             TrendingTopAppBar(
-                title = { Text(stringResource(Res.string.app_settings)) },
+                title = { Text(stringResource(Res.string.settings)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(Res.string.back))
@@ -159,8 +194,27 @@ fun AppSettingsScreen(
                 },
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { padding ->
         LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
+            // ① 个性化
+            item(key = "group_personalization") { SettingsHeader(stringResource(Res.string.personalization)) }
+            item(key = "appearance") {
+                ListItem(
+                    headlineContent = { Text(stringResource(Res.string.appearance)) },
+                    leadingContent = { Icon(Icons.Default.Palette, null) },
+                    trailingContent = {
+                        Text(
+                            text = themeModeText(themeMode),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    modifier = Modifier.clickable {
+                        trackEvent("settings_appearance")
+                        onNavigateToAppearance()
+                    }
+                )
+            }
             // 应用语言：只管界面文案；iOS 由系统的按 App 语言设置接管，跳系统设置
             item(key = "app_language") {
                 var expanded by remember { mutableStateOf(false) }
@@ -275,6 +329,61 @@ fun AppSettingsScreen(
                     }
                 )
             }
+            item(key = "divider_1") { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
+
+            // ② 订阅与提醒
+            item(key = "group_subscription") { SettingsHeader(stringResource(Res.string.subscription_reminders)) }
+            item(key = "subscribe") {
+                ListItem(
+                    headlineContent = { Text(stringResource(Res.string.subscribe_title)) },
+                    leadingContent = { Icon(Icons.Default.Email, null) },
+                    modifier = Modifier.clickable {
+                        trackEvent("settings_subscribe")
+                        onNavigateToSubscribe()
+                    }
+                )
+            }
+            if (globalDailyPicksNotifier.isSupported) {
+                item(key = "daily_picks_notification") {
+                    ListItem(
+                        headlineContent = { Text(stringResource(Res.string.daily_picks_notification)) },
+                        leadingContent = { Icon(Icons.Default.Notifications, null) },
+                        trailingContent = {
+                            Switch(
+                                checked = dailyPicksNotificationEnabled,
+                                onCheckedChange = { enabled ->
+                                    trackEvent(
+                                        "settings_daily_picks_notification",
+                                        mapOf("enabled" to enabled.toString())
+                                    )
+                                    if (enabled) {
+                                        settingsScope.launch {
+                                            val granted = globalDailyPicksNotifier.enable()
+                                            globalSettingsManager.setDailyPicksNotificationEnabled(granted)
+                                            if (!granted) {
+                                                val result = snackbarHostState.showSnackbar(
+                                                    message = permissionDeniedMsg,
+                                                    actionLabel = openSystemSettingsLabel,
+                                                )
+                                                if (result == SnackbarResult.ActionPerformed) {
+                                                    openAppSettings()
+                                                }
+                                            }
+                                        }
+                                    } else {
+                                        globalDailyPicksNotifier.disable()
+                                        globalSettingsManager.setDailyPicksNotificationEnabled(false)
+                                    }
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+            item(key = "divider_2") { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
+
+            // ③ 通用
+            item(key = "group_general") { SettingsHeader(stringResource(Res.string.settings_group_general)) }
             // 外链打开方式：行点击与开关同为切换
             item(key = "open_links") {
                 val toggleOpenLinks = { enabled: Boolean ->
@@ -294,8 +403,30 @@ fun AppSettingsScreen(
                     modifier = Modifier.clickable { toggleOpenLinks(!openLinksInCustomTab) }
                 )
             }
+            item(key = "feedback") {
+                ListItem(
+                    headlineContent = { Text(stringResource(Res.string.feedback)) },
+                    leadingContent = { Icon(Icons.Default.Feedback, null) },
+                    modifier = Modifier.clickable {
+                        trackEvent("settings_feedback")
+                        onNavigateToFeedback()
+                    }
+                )
+            }
+            item(key = "bottom_spacer") { Spacer(Modifier.height(24.dp)) }
         }
     }
+}
+
+/** 设置分组标题，账户页与设置页共用。 */
+@Composable
+fun SettingsHeader(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+    )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -452,7 +452,7 @@ private fun languageOptionText(language: SummaryLanguage): String {
 
 @Composable
 private fun homeTabOptionText(tab: HomeTab): String = when (tab) {
-    HomeTab.Trending -> stringResource(Res.string.home_title)
+    HomeTab.Home -> stringResource(Res.string.home_title)
     HomeTab.Picks -> stringResource(Res.string.picks_title)
     HomeTab.Me -> stringResource(Res.string.me_title)
     // Chat 不在 defaultCandidates 里，选项列表不会渲染它；穷尽 when 用

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -56,6 +56,7 @@ import trendingai.shared.generated.resources.appearance
 import trendingai.shared.generated.resources.back
 import trendingai.shared.generated.resources.cancel
 import trendingai.shared.generated.resources.close
+import trendingai.shared.generated.resources.chat_title
 import trendingai.shared.generated.resources.daily_picks_notification
 import trendingai.shared.generated.resources.default_home_tab
 import trendingai.shared.generated.resources.default_home_tab_desc
@@ -64,7 +65,6 @@ import trendingai.shared.generated.resources.feedback_email_invalid
 import trendingai.shared.generated.resources.feedback_email_placeholder
 import trendingai.shared.generated.resources.feedback_error
 import trendingai.shared.generated.resources.feedback_rate_limit
-import trendingai.shared.generated.resources.hackernews_title
 import trendingai.shared.generated.resources.language_option_chinese
 import trendingai.shared.generated.resources.language_option_english
 import trendingai.shared.generated.resources.language_option_follow_system
@@ -75,7 +75,7 @@ import trendingai.shared.generated.resources.open_links_in_browser_desc
 import trendingai.shared.generated.resources.open_system_settings
 import trendingai.shared.generated.resources.personalization
 import trendingai.shared.generated.resources.picks_title
-import trendingai.shared.generated.resources.producthunt_title
+import trendingai.shared.generated.resources.me_title
 import trendingai.shared.generated.resources.settings
 import trendingai.shared.generated.resources.settings_group_general
 import trendingai.shared.generated.resources.subscribe_title
@@ -89,6 +89,7 @@ import trendingai.shared.generated.resources.summary_language_desc
 import trendingai.shared.generated.resources.summary_language_feedback
 import trendingai.shared.generated.resources.summary_language_message
 import trendingai.shared.generated.resources.summary_language_sponsor
+import trendingai.shared.generated.resources.trending_title
 import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.core.ProSponsor
@@ -306,7 +307,7 @@ fun SettingsScreen(
                     trailingContent = {
                         Box {
                             Text(
-                                text = homeTabOptionText(HomeTab.fromNameOrDefault(defaultHomeTab)),
+                                text = homeTabOptionText(HomeTab.defaultFromName(defaultHomeTab)),
                                 color = MaterialTheme.colorScheme.primary,
                                 modifier = Modifier.clickable { expanded = true }
                             )
@@ -314,7 +315,7 @@ fun SettingsScreen(
                                 expanded = expanded,
                                 onDismissRequest = { expanded = false }
                             ) {
-                                HomeTab.entries.forEach { tab ->
+                                HomeTab.defaultCandidates.forEach { tab ->
                                     DropdownMenuItem(
                                         text = { Text(homeTabOptionText(tab)) },
                                         onClick = {
@@ -451,10 +452,11 @@ private fun languageOptionText(language: SummaryLanguage): String {
 
 @Composable
 private fun homeTabOptionText(tab: HomeTab): String = when (tab) {
-    HomeTab.GitHub -> "GitHub"
-    HomeTab.HackerNews -> stringResource(Res.string.hackernews_title)
-    HomeTab.ProductHunt -> stringResource(Res.string.producthunt_title)
+    HomeTab.Trending -> stringResource(Res.string.trending_title)
     HomeTab.Picks -> stringResource(Res.string.picks_title)
+    HomeTab.Me -> stringResource(Res.string.me_title)
+    // Chat 不在 defaultCandidates 里，选项列表不会渲染它；穷尽 when 用
+    HomeTab.Chat -> stringResource(Res.string.chat_title)
 }
 
 /**

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -89,7 +89,7 @@ import trendingai.shared.generated.resources.summary_language_desc
 import trendingai.shared.generated.resources.summary_language_feedback
 import trendingai.shared.generated.resources.summary_language_message
 import trendingai.shared.generated.resources.summary_language_sponsor
-import trendingai.shared.generated.resources.trending_title
+import trendingai.shared.generated.resources.home_title
 import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.core.ProSponsor
@@ -452,7 +452,7 @@ private fun languageOptionText(language: SummaryLanguage): String {
 
 @Composable
 private fun homeTabOptionText(tab: HomeTab): String = when (tab) {
-    HomeTab.Trending -> stringResource(Res.string.trending_title)
+    HomeTab.Trending -> stringResource(Res.string.home_title)
     HomeTab.Picks -> stringResource(Res.string.picks_title)
     HomeTab.Me -> stringResource(Res.string.me_title)
     // Chat 不在 defaultCandidates 里，选项列表不会渲染它；穷尽 when 用

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
@@ -59,12 +59,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import whl.trending.ai.ui.common.LocalContentBottomPadding
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -167,7 +169,10 @@ fun TrendingScreen(
         )
         SnackbarHost(
             hostState = snackbarHostState,
-            modifier = Modifier.align(Alignment.BottomCenter),
+            // 抬到悬浮底栏之上，否则 star 结果提示会被胶囊压住
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = LocalContentBottomPadding.current),
         )
     }
 
@@ -285,7 +290,12 @@ private fun RepoList(
             else -> {
                 val favorites by globalSettingsManager.favorites.collectAsState(emptyList())
                 val favoriteUrls = remember(favorites) { favorites.map { it.url }.toSet() }
-                LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                    // 末条要能从悬浮底栏下面滚出来
+                    contentPadding = PaddingValues(bottom = LocalContentBottomPadding.current),
+                ) {
                 items(
                     count = displayRepos.size,
                     key = { index -> displayRepos[index].url }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/core/BackStackPopTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/core/BackStackPopTest.kt
@@ -7,7 +7,7 @@ class BackStackPopTest {
 
     @Test
     fun pop_removes_top_entry() {
-        val backStack = mutableListOf<Any>(Home, Profile)
+        val backStack = mutableListOf<Any>(Home, Settings)
         backStack.safePop()
         assertEquals(listOf<Any>(Home), backStack)
     }
@@ -15,7 +15,7 @@ class BackStackPopTest {
     @Test
     fun double_pop_keeps_root() {
         // 模拟转场动画期间二次点击返回：第二次出栈必须被吞掉，栈底 Home 不可弹出
-        val backStack = mutableListOf<Any>(Home, Profile)
+        val backStack = mutableListOf<Any>(Home, Settings)
         backStack.safePop()
         backStack.safePop()
         assertEquals(listOf<Any>(Home), backStack)
@@ -30,8 +30,8 @@ class BackStackPopTest {
 
     @Test
     fun pop_deep_stack_removes_only_top() {
-        val backStack = mutableListOf<Any>(Home, Profile, Favorites, RepoDetail("a", "b"))
+        val backStack = mutableListOf<Any>(Home, Settings, Favorites, RepoDetail("a", "b"))
         backStack.safePop()
-        assertEquals(listOf<Any>(Home, Profile, Favorites), backStack)
+        assertEquals(listOf<Any>(Home, Settings, Favorites), backStack)
     }
 }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt
@@ -131,10 +131,10 @@ class SettingsManagerTest {
     }
 
     @Test
-    fun defaultHomeTab_defaults_to_trending_and_persists() = runTest {
-        // 默认值：Trending
-        assertEquals("Trending", manager.currentDefaultHomeTab())
-        assertEquals("Trending", manager.defaultHomeTab.first())
+    fun defaultHomeTab_defaults_to_home_and_persists() = runTest {
+        // 默认值：Home
+        assertEquals("Home", manager.currentDefaultHomeTab())
+        assertEquals("Home", manager.defaultHomeTab.first())
 
         // 改为 Picks
         manager.setDefaultHomeTab("Picks")

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt
@@ -131,10 +131,10 @@ class SettingsManagerTest {
     }
 
     @Test
-    fun defaultHomeTab_defaults_to_github_and_persists() = runTest {
-        // 默认值：GitHub
-        assertEquals("GitHub", manager.currentDefaultHomeTab())
-        assertEquals("GitHub", manager.defaultHomeTab.first())
+    fun defaultHomeTab_defaults_to_trending_and_persists() = runTest {
+        // 默认值：Trending
+        assertEquals("Trending", manager.currentDefaultHomeTab())
+        assertEquals("Trending", manager.defaultHomeTab.first())
 
         // 改为 Picks
         manager.setDefaultHomeTab("Picks")
@@ -144,5 +144,19 @@ class SettingsManagerTest {
         // 模拟应用重启：同一份底层存储，新建 manager
         val rebuilt = SettingsManager(settings)
         assertEquals("Picks", rebuilt.currentDefaultHomeTab())
+    }
+
+    @Test
+    fun trendingSource_defaults_to_github_and_persists() = runTest {
+        // 默认值：GitHub
+        assertEquals("GitHub", manager.currentTrendingSource())
+
+        // 切到 HN
+        manager.setTrendingSource("HackerNews")
+        assertEquals("HackerNews", manager.currentTrendingSource())
+
+        // 模拟应用重启：上次看的源要能带回来
+        val rebuilt = SettingsManager(settings)
+        assertEquals("HackerNews", rebuilt.currentTrendingSource())
     }
 }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/home/HomeTabRequestTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/home/HomeTabRequestTest.kt
@@ -25,7 +25,7 @@ class HomeTabRequestTest {
 
     @Test
     fun latestRequestWins() {
-        HomeTabRequest.request(HomeTab.Trending)
+        HomeTabRequest.request(HomeTab.Home)
         HomeTabRequest.request(HomeTab.Picks)
         assertEquals(HomeTab.Picks, HomeTabRequest.pending.value)
     }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/home/HomeTabRequestTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/home/HomeTabRequestTest.kt
@@ -25,7 +25,7 @@ class HomeTabRequestTest {
 
     @Test
     fun latestRequestWins() {
-        HomeTabRequest.request(HomeTab.GitHub)
+        HomeTabRequest.request(HomeTab.Trending)
         HomeTabRequest.request(HomeTab.Picks)
         assertEquals(HomeTab.Picks, HomeTabRequest.pending.value)
     }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/home/HomeTabTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/home/HomeTabTest.kt
@@ -14,26 +14,27 @@ class HomeTabTest {
     }
 
     @Test
-    fun fromNameOrDefault_falls_back_to_trending_on_unknown_name() {
-        assertEquals(HomeTab.Trending, HomeTab.fromNameOrDefault("NoSuchTab"))
+    fun fromNameOrDefault_falls_back_to_home_on_unknown_name() {
+        assertEquals(HomeTab.Home, HomeTab.fromNameOrDefault("NoSuchTab"))
     }
 
     @Test
-    fun fromNameOrDefault_falls_back_to_trending_on_blank() {
-        assertEquals(HomeTab.Trending, HomeTab.fromNameOrDefault(""))
+    fun fromNameOrDefault_falls_back_to_home_on_blank() {
+        assertEquals(HomeTab.Home, HomeTab.fromNameOrDefault(""))
     }
 
     @Test
     fun fromNameOrDefault_is_case_sensitive_like_storage() {
-        // 存储值就是 HomeTab.name 原文，大小写不符视为非法、回落 Trending
-        assertEquals(HomeTab.Trending, HomeTab.fromNameOrDefault("picks"))
+        // 存储值就是 HomeTab.name 原文，大小写不符视为非法、回落 Home
+        assertEquals(HomeTab.Home, HomeTab.fromNameOrDefault("picks"))
     }
 
     @Test
-    fun legacy_source_tabs_resolve_to_trending() {
-        // 0.23 前底栏的三个源名：它们现在是 Trending 的子源，落到 Trending 才是同一个位置
-        listOf("GitHub", "HackerNews", "ProductHunt").forEach { legacy ->
-            assertEquals(HomeTab.Trending, HomeTab.fromNameOrDefault(legacy))
+    fun legacy_tab_names_resolve_to_home() {
+        // GitHub/HackerNews/ProductHunt 是 0.23 前的三个一级 tab（现为首页的子源），
+        // Trending 是首页 tab 改名前的旧名——存量值全靠回落收口，落点与改名前一致
+        listOf("GitHub", "HackerNews", "ProductHunt", "Trending").forEach { legacy ->
+            assertEquals(HomeTab.Home, HomeTab.fromNameOrDefault(legacy))
         }
     }
 
@@ -46,13 +47,13 @@ class HomeTabTest {
     @Test
     fun defaultCandidates_excludes_chat() {
         assertFalse(HomeTab.Chat in HomeTab.defaultCandidates)
-        assertEquals(listOf(HomeTab.Trending, HomeTab.Picks, HomeTab.Me), HomeTab.defaultCandidates)
+        assertEquals(listOf(HomeTab.Home, HomeTab.Picks, HomeTab.Me), HomeTab.defaultCandidates)
     }
 
     @Test
     fun defaultFromName_treats_chat_as_invalid() {
         // Chat 只是入口：即便被写进设置也不能当落点
-        assertEquals(HomeTab.Trending, HomeTab.defaultFromName(HomeTab.Chat.name))
+        assertEquals(HomeTab.Home, HomeTab.defaultFromName(HomeTab.Chat.name))
         assertEquals(HomeTab.Me, HomeTab.defaultFromName(HomeTab.Me.name))
     }
 }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/home/HomeTabTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/home/HomeTabTest.kt
@@ -2,6 +2,7 @@ package whl.trending.ai.ui.home
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class HomeTabTest {
 
@@ -13,18 +14,62 @@ class HomeTabTest {
     }
 
     @Test
-    fun fromNameOrDefault_falls_back_to_github_on_unknown_name() {
-        assertEquals(HomeTab.GitHub, HomeTab.fromNameOrDefault("NoSuchTab"))
+    fun fromNameOrDefault_falls_back_to_trending_on_unknown_name() {
+        assertEquals(HomeTab.Trending, HomeTab.fromNameOrDefault("NoSuchTab"))
     }
 
     @Test
-    fun fromNameOrDefault_falls_back_to_github_on_blank() {
-        assertEquals(HomeTab.GitHub, HomeTab.fromNameOrDefault(""))
+    fun fromNameOrDefault_falls_back_to_trending_on_blank() {
+        assertEquals(HomeTab.Trending, HomeTab.fromNameOrDefault(""))
     }
 
     @Test
     fun fromNameOrDefault_is_case_sensitive_like_storage() {
-        // 存储值就是 HomeTab.name 原文，大小写不符视为非法、回落 GitHub
-        assertEquals(HomeTab.GitHub, HomeTab.fromNameOrDefault("picks"))
+        // 存储值就是 HomeTab.name 原文，大小写不符视为非法、回落 Trending
+        assertEquals(HomeTab.Trending, HomeTab.fromNameOrDefault("picks"))
+    }
+
+    @Test
+    fun legacy_source_tabs_resolve_to_trending() {
+        // 0.23 前底栏的三个源名：它们现在是 Trending 的子源，落到 Trending 才是同一个位置
+        listOf("GitHub", "HackerNews", "ProductHunt").forEach { legacy ->
+            assertEquals(HomeTab.Trending, HomeTab.fromNameOrDefault(legacy))
+        }
+    }
+
+    @Test
+    fun picks_survives_the_rename() {
+        // Picks 名字没变，老用户存的默认首页应当原样保留
+        assertEquals(HomeTab.Picks, HomeTab.fromNameOrDefault("Picks"))
+    }
+
+    @Test
+    fun defaultCandidates_excludes_chat() {
+        assertFalse(HomeTab.Chat in HomeTab.defaultCandidates)
+        assertEquals(listOf(HomeTab.Trending, HomeTab.Picks, HomeTab.Me), HomeTab.defaultCandidates)
+    }
+
+    @Test
+    fun defaultFromName_treats_chat_as_invalid() {
+        // Chat 只是入口：即便被写进设置也不能当落点
+        assertEquals(HomeTab.Trending, HomeTab.defaultFromName(HomeTab.Chat.name))
+        assertEquals(HomeTab.Me, HomeTab.defaultFromName(HomeTab.Me.name))
+    }
+}
+
+class TrendingSourceTest {
+
+    @Test
+    fun fromNameOrDefault_resolves_every_valid_name() {
+        TrendingSource.entries.forEach { source ->
+            assertEquals(source, TrendingSource.fromNameOrDefault(source.name))
+        }
+    }
+
+    @Test
+    fun fromNameOrDefault_falls_back_to_github() {
+        assertEquals(TrendingSource.GitHub, TrendingSource.fromNameOrDefault("NoSuchSource"))
+        assertEquals(TrendingSource.GitHub, TrendingSource.fromNameOrDefault(""))
+        assertEquals(TrendingSource.GitHub, TrendingSource.fromNameOrDefault("hackernews"))
     }
 }


### PR DESCRIPTION
参照 [Echo Music](https://github.com/EchoMusicApp/Echo-Music) 对首页做了一轮改版，分四个阶段推进，每阶段都在 Pixel_9_2 模拟器上验证过；最后一版还在小米 13 上跑了 release 包（R8 混淆开启，启动无崩溃）。

## 改了什么

**① 个人中心与设置拆分**（`cca7280`）
原账户中心把身份、额度、设置分组混在一页，低频偏好还要再折叠一层「应用设置」子页。拆成 `ProfileScreen`（身份 / 套餐用量 / GitHub 入口 / 收藏 / 退出登录）与 `SettingsScreen`（外观、界面语言、摘要语言、默认首页、邮件订阅、每日推送、外链打开方式、反馈，分三组平铺）。「应用设置」这层折叠随之删除。

**② 首页 tab 重排**（`92a3dda`）
底栏从 GitHub / HN / PH / Picks 变为 **首页 / Picks / AI 对话 / 我的**。三个源收进首页，用 `SecondaryTabRow` 切换（只点击、不横滑）；GitHub 独有的筛选、历史、只看 New 仍在顶栏 actions，随子源显隐。AI 对话点击直接推全屏聊天页，底栏选中态留在原 tab；iOS 上该项隐藏。「我的」升为一级 tab，各页顶栏的头像入口与首页的 AI 悬浮 FAB 一并删除。

**③ 悬浮胶囊底栏**（`30d1ab2` `e073fcb` `35e3c75`）
标准 NavigationBar 换成 M3 Expressive 的 `HorizontalFloatingToolbar`：胶囊按内容宽度收紧居中，右侧独立圆形 FAB 承载「⋯」菜单（设置 / 关于我们）。选中态是跟着选中项 spring 滑动的药丸。底栏浮在内容之上，新增 `LocalContentBottomPadding` 把遮挡高度透给各内容页。

**④ 转场与图标**（`9687fc0` `2b70811` `69d5850` `3be4d2b` `721e4a2`）
切 tab 与页面跳转统一为「1/8 屏方向性位移 + 200ms 淡入淡出」；底栏图标改实心/描边双态，选中 Crossfade 切换。

## 与 Echo 的对齐程度

尺寸、形状、动画参数、配色常量逐项照抄（72dp 槽位、480dp 上限、24dp 圆角、48dp 最小宽、spring 参数、按下 0.91、选中放大 1.12、surfaceContainer / primaryContainer / secondaryContainer）。

有意保留的差异：底栏挂在 HomeScreen 内而非 NavHost 之外（Echo 进二级页时底栏竖向滑走，我们是跟着页面横向滑出）；不做 liquidGlass、iOS26 悬浮 tab bar、横屏 Rail；FAB 显式传 `CircleShape`（CMP 版 material3 默认形状与 androidx 版不同，不传拿不到同款外观）。

## 兼容性与埋点

- **默认首页设置**：存的是 `HomeTab.name` 字符串，靠 `fromNameOrDefault` 回落收口，不写迁移代码。旧值 `GitHub`/`HackerNews`/`ProductHunt`（0.23 前的三个一级 tab）与 `Trending`（首页 tab 改名前的旧名）都匹配不上，统一落到 `Home`——落点与改名前一致；`Picks`/`Me` 正常匹配。
- **通知深链** `HomeTabRequest.request(HomeTab.Picks)` 不受影响。
- **埋点断点**：`tab_switch` / `tab_double_tap_refresh` 的 `tab` 取值随枚举变化（→ `home`/`picks`/`chat`/`me`）；新增 `trending_source_switch`；`settings_app_settings` 作废，个人中心的设置入口改名 `profile_open_settings`。拉相关漏斗需按版本切段。

## 验证

- `:androidApp:compileR2DebugKotlin`、`:shared:testAndroidHostTest` 全绿；`HomeTabTest` 补了存量值回落与 Chat 排除，新增 `TrendingSourceTest`，`SettingsManagerTest` 补了子源持久化
- 模拟器走过：三源切换、Chat 进出、我的 tab、冷启动子源记忆、⋯ 菜单跳转、列表滚到底不被胶囊遮挡
- 小米 13 上 r2 release 包（R8 开启）启动正常、无崩溃

## 尚未验证

深色 / AMOLED 观感、登录态下的「我的」页、iOS 端编译与三 tab 退化形态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfDK8nydHuwHBkSdAEdH32

## Summary by Sourcery

重构首页体验，采用包含四个标签页的布局和悬浮胶囊形底部栏，引入独立的个人资料和设置页面，并使导航与动效与 Echo Music 的设计保持一致。

New Features:
- 引入一个 Home 标签页，将 GitHub、Hacker News 和 Product Hunt 的信息流聚合在一起，并通过内部的二级标签行在不同来源之间切换。
- 在底部栏新增 Chat 入口，打开全屏 AI 聊天界面的同时保持原始标签页处于选中状态。
- 将个人资料体验提升为顶级 Me 标签页，引入焕新的 Profile 界面，重点展示身份信息、配额、GitHub 入口以及收藏内容。
- 新增独立的 Settings 界面，集中管理外观、语言、默认首页标签、链接行为、订阅以及通知偏好。
- 实现悬浮的水平底部工具栏，仅使用图标按钮，带有滑动药丸式选中指示器，并通过溢出 FAB 暴露 Settings 和 About 功能。

Enhancements:
- 将最近一次选中的 trending 来源与默认首页标签分开持久化存储，使首页能够恢复到上次查看的内容源。
- 统一页面与标签切换的过渡动效，采用短距离横向滑动加淡入淡出动画，打造一致的导航体验。
- 调整顶部栏以反映新的标签结构，移除内联账号入口，改为通过 Me 标签和溢出菜单访问。
- 新增共享的 LocalContentBottomPadding，确保可滚动内容和 snackbars 不会被悬浮底部栏遮挡。
- 优化首页标签枚举及默认解析逻辑，将旧版标签名称和 Chat 入口视为向后兼容的默认值。

Tests:
- 扩展 HomeTab 测试范围，覆盖旧版映射、默认候选项以及 Chat 处理，并新增 TrendingSource 名称解析相关测试。
- 扩展 SettingsManager 测试范围，覆盖新的默认首页标签值和持久化 trending 来源的行为。
- 更新返回栈测试，以反映新的 Settings 目的地，替代已移除的 Profile 路由。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revamp the home experience to use a four-tab layout with a floating capsule bottom bar, introduce dedicated profile and settings screens, and align navigation and animations with the Echo Music design.

New Features:
- Introduce a Home tab that aggregates GitHub, Hacker News, and Product Hunt feeds with an internal secondary tab row for source switching.
- Add a Chat entry in the bottom bar that opens the full-screen AI chat while keeping the original tab selected.
- Promote the profile experience to a top-level Me tab with a refreshed Profile screen focused on identity, quota, GitHub entry, and favorites.
- Add a standalone Settings screen that centralizes appearance, language, default home tab, link behavior, subscriptions, and notifications preferences.
- Implement a floating horizontal bottom toolbar with icon-only items, a sliding pill selection indicator, and an overflow FAB exposing Settings and About.

Enhancements:
- Persist the last selected trending source separately from the default home tab so home resumes on the last-viewed feed.
- Unify page and tab-switch transitions to short horizontal slide plus fade animations for a consistent navigation feel.
- Adjust top bars to reflect the new tab structure and remove inline account entry in favor of the Me tab and overflow menu.
- Add a shared LocalContentBottomPadding to ensure scrollable content and snackbars are not obscured by the floating bottom bar.
- Refine home tab enums and default resolution logic to treat legacy tab names and the Chat entry as non-breaking defaults.

Tests:
- Extend HomeTab tests to cover legacy mappings, default candidates, and Chat handling, and add tests for TrendingSource name resolution.
- Expand SettingsManager tests to cover the new default home tab value and persisted trending source behavior.
- Update back stack tests to reflect the new Settings destination instead of the removed Profile route.

</details>