### PR TITLE
设置页 / 关于页 /「我的」页统一为 M3 Expressive 卡片组

### DIFF
--- a/docs/home-redesign-handover.md
+++ b/docs/home-redesign-handover.md
@@ -61,7 +61,7 @@
    两个低值都不构成问题：**药丸**的选中态是三重信号叠加（药丸底色 + 图标从描边变实心 + 图标提亮到 196 vs 未选中 174），不靠色差单打独斗；**胶囊**靠形状与阴影立起来，且 Echo 在 pureBlack 档更极端——它把胶囊直接压成 `Color.Black`（`FloatingNavigationToolbar.kt:512`），与纯黑页面零色差，我们交给主题层的 AMOLED 反而留了 1.20:1。截图放大核对过，两档下胶囊边界、药丸、实心/描边差异都清晰。
 
    同日修掉的深色专有 bug：一级页转场整屏白闪——根部缺兜底底色，fade 那 200ms 透出了 window 背景，而 window 主题是 `AppCompat.DayNight`、跟系统深浅走，app 内深色/AMOLED 传不过去。修法照抄 Echo `MainActivity.kt:559` 的 `BoxWithConstraints(.background(...))`，见 `App.kt` 的 `Box(Modifier.fillMaxSize().background(colorScheme.background))`。
-2. **登录态下的「我的」页** — 身份区、额度条、GitHub 入口卡在登录后长什么样，一次都没看过。需真登一次 GitHub。
+2. ~~**登录态下的「我的」页**~~ — **2026-08-05 已验**（模拟器为 Pro + 已关联 GitHub 的登录态）：身份区的头像 / 名称 / PRO 徽章 / 邮箱、额度条的「0% used + 重置倒计时 + Pro 文案」、GitHub 入口卡的头像与 followers/repos 摘要，渲染均正常。同一轮把「我的」页的三个列表项（GitHub 入口 / 收藏 / 退出登录）一并卡片化了。
 
 （iOS 端不作验证要求，见下方「其他产品决策」。）
 

--- a/docs/settings-style-comparison.md
+++ b/docs/settings-style-comparison.md
@@ -167,13 +167,19 @@ fun SettingsGroup(title: String? = null, items: List<SettingsItem>)
 
 ---
 
-## 七、需要拍板的三件事
+## 七、已定的决策（2026-08-05，迁移已完成）
 
-1. **图标容器形状** — 圆角方 12dp（Echo）／圆形（Rhythm）／多边形 Cookie4Sided（EchoFlow）。倾向圆形：与首页底栏的圆形药丸、头像同语言，最省心；多边形最"Expressive"但要引入 `MaterialShapes` 依赖，且和我们现有的圆角语言差异大。
-2. **按压缩放反馈** — 是否抄 Rhythm 的 0.97 缩放（代价是要关掉 ripple 自己接 `interactionSource`）。
-3. **改造边界** — 只改 `SettingsScreen`，还是连 `AboutScreen`、「我的」页一起统一。
+迁移在 `feat/settings-card-style` 分支落地，覆盖设置页、关于页、「我的」页三处。当时留白的选项都已拍板：
 
----
+| 项 | 决定 | 说明 |
+|---|---|---|
+| 图标容器形状 | **圆形** | 与首页底栏的圆形药丸、头像同语言 |
+| 卡片底色 | `surfaceContainer` | 与统一后的顶栏一致 |
+| 组件 API | **slot API**，不用数据类 | 见 6.1；后续只加了一个 `leading` slot（给「我的」页 GitHub 入口的 40dp 头像用） |
+| 按压缩放反馈 | **不做** | 只有 Rhythm 有。它是全局手感决策——全 app 其余部分都是 ripple，只在设置页换成缩放会更不自洽。要做得整体换，另开一轮 |
+| 长描述行高不均 | **不调** | 「应用语言」「默认首页 tab」「外链打开方式」的描述会换行，卡片高度参差；维持规格值不动 |
+| 退出登录的图标色 | **不特化** | 文字保持 `error` 色，图标沿用默认容器色，不为此给 `settingsItem` 加颜色参数 |
+| 改造边界 | 设置页 + 关于页 + 「我的」页 | `AppearanceScreen` 主体是主题选择卡，不动；`PlanUsageCard` / `AccountHeader` 是特化组件，不动 |
 
 ## 附：本文引用的源码位置
 

--- a/docs/settings-style-comparison.md
+++ b/docs/settings-style-comparison.md
@@ -1,0 +1,185 @@
+# 设置页与主题实现对比：Echo / Rhythm / EchoFlow vs TrendingAI
+
+三个参照仓库常驻 `TrendingProjects/.refs/` （见父目录 `CLAUDE.md` 的「参照仓库」节）。本文对比它们与 TrendingAI 在**主题层**和**设置页组件层**的实现，并给出对齐方案。2026-08-05 成文，代码位置以当时的 HEAD 为准。
+
+---
+
+## 一、一句话结论
+
+**差异在组件范式，不在颜色和字号。**
+
+三个参照仓库共享同一套「**连体卡片式设置组**」：每个设置项是一张独立卡片，同组内首尾大圆角、中间小圆角、彼此留 4dp 缝，图标装在 40dp 的着色容器里。Echo 和 Rhythm 甚至有**同名文件** `Material3SettingsGroup.kt`，连注释里的圆角规则都一致；EchoFlow 换了名字（`groupedItemShape()`），做的是同一件事。
+
+TrendingAI 用的是**裸 `ListItem` + `HorizontalDivider`** 的标准 M3 列表范式：没有卡片、没有圆角、没有图标容器，靠分隔线分组。
+
+所以你看到的"它们仨像、我们不像"，根源是这个。反过来说，只要补上这套组件，视觉就能对齐——主题层我们其实比它们做得更多（见第四节）。
+
+---
+
+## 二、设置项范式对比（核心）
+
+| 维度 | Echo | Rhythm | EchoFlow | **TrendingAI** |
+|---|---|---|---|---|
+| 组件文件 | `ui/component/Material3SettingsGroup.kt` | `shared/presentation/components/Material3SettingsGroup.kt` | `ui/components/ExpressiveComponents.kt` + `ui/screens/SettingsComponents.kt` | 无，直接在 `SettingsScreen.kt` 里堆 `ListItem` |
+| 单项容器 | `Card`，elevation 0 | `Card`，elevation 0 | `Card` / `Surface` | 无容器 |
+| 容器底色 | `surfaceVariant` @30% | `surfaceContainer`（可传参） | `surface` / `surfaceContainerLow` | `surface`（ListItem 默认） |
+| 圆角 | 单项 24；首 24/6，中 6，末 6/24 | 同左，另支持 `itemShape`/`lastItemShape` 覆盖以拼接更大卡组 | `groupedItemShape(large=22, small=6)` | 无圆角 |
+| 项间距 | 4dp | 4dp | Spacing 体系 | 0（贴合） |
+| 组间分隔 | 靠圆角+标题 | 靠圆角+标题 | 靠圆角+标题 | `HorizontalDivider` |
+| 行内边距 | h20 / v16（compact h14/v10） | h21 / v16 | h16 / v12 | ListItem 默认 h16 / v8~12 |
+| 图标容器 | 40dp，圆角 12dp 方形 | 40dp，**圆形** `Surface` | 40dp，**多边形** `RoundedPolygonShape(MaterialShapes.Cookie4Sided)` | **无容器**，裸 `Icon` |
+| 容器底色 | `primary` @10%（高亮 15%） | `secondaryContainer`（高亮 `primaryContainer` + tonalElevation 2dp） | `secondaryContainer` / `tertiaryContainer` | — |
+| 图标尺寸/色 | 24dp，`primary` @90% | 24dp，`onSecondaryContainer` | 20dp，`onSecondaryContainer` | 24dp，`onSurfaceVariant`（默认） |
+| 图标↔文字间距 | 16dp（自定义图标 20dp） | 16dp | 16dp | ListItem 默认 |
+| 标题 | `titleMedium` / `onSurface` | `titleMedium` / `onSurface` | `titleMedium` | `bodyLarge`（ListItem 默认） |
+| 副标题 | `bodyMedium` / `onSurfaceVariant`，间隔 2dp | 同左 | `bodyMedium` | `bodyMedium`（ListItem 默认） |
+| 分组标题 | `labelLarge` + `primary`，上下 8dp | `labelLarge` + `primary`，上 18 下 8 | `labelLarge` + `primary`，start16/top4/bottom8 | **`labelLarge` + `primary`，h16 v8** ✅ 已一致 |
+| 按压反馈 | 默认 ripple | **缩放 0.97 + spring(MediumBouncy)**，关掉 ripple | 默认 | 默认 ripple |
+| 数据结构 | `data class Material3SettingsItem`（11 字段） | 同名（12 字段，多 `scope`/`leadingContent`） | 每类行一个 composable | 无，逐个手写 |
+
+**唯一已经对齐的一格**：分组标题样式（`SettingsScreen.kt:438` 的 `SettingsHeader`）——`labelLarge` + `primary` 与三家完全一致。其余全不同。
+
+### 调用方式的差别
+
+三家都是**声明式清单**，一组就是一个 `items = listOf(...)`：
+
+```kotlin
+// Rhythm: GoSettingsScreen.kt:178
+Material3SettingsGroup(
+    title = stringResource(R.string.streaming_settings_group_services),
+    items = listOf(
+        Material3SettingsItem(
+            icon = MaterialSymbolIcon("cloud_queue"),
+            title = { Text(...) },
+            description = { Text(selectedService) },
+            onClick = { showServiceSheet = true },
+        ),
+        ...
+    )
+)
+```
+
+我们是**逐项手写**（`SettingsScreen.kt:205` 起）：每项一个 `LazyColumn.item { ListItem(...) }`，圆角、间距、图标容器这些无处安放，加一项就要复制一遍模板。这也是 589 行的由来。
+
+---
+
+## 三、三家为什么长得像
+
+把三份实现叠在一起看，共同点收敛成五条，可以直接当作"这套风格"的定义：
+
+1. **连体卡片组** — 首项顶部大圆角、末项底部大圆角、中间一律 6dp，组内留 4dp 缝。视觉上是一整块被切开的圆角面板。大圆角取值：Echo/Rhythm 24dp，EchoFlow 22dp。
+2. **图标必有容器** — 统一 40dp，填一个 container 系颜色，图标 20–24dp。形状是三家唯一的分歧点（圆角方 / 圆 / 多边形）。
+3. **标题升一级** — `titleMedium` 而非 M3 `ListItem` 默认的 `bodyLarge`，副标题 `bodyMedium`，行高因此比标准 list item 高一截（约 72–80dp）。
+4. **不用分隔线** — 分组靠卡片边界和 `primary` 色小标题，页面上没有任何 `HorizontalDivider`。
+5. **数据驱动** — 一个 `SettingsItem` 数据类 + 一个渲染器，页面只声明内容。
+
+---
+
+## 四、主题层对比
+
+| 维度 | Echo | Rhythm | EchoFlow | **TrendingAI** |
+|---|---|---|---|---|
+| 配色来源 | Material You 壁纸动态色，不可用时回落手写 scheme | 动态色 + **多套手写预设 palette** | 动态色 + 品牌 `darkColorScheme` | **materialKolor 由 seed 生成**（15 个预设 + 调色台自定义） |
+| 壁纸动态色 | ✅ | ✅ | ✅ | ❌ 不支持 |
+| 纯黑档 | `ColorScheme.pureBlack()` 覆盖 `surface`/`background` = `Color.Black` | `amoledTheme` 参数，深色时覆盖 | 无 | ✅ materialKolor 的 `isAmoled` |
+| 对比度档位 | ❌ | ❌ | ❌ | ✅ `contrastLevel` |
+| 配色风格档位 | ❌ | 主题预设切换 | ❌ | ✅ `style`（TonalSpot/Vibrant/…） |
+| 色规版本 | 库默认 | 库默认 | 库默认 | ✅ 显式 `SPEC_2025` |
+| 形状体系 | 无集中定义 | `Shape.kt` + `MaterialShapesUtils.kt` | `Shape.kt` + `ExpressiveShapes.kt` | 无集中定义 |
+| 间距体系 | 散在各处 | 散在各处 | ✅ `Spacing.kt`（xs4/s8/m12/base16/l20/xl24/xxl32/huge48） | 散在各处 |
+| 动效体系 | 散在各处 | 组件内 spring | ✅ `Motion.kt` | 散在各处 |
+
+**结论**：主题层我们不落后，反而在可定制性上最强（seed 调色台 + 对比度 + 风格档 + SPEC_2025 是它们都没有的）。真正缺的是**壁纸动态色**（Material You）这一项，以及 EchoFlow 那种把间距/形状/动效抽成常量的工程习惯。
+
+---
+
+## 五、差异清单（按肉眼可感知度排序）
+
+| # | 差异 | 感知度 | 对齐成本 |
+|---|---|---|---|
+| 1 | 卡片组 vs 裸列表 | ★★★★★ | 中 |
+| 2 | 图标有无容器 | ★★★★☆ | 小（随 #1 一起做） |
+| 3 | 标题字号 `bodyLarge` → `titleMedium` | ★★★☆☆ | 小 |
+| 4 | 分隔线 vs 圆角分组 | ★★★☆☆ | 小（随 #1 消失） |
+| 5 | 按压缩放反馈（仅 Rhythm 有） | ★★☆☆☆ | 小 |
+| 6 | 页面主标题层级（`displaySmall`/`titleLarge`，见 `home-redesign-handover.md` 待办 A2） | ★★☆☆☆ | 小 |
+| 7 | 间距常量体系 | ★☆☆☆☆（不可见，影响维护） | 中 |
+| 8 | 壁纸动态色 | 不可见（能力缺失） | 中大，且与现有调色台冲突，**建议不做** |
+
+---
+
+## 六、对齐方案
+
+### 6.1 新增组件
+
+在 `shared/src/commonMain/kotlin/whl/trending/ai/ui/common/` 下新建 `SettingsGroup.kt`，提供：
+
+```kotlin
+data class SettingsItem(
+    val icon: ImageVector? = null,
+    val title: @Composable () -> Unit,
+    val description: (@Composable () -> Unit)? = null,
+    val trailingContent: (@Composable () -> Unit)? = null,
+    val enabled: Boolean = true,
+    val onClick: (() -> Unit)? = null,
+)
+
+@Composable
+fun SettingsGroup(title: String? = null, items: List<SettingsItem>)
+```
+
+刻意**不抄**的字段：Rhythm 的 `scope`（我们没有 Local/Streaming 之分）、Echo 的 `showBadge`/`isHighlighted`/`scrollToOnHighlight`（那是给设置项搜索定位用的，我们没有搜索）。将来要就再加。
+
+### 6.2 规格建议（取三家交集 + 我们自己的 token）
+
+| 项 | 建议值 | 依据 |
+|---|---|---|
+| 卡片圆角 | 单项 24；首 24/6，中 6，末 6/24 | Echo 与 Rhythm 一致 |
+| 项间距 | 4dp | 三家一致 |
+| 卡片底色 | `surfaceContainer` | 跟 Rhythm；Echo 的 `surfaceVariant`@30% 在我们的 AMOLED 档下会偏灰，且我们顶栏刚统一到 `surfaceContainer`（`fc1579e`），一致 |
+| elevation | 0 | 三家一致 |
+| 行内边距 | h20 / v16 | Echo 20、Rhythm 21，取整 |
+| 图标容器 | 40dp，`secondaryContainer` 底，图标 24dp、`onSecondaryContainer` | 跟 Rhythm；与首页底栏选中药丸同一对 token，全 app 语言统一 |
+| 图标容器形状 | **待定**，见第七节 | 三家唯一分歧点 |
+| 标题 / 副标题 | `titleMedium`/`onSurface` + `bodyMedium`/`onSurfaceVariant`，间隔 2dp | 三家一致 |
+| trailing 前间距 | 8dp | 三家一致 |
+| 分组标题 | 保持现状（`labelLarge`+`primary`），上边距加到 18dp | Rhythm 的 top18 更透气；样式本来就一致 |
+
+### 6.3 改造范围
+
+| 文件 | 改动 |
+|---|---|
+| `ui/common/SettingsGroup.kt` | 新增，约 120 行 |
+| `ui/settings/SettingsScreen.kt` | 三组共 9 项改为声明式清单；删掉两个 `HorizontalDivider`；预计从 589 行减到 400 行上下 |
+| `ui/settings/AboutScreen.kt` | 同款改造（未细读，需先看结构） |
+| `ui/settings/AppearanceScreen.kt` | 主体是主题选择卡，**不改**，只有底部零散项按需并入 |
+| `ui/profile/ProfileScreen.kt` | 「我的」页也有列表项，可选，建议本轮不动 |
+
+工作量估计：组件 + `SettingsScreen` 半天，含深浅三档验证。`AboutScreen` 另算。
+
+### 6.4 风险点
+
+- **trailing 控件适配**：我们的设置项 trailing 有下拉菜单锚点（`Box` + `DropdownMenu`）、`Switch`、纯文本三种。卡片化后行高变大，下拉菜单的锚点位置要重验，别弹到屏幕外。
+- **`LazyColumn` 的 key**：现在每项一个 `item(key=...)`，改成一组一个 `item` 后 key 要重排，注意别让滚动位置跳。
+- **iOS 端**：`shared` 里的改动 iOS 同样吃到，但按既有决策不做 iOS 验证（见 `home-redesign-handover.md`）。
+- **R8**：纯 UI 改动，无反射，风险低；发版前照常跑 `scripts/release-smoke.sh`。
+- **许可证**：Echo 和 Rhythm 都是 GPL-3.0，TrendingAI 是 MIT，**只能照着规格自己写，不能复制代码**；EchoFlow 是 MIT 可复制但需保留版权声明。本文列的是规格数值（尺寸、token、层级），不构成代码复制。
+
+---
+
+## 七、需要拍板的三件事
+
+1. **图标容器形状** — 圆角方 12dp（Echo）／圆形（Rhythm）／多边形 Cookie4Sided（EchoFlow）。倾向圆形：与首页底栏的圆形药丸、头像同语言，最省心；多边形最"Expressive"但要引入 `MaterialShapes` 依赖，且和我们现有的圆角语言差异大。
+2. **按压缩放反馈** — 是否抄 Rhythm 的 0.97 缩放（代价是要关掉 ripple 自己接 `interactionSource`）。
+3. **改造边界** — 只改 `SettingsScreen`，还是连 `AboutScreen`、「我的」页一起统一。
+
+---
+
+## 附：本文引用的源码位置
+
+| 仓库 | 文件 |
+|---|---|
+| Echo | `.refs/Echo-Music/app/src/main/kotlin/com/music/echo/ui/component/Material3SettingsGroup.kt`（261 行）、`ui/theme/Theme.kt` |
+| Rhythm | `.refs/Rhythm/app/src/main/java/chromahub/rhythm/app/shared/presentation/components/Material3SettingsGroup.kt`（310 行）、`shared/presentation/theme/Theme.kt`、`features/streaming/presentation/screens/GoSettingsScreen.kt:178`（调用范例） |
+| EchoFlow | `.refs/EchoFlow/app/src/main/java/com/echoflow/ui/components/ExpressiveComponents.kt:33`（`groupedItemShape`）、`ui/screens/SettingsComponents.kt`（788 行）、`ui/theme/Spacing.kt` |
+| TrendingAI | `shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt`（589 行，`SettingsHeader` 在 :438）、`ui/theme/TrendingTheme.kt` |

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SettingsGroup.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SettingsGroup.kt
@@ -81,10 +81,12 @@ class SettingsGroupScope internal constructor() {
 
     /**
      * 一个设置项。[trailing] 放开关、当前值、下拉菜单锚点等；整行点击走 [onClick]。
-     * 图标会被放进 40dp 的圆形容器里（与首页底栏选中药丸同一对 token）。
+     * [icon] 会被放进 40dp 的圆形容器里（与首页底栏选中药丸同一对 token）；
+     * 需要头像这类自带形状的前导元素时改用 [leading]，它优先于 [icon]，尺寸自理。
      */
     fun settingsItem(
         icon: ImageVector? = null,
+        leading: (@Composable () -> Unit)? = null,
         title: @Composable () -> Unit,
         description: (@Composable () -> Unit)? = null,
         enabled: Boolean = true,
@@ -95,6 +97,7 @@ class SettingsGroupScope internal constructor() {
             SettingsItemRow(
                 shape = shape,
                 icon = icon,
+                leading = leading,
                 title = title,
                 description = description,
                 enabled = enabled,
@@ -109,6 +112,7 @@ class SettingsGroupScope internal constructor() {
 private fun SettingsItemRow(
     shape: Shape,
     icon: ImageVector?,
+    leading: (@Composable () -> Unit)?,
     title: @Composable () -> Unit,
     description: (@Composable () -> Unit)?,
     enabled: Boolean,
@@ -134,7 +138,10 @@ private fun SettingsItemRow(
                 .padding(horizontal = 20.dp, vertical = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            icon?.let {
+            if (leading != null) {
+                leading()
+                Spacer(Modifier.width(16.dp))
+            } else icon?.let {
                 Surface(
                     modifier = Modifier.size(IconContainerSize),
                     shape = CircleShape,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SettingsGroup.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SettingsGroup.kt
@@ -1,0 +1,197 @@
+package whl.trending.ai.ui.common
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+/**
+ * 设置项分组：一组连体卡片。
+ *
+ * 每项一张独立卡片，组内首尾大圆角、中间小圆角、彼此留 4dp 缝，视觉上是一整块被切开的圆角面板。
+ * 分组之间靠圆角与 `primary` 色小标题分隔，**不用分隔线**。
+ *
+ * 用 slot API 而不是「一个 SettingsItem 数据类 + 遍历渲染」：参照仓库那套数据类会随特例不断长字段
+ * （Echo 11 个、Rhythm 12 个），而我们的设置项恰恰有 iOS 分支、Switch、DropdownMenu 锚点这些不规则
+ * 需求——slot 下它们就是调用处的普通 Compose 代码，组件不必知情。
+ *
+ * `content` 不是 `@Composable`：它先把每项收集成 lambda（同 `LazyListScope.item` 的做法），
+ * 收集完才知道总数，进而给每项分配正确的圆角。方法名叫 `settingsItem` 而不是 `item`，
+ * 是为了在 `LazyColumn.item { }` 内部调用时不与 `LazyListScope.item` 撞名。
+ *
+ * ```
+ * SettingsGroup(title = "个性化", modifier = Modifier.padding(horizontal = 16.dp)) {
+ *     item(
+ *         icon = Icons.Default.Palette,
+ *         title = { Text("外观") },
+ *         trailing = { Text(themeModeText(themeMode)) },
+ *         onClick = { onNavigateToAppearance() },
+ *     )
+ * }
+ * ```
+ */
+@Composable
+fun SettingsGroup(
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    content: SettingsGroupScope.() -> Unit,
+) {
+    val entries = SettingsGroupScope().apply(content).entries
+    Column(modifier = modifier.fillMaxWidth()) {
+        title?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(top = 18.dp, bottom = 8.dp),
+            )
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(ItemGap)) {
+            entries.forEachIndexed { index, entry ->
+                entry(groupItemShape(index, entries.size))
+            }
+        }
+    }
+}
+
+/** 收集设置项。见 [SettingsGroup] 的说明——这里收的是 lambda，渲染发生在拿到总数之后。 */
+class SettingsGroupScope internal constructor() {
+    internal val entries = mutableListOf<@Composable (Shape) -> Unit>()
+
+    /**
+     * 一个设置项。[trailing] 放开关、当前值、下拉菜单锚点等；整行点击走 [onClick]。
+     * 图标会被放进 40dp 的圆形容器里（与首页底栏选中药丸同一对 token）。
+     */
+    fun settingsItem(
+        icon: ImageVector? = null,
+        title: @Composable () -> Unit,
+        description: (@Composable () -> Unit)? = null,
+        enabled: Boolean = true,
+        onClick: (() -> Unit)? = null,
+        trailing: (@Composable () -> Unit)? = null,
+    ) {
+        entries += { shape ->
+            SettingsItemRow(
+                shape = shape,
+                icon = icon,
+                title = title,
+                description = description,
+                enabled = enabled,
+                onClick = onClick,
+                trailing = trailing,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SettingsItemRow(
+    shape: Shape,
+    icon: ImageVector?,
+    title: @Composable () -> Unit,
+    description: (@Composable () -> Unit)?,
+    enabled: Boolean,
+    onClick: (() -> Unit)?,
+    trailing: (@Composable () -> Unit)?,
+) {
+    val contentColor = if (enabled) {
+        MaterialTheme.colorScheme.onSurface
+    } else {
+        MaterialTheme.colorScheme.onSurface.copy(alpha = DisabledAlpha)
+    }
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = shape,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(
+                    if (onClick != null && enabled) Modifier.clickable(onClick = onClick) else Modifier
+                )
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            icon?.let {
+                Surface(
+                    modifier = Modifier.size(IconContainerSize),
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                ) {
+                    Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                        Icon(
+                            imageVector = it,
+                            contentDescription = null,
+                            tint = if (enabled) {
+                                MaterialTheme.colorScheme.onSecondaryContainer
+                            } else {
+                                MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = DisabledAlpha)
+                            },
+                            modifier = Modifier.size(IconSize),
+                        )
+                    }
+                }
+                Spacer(Modifier.width(16.dp))
+            }
+
+            Column(modifier = Modifier.weight(1f)) {
+                ProvideTextStyle(MaterialTheme.typography.titleMedium.copy(color = contentColor)) {
+                    title()
+                }
+                description?.let {
+                    Spacer(Modifier.height(2.dp))
+                    ProvideTextStyle(
+                        MaterialTheme.typography.bodyMedium.copy(
+                            color = if (enabled) {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            } else {
+                                MaterialTheme.colorScheme.onSurface.copy(alpha = DisabledAlpha)
+                            },
+                        )
+                    ) { it() }
+                }
+            }
+
+            trailing?.let {
+                Spacer(Modifier.width(8.dp))
+                it()
+            }
+        }
+    }
+}
+
+/** 首项顶部大圆角、末项底部大圆角、中间一律小圆角；只有一项时四角全大。 */
+private fun groupItemShape(index: Int, count: Int): Shape {
+    val top = if (index == 0) LargeCorner else SmallCorner
+    val bottom = if (index == count - 1) LargeCorner else SmallCorner
+    return RoundedCornerShape(topStart = top, topEnd = top, bottomStart = bottom, bottomEnd = bottom)
+}
+
+private val LargeCorner = 24.dp
+private val SmallCorner = 6.dp
+private val ItemGap = 4.dp
+private val IconContainerSize = 40.dp
+private val IconSize = 24.dp
+private const val DisabledAlpha = 0.38f

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SettingsGroup.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SettingsGroup.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 
 /**
@@ -42,7 +43,7 @@ import androidx.compose.ui.unit.dp
  *
  * ```
  * SettingsGroup(title = "个性化", modifier = Modifier.padding(horizontal = 16.dp)) {
- *     item(
+ *     settingsItem(
  *         icon = Icons.Default.Palette,
  *         title = { Text("外观") },
  *         trailing = { Text(themeModeText(themeMode)) },
@@ -132,8 +133,15 @@ private fun SettingsItemRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                // 只在有 onClick 时才挂 clickable：没有点击行为的行（「联系作者」、纯开关行）
+                // 不该带任何按钮语义。有 onClick 但 enabled=false 时仍挂着、由 clickable 自己
+                // 表达「暂不可用」（如正在检查更新），这样 TalkBack 才播报得出禁用态。
                 .then(
-                    if (onClick != null && enabled) Modifier.clickable(onClick = onClick) else Modifier
+                    if (onClick != null) {
+                        Modifier.clickable(enabled = enabled, role = Role.Button, onClick = onClick)
+                    } else {
+                        Modifier
+                    }
                 )
                 .padding(horizontal = 20.dp, vertical = 16.dp),
             verticalAlignment = Alignment.CenterVertically,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import whl.trending.ai.ui.common.LocalContentBottomPadding
+import whl.trending.ai.ui.common.SettingsGroup
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import kotlinx.coroutines.delay
@@ -246,43 +247,38 @@ fun ProfileScreen(
                         })
                     }
                 }
-
-                item(key = "divider_top") { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
             }
 
             // ④ 收藏入口。设置与关于我们不在这里——它们挂在底栏的「⋯」扩展菜单上，
                 // 两处都放会变成同一个入口的两个按钮。
             item(key = "favorites") {
-                ListItem(
-                    headlineContent = { Text(stringResource(Res.string.favorites)) },
-                    leadingContent = { Icon(Icons.Default.Favorite, null) },
-                    modifier = Modifier.clickable {
-                        trackEvent("settings_favorites")
-                        onNavigateToFavorites()
-                    }
-                )
+                SettingsGroup(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                    settingsItem(
+                        icon = Icons.Default.Favorite,
+                        title = { Text(stringResource(Res.string.favorites)) },
+                        onClick = {
+                            trackEvent("settings_favorites")
+                            onNavigateToFavorites()
+                        },
+                    )
+                }
             }
 
             // ⑤ 退出登录（仅登录用户）
             if (uiState.loggedIn) {
                 item(key = "sign_out") {
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-                    ListItem(
-                        headlineContent = {
-                            Text(
-                                stringResource(Res.string.sign_out),
-                                color = MaterialTheme.colorScheme.error,
-                            )
-                        },
-                        leadingContent = {
-                            Icon(
-                                Icons.AutoMirrored.Filled.Logout,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.error,
-                            )
-                        },
-                        modifier = Modifier.clickable { showSignOutDialog = true }
-                    )
+                    SettingsGroup(modifier = Modifier.padding(horizontal = 16.dp)) {
+                        settingsItem(
+                            icon = Icons.AutoMirrored.Filled.Logout,
+                            title = {
+                                Text(
+                                    stringResource(Res.string.sign_out),
+                                    color = MaterialTheme.colorScheme.error,
+                                )
+                            },
+                            onClick = { showSignOutDialog = true },
+                        )
+                    }
                 }
             }
             item(key = "bottom_spacer") { Spacer(Modifier.height(24.dp)) }
@@ -563,24 +559,25 @@ private fun TierPillFree() {
  */
 @Composable
 private fun LinkGithubCard(onClick: () -> Unit) {
-    ListItem(
-        headlineContent = { Text(stringResource(Res.string.account_link_github)) },
-        supportingContent = {
-            Text(
-                stringResource(Res.string.account_link_github_desc),
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-            )
-        },
-        leadingContent = {
-            Icon(Icons.Default.AccountCircle, null, modifier = Modifier.size(40.dp))
-        },
-        trailingContent = {
-            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
-        },
-        colors = ListItemDefaults.colors(containerColor = androidx.compose.ui.graphics.Color.Transparent),
-        modifier = Modifier.clickable(onClick = onClick),
-    )
+    SettingsGroup(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        settingsItem(
+            leading = {
+                Icon(Icons.Default.AccountCircle, null, modifier = Modifier.size(40.dp))
+            },
+            title = { Text(stringResource(Res.string.account_link_github)) },
+            description = {
+                Text(
+                    stringResource(Res.string.account_link_github_desc),
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            },
+            trailing = {
+                Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+            },
+            onClick = onClick,
+        )
+    }
 }
 
 /** GitHub 主页入口卡：头像 + 名称 + 计数摘要，点击进 [GithubProfileScreen]。 */
@@ -603,24 +600,25 @@ private fun GithubEntryCard(uiState: ProfileUiState, onClick: () -> Unit) {
     } else {
         stringResource(Res.string.account_github_entry_desc)
     }
-    ListItem(
-        headlineContent = { Text(stringResource(Res.string.account_github_entry)) },
-        supportingContent = { Text(summary, maxLines = 1, overflow = TextOverflow.Ellipsis) },
-        leadingContent = {
-            if (user.avatarUrl != null) {
-                AsyncImage(
-                    model = user.avatarUrl,
-                    contentDescription = null,
-                    modifier = Modifier.size(40.dp).clip(CircleShape),
-                )
-            } else {
-                Icon(Icons.Default.AccountCircle, null, modifier = Modifier.size(40.dp))
-            }
-        },
-        trailingContent = {
-            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
-        },
-        colors = ListItemDefaults.colors(containerColor = androidx.compose.ui.graphics.Color.Transparent),
-        modifier = Modifier.clickable { onClick() },
-    )
+    SettingsGroup(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        settingsItem(
+            leading = {
+                if (user.avatarUrl != null) {
+                    AsyncImage(
+                        model = user.avatarUrl,
+                        contentDescription = null,
+                        modifier = Modifier.size(40.dp).clip(CircleShape),
+                    )
+                } else {
+                    Icon(Icons.Default.AccountCircle, null, modifier = Modifier.size(40.dp))
+                }
+            },
+            title = { Text(stringResource(Res.string.account_github_entry)) },
+            description = { Text(summary, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+            trailing = {
+                Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+            },
+            onClick = onClick,
+        )
+    }
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/AboutScreen.kt
@@ -5,6 +5,7 @@ import whl.trending.ai.core.ProSponsor
 import whl.trending.ai.core.platform.getAppVersion
 import whl.trending.ai.core.platform.isIosPlatform
 import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.ui.common.SettingsGroup
 import whl.trending.ai.ui.common.TrendingScaffold
 import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.ai.ui.home.githubLogoPainter
@@ -36,7 +37,6 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -125,76 +125,78 @@ fun AboutScreen(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
-            // 检查更新：apk 渠道点按自建检查，iOS 跳官网；play/fdroid 渠道由商店接管，不显示
-            if (globalUpdateChecker.isEnabled || isIos) {
-                ListItem(
-                    headlineContent = { Text(stringResource(Res.string.check_updates)) },
-                    leadingContent = { Icon(Icons.Default.Refresh, null) },
-                    trailingContent = {
-                        when {
-                            !isIos && isChecking -> LoadingIndicator(
-                                modifier = Modifier.size(24.dp)
-                            )
-                            !isIos && isUpToDate -> Text(
-                                stringResource(Res.string.version_up_to_date),
-                                color = MaterialTheme.colorScheme.primary
-                            )
-                            !isIos && isCheckFailed -> Text(
-                                stringResource(Res.string.check_update_failed),
-                                color = MaterialTheme.colorScheme.error
-                            )
+            // 隐私政策标题要传给 WebView，须在 composable 作用域取；SettingsGroup 的 content 不是 @Composable
+            val privacyTitle = stringResource(Res.string.privacy_policy)
+            SettingsGroup(modifier = Modifier.padding(horizontal = 16.dp)) {
+                // 检查更新：apk 渠道点按自建检查，iOS 跳官网；play/fdroid 渠道由商店接管，不显示
+                if (globalUpdateChecker.isEnabled || isIos) {
+                    settingsItem(
+                        icon = Icons.Default.Refresh,
+                        title = { Text(stringResource(Res.string.check_updates)) },
+                        enabled = !isChecking,
+                        trailing = {
+                            when {
+                                !isIos && isChecking -> LoadingIndicator(
+                                    modifier = Modifier.size(24.dp)
+                                )
+                                !isIos && isUpToDate -> Text(
+                                    stringResource(Res.string.version_up_to_date),
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                                !isIos && isCheckFailed -> Text(
+                                    stringResource(Res.string.check_update_failed),
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            }
+                        },
+                        onClick = {
+                            trackEvent("settings_check_update")
+                            if (isIos) {
+                                uriHandler.openUri(Constants.OFFICIAL_WEBSITE_URL)
+                            } else {
+                                globalUpdateChecker.manualCheck()
+                            }
+                        },
+                    )
+                }
+                settingsItem(
+                    icon = Icons.Default.History,
+                    title = { Text(stringResource(Res.string.changelog)) },
+                    onClick = {
+                        trackEvent("settings_changelog")
+                        uriHandler.openUri(Constants.CHANGELOG_URL)
+                    },
+                )
+                settingsItem(
+                    icon = Icons.Default.Public,
+                    title = { Text(stringResource(Res.string.official_website)) },
+                    onClick = { uriHandler.openUri(Constants.OFFICIAL_WEBSITE_URL) },
+                )
+                // 邮箱可长按选中复制，因此这一项整行不可点
+                settingsItem(
+                    icon = Icons.Default.AlternateEmail,
+                    title = { Text(stringResource(Res.string.contact_author)) },
+                    trailing = {
+                        SelectionContainer {
+                            Text(Constants.AUTHOR_EMAIL, color = MaterialTheme.colorScheme.outline)
                         }
                     },
-                    modifier = Modifier.clickable(enabled = !isChecking) {
-                        trackEvent("settings_check_update")
-                        if (isIos) {
-                            uriHandler.openUri(Constants.OFFICIAL_WEBSITE_URL)
-                        } else {
-                            globalUpdateChecker.manualCheck()
-                        }
-                    }
+                )
+                settingsItem(
+                    icon = Icons.Default.VolunteerActivism,
+                    title = { Text(stringResource(Res.string.donate)) },
+                    onClick = {
+                        trackEvent("settings_donate")
+                        showDonateDialog = true
+                    },
+                )
+                settingsItem(
+                    icon = Icons.Default.PrivacyTip,
+                    title = { Text(privacyTitle) },
+                    onClick = { onNavigateToWebPage(Constants.PRIVACY_POLICY_URL, privacyTitle) },
                 )
             }
-            ListItem(
-                headlineContent = { Text(stringResource(Res.string.changelog)) },
-                leadingContent = { Icon(Icons.Default.History, null) },
-                modifier = Modifier.clickable {
-                    trackEvent("settings_changelog")
-                    uriHandler.openUri(Constants.CHANGELOG_URL)
-                }
-            )
-            ListItem(
-                headlineContent = { Text(stringResource(Res.string.official_website)) },
-                leadingContent = { Icon(Icons.Default.Public, null) },
-                modifier = Modifier.clickable {
-                    uriHandler.openUri(Constants.OFFICIAL_WEBSITE_URL)
-                }
-            )
-            ListItem(
-                headlineContent = { Text(stringResource(Res.string.contact_author)) },
-                trailingContent = {
-                    SelectionContainer {
-                        Text(Constants.AUTHOR_EMAIL, color = MaterialTheme.colorScheme.outline)
-                    }
-                },
-                leadingContent = { Icon(Icons.Default.AlternateEmail, null) }
-            )
-            ListItem(
-                headlineContent = { Text(stringResource(Res.string.donate)) },
-                leadingContent = { Icon(Icons.Default.VolunteerActivism, null) },
-                modifier = Modifier.clickable {
-                    trackEvent("settings_donate")
-                    showDonateDialog = true
-                }
-            )
-            val privacyTitle = stringResource(Res.string.privacy_policy)
-            ListItem(
-                headlineContent = { Text(privacyTitle) },
-                leadingContent = { Icon(Icons.Default.PrivacyTip, null) },
-                modifier = Modifier.clickable {
-                    onNavigateToWebPage(Constants.PRIVACY_POLICY_URL, privacyTitle)
-                }
-            )
+            Spacer(Modifier.height(24.dp))
         }
     }
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -27,10 +27,8 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -108,6 +106,7 @@ import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.remote.ApiException
 import whl.trending.ai.data.repository.TrendingRepository
 import whl.trending.ai.notification.globalDailyPicksNotifier
+import whl.trending.ai.ui.common.SettingsGroup
 import whl.trending.ai.ui.common.TrendingScaffold
 import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.ai.ui.home.HomeTab
@@ -147,6 +146,11 @@ fun SettingsScreen(
 
     var showSummaryLanguageDialog by remember { mutableStateOf(false) }
     var showLangCaptureDialog by remember { mutableStateOf(false) }
+    // 三个下拉菜单的展开态提到页面作用域：SettingsGroup 的 content 是收集用的普通 lambda，
+    // 不是 @Composable，里面调不了 remember
+    var appLanguageMenuExpanded by remember { mutableStateOf(false) }
+    var summaryLanguageMenuExpanded by remember { mutableStateOf(false) }
+    var homeTabMenuExpanded by remember { mutableStateOf(false) }
 
     val snackbarHostState = remember { SnackbarHostState() }
     val settingsScope = rememberCoroutineScope()
@@ -202,231 +206,228 @@ fun SettingsScreen(
     ) { padding ->
         LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
             // ① 个性化
-            item(key = "group_personalization") { SettingsHeader(stringResource(Res.string.personalization)) }
-            item(key = "appearance") {
-                ListItem(
-                    headlineContent = { Text(stringResource(Res.string.appearance)) },
-                    leadingContent = { Icon(Icons.Default.Palette, null) },
-                    trailingContent = {
-                        Text(
-                            text = themeModeText(themeMode),
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    },
-                    modifier = Modifier.clickable {
-                        trackEvent("settings_appearance")
-                        onNavigateToAppearance()
-                    }
-                )
-            }
-            // 应用语言：只管界面文案；iOS 由系统的按 App 语言设置接管，跳系统设置
-            item(key = "app_language") {
-                var expanded by remember { mutableStateOf(false) }
-                ListItem(
-                    headlineContent = { Text(stringResource(Res.string.language_settings)) },
-                    supportingContent = { Text(stringResource(Res.string.app_language_desc)) },
-                    leadingContent = { Icon(Icons.Default.Language, null) },
-                    trailingContent = {
-                        if (isIos) {
+            item(key = "group_personalization") {
+                SettingsGroup(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    title = stringResource(Res.string.personalization),
+                ) {
+                    settingsItem(
+                        icon = Icons.Default.Palette,
+                        title = { Text(stringResource(Res.string.appearance)) },
+                        trailing = {
                             Text(
-                                text = stringResource(Res.string.open_system_settings),
-                                color = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.clickable { openAppSettings() }
+                                text = themeModeText(themeMode),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
-                        } else {
+                        },
+                        onClick = {
+                            trackEvent("settings_appearance")
+                            onNavigateToAppearance()
+                        },
+                    )
+                    // 应用语言：只管界面文案；iOS 由系统的按 App 语言设置接管，跳系统设置
+                    settingsItem(
+                        icon = Icons.Default.Language,
+                        title = { Text(stringResource(Res.string.language_settings)) },
+                        description = { Text(stringResource(Res.string.app_language_desc)) },
+                        trailing = {
+                            if (isIos) {
+                                Text(
+                                    text = stringResource(Res.string.open_system_settings),
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
+                            } else {
+                                Box {
+                                    Text(
+                                        text = languageOptionText(appLanguage),
+                                        color = MaterialTheme.colorScheme.primary,
+                                    )
+                                    DropdownMenu(
+                                        expanded = appLanguageMenuExpanded,
+                                        onDismissRequest = { appLanguageMenuExpanded = false },
+                                    ) {
+                                        AppLanguage.entries.forEach { language ->
+                                            DropdownMenuItem(
+                                                text = { Text(languageOptionText(language)) },
+                                                onClick = {
+                                                    appLanguageMenuExpanded = false
+                                                    trackEvent("settings_language_change", mapOf("language" to language.name.lowercase()))
+                                                    globalSettingsManager.setLanguage(language)
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        onClick = {
+                            if (isIos) openAppSettings() else appLanguageMenuExpanded = true
+                        },
+                    )
+                    // 摘要语言：独立决定 AI 摘要/解读的请求语言；行点击弹说明（含「更多语言」引导采集 + 赞助），
+                    // 点右侧当前值才是直接换语言——两个动作分开，别合并
+                    settingsItem(
+                        icon = Icons.Default.Translate,
+                        title = { Text(stringResource(Res.string.summary_language)) },
+                        description = { Text(stringResource(Res.string.summary_language_desc)) },
+                        trailing = {
                             Box {
                                 Text(
-                                    text = languageOptionText(appLanguage),
+                                    text = languageOptionText(summaryLanguage),
                                     color = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.clickable { expanded = true }
+                                    modifier = Modifier.clickable { summaryLanguageMenuExpanded = true },
                                 )
                                 DropdownMenu(
-                                    expanded = expanded,
-                                    onDismissRequest = { expanded = false }
+                                    expanded = summaryLanguageMenuExpanded,
+                                    onDismissRequest = { summaryLanguageMenuExpanded = false },
                                 ) {
-                                    AppLanguage.entries.forEach { language ->
+                                    SummaryLanguage.entries.forEach { language ->
                                         DropdownMenuItem(
                                             text = { Text(languageOptionText(language)) },
                                             onClick = {
-                                                expanded = false
-                                                trackEvent("settings_language_change", mapOf("language" to language.name.lowercase()))
-                                                globalSettingsManager.setLanguage(language)
+                                                summaryLanguageMenuExpanded = false
+                                                trackEvent("settings_summary_language_change", mapOf("language" to language.name.lowercase()))
+                                                globalSettingsManager.setSummaryLanguage(language)
                                             }
                                         )
                                     }
                                 }
                             }
-                        }
-                    },
-                    modifier = Modifier.clickable {
-                        if (isIos) openAppSettings() else expanded = true
-                    }
-                )
-            }
-            // 摘要语言：独立决定 AI 摘要/解读的请求语言；行点击弹说明（含「更多语言」引导采集 + 赞助）
-            item(key = "summary_language") {
-                var expanded by remember { mutableStateOf(false) }
-                ListItem(
-                    headlineContent = { Text(stringResource(Res.string.summary_language)) },
-                    supportingContent = { Text(stringResource(Res.string.summary_language_desc)) },
-                    leadingContent = { Icon(Icons.Default.Translate, null) },
-                    trailingContent = {
-                        Box {
-                            Text(
-                                text = languageOptionText(summaryLanguage),
-                                color = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.clickable { expanded = true }
-                            )
-                            DropdownMenu(
-                                expanded = expanded,
-                                onDismissRequest = { expanded = false }
-                            ) {
-                                SummaryLanguage.entries.forEach { language ->
-                                    DropdownMenuItem(
-                                        text = { Text(languageOptionText(language)) },
-                                        onClick = {
-                                            expanded = false
-                                            trackEvent("settings_summary_language_change", mapOf("language" to language.name.lowercase()))
-                                            globalSettingsManager.setSummaryLanguage(language)
-                                        }
-                                    )
-                                }
-                            }
-                        }
-                    },
-                    modifier = Modifier.clickable {
-                        trackEvent("settings_summary_language", mapOf("summary_language" to summaryLanguage.name.lowercase()))
-                        showSummaryLanguageDialog = true
-                    }
-                )
-            }
-            // 默认首页 tab：只决定冷启动进入哪个 tab，会话内切换不回写
-            item(key = "default_home_tab") {
-                var expanded by remember { mutableStateOf(false) }
-                ListItem(
-                    headlineContent = { Text(stringResource(Res.string.default_home_tab)) },
-                    supportingContent = { Text(stringResource(Res.string.default_home_tab_desc)) },
-                    leadingContent = { Icon(Icons.Default.Home, null) },
-                    trailingContent = {
-                        Box {
-                            Text(
-                                text = homeTabOptionText(HomeTab.defaultFromName(defaultHomeTab)),
-                                color = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.clickable { expanded = true }
-                            )
-                            DropdownMenu(
-                                expanded = expanded,
-                                onDismissRequest = { expanded = false }
-                            ) {
-                                HomeTab.defaultCandidates.forEach { tab ->
-                                    DropdownMenuItem(
-                                        text = { Text(homeTabOptionText(tab)) },
-                                        onClick = {
-                                            expanded = false
-                                            trackEvent("settings_default_home_tab_change", mapOf("tab" to tab.name.lowercase()))
-                                            globalSettingsManager.setDefaultHomeTab(tab.name)
-                                        }
-                                    )
-                                }
-                            }
-                        }
-                    }
-                )
-            }
-            item(key = "divider_1") { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
-
-            // ② 订阅与提醒
-            item(key = "group_subscription") { SettingsHeader(stringResource(Res.string.subscription_reminders)) }
-            item(key = "subscribe") {
-                ListItem(
-                    headlineContent = { Text(stringResource(Res.string.subscribe_title)) },
-                    leadingContent = { Icon(Icons.Default.Email, null) },
-                    modifier = Modifier.clickable {
-                        trackEvent("settings_subscribe")
-                        onNavigateToSubscribe()
-                    }
-                )
-            }
-            if (globalDailyPicksNotifier.isSupported) {
-                item(key = "daily_picks_notification") {
-                    ListItem(
-                        headlineContent = { Text(stringResource(Res.string.daily_picks_notification)) },
-                        leadingContent = { Icon(Icons.Default.Notifications, null) },
-                        trailingContent = {
-                            Switch(
-                                checked = dailyPicksNotificationEnabled,
-                                onCheckedChange = { enabled ->
-                                    trackEvent(
-                                        "settings_daily_picks_notification",
-                                        mapOf("enabled" to enabled.toString())
-                                    )
-                                    if (enabled) {
-                                        settingsScope.launch {
-                                            val granted = globalDailyPicksNotifier.enable()
-                                            globalSettingsManager.setDailyPicksNotificationEnabled(granted)
-                                            if (!granted) {
-                                                val result = snackbarHostState.showSnackbar(
-                                                    message = permissionDeniedMsg,
-                                                    actionLabel = openSystemSettingsLabel,
-                                                )
-                                                if (result == SnackbarResult.ActionPerformed) {
-                                                    openAppSettings()
-                                                }
+                        },
+                        onClick = {
+                            trackEvent("settings_summary_language", mapOf("summary_language" to summaryLanguage.name.lowercase()))
+                            showSummaryLanguageDialog = true
+                        },
+                    )
+                    // 默认首页 tab：只决定冷启动进入哪个 tab，会话内切换不回写
+                    settingsItem(
+                        icon = Icons.Default.Home,
+                        title = { Text(stringResource(Res.string.default_home_tab)) },
+                        description = { Text(stringResource(Res.string.default_home_tab_desc)) },
+                        trailing = {
+                            Box {
+                                Text(
+                                    text = homeTabOptionText(HomeTab.defaultFromName(defaultHomeTab)),
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
+                                DropdownMenu(
+                                    expanded = homeTabMenuExpanded,
+                                    onDismissRequest = { homeTabMenuExpanded = false },
+                                ) {
+                                    HomeTab.defaultCandidates.forEach { tab ->
+                                        DropdownMenuItem(
+                                            text = { Text(homeTabOptionText(tab)) },
+                                            onClick = {
+                                                homeTabMenuExpanded = false
+                                                trackEvent("settings_default_home_tab_change", mapOf("tab" to tab.name.lowercase()))
+                                                globalSettingsManager.setDefaultHomeTab(tab.name)
                                             }
-                                        }
-                                    } else {
-                                        globalDailyPicksNotifier.disable()
-                                        globalSettingsManager.setDailyPicksNotificationEnabled(false)
+                                        )
                                     }
                                 }
-                            )
-                        }
+                            }
+                        },
+                        onClick = { homeTabMenuExpanded = true },
                     )
                 }
             }
-            item(key = "divider_2") { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
+
+            // ② 订阅与提醒
+            item(key = "group_subscription") {
+                SettingsGroup(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    title = stringResource(Res.string.subscription_reminders),
+                ) {
+                    settingsItem(
+                        icon = Icons.Default.Email,
+                        title = { Text(stringResource(Res.string.subscribe_title)) },
+                        onClick = {
+                            trackEvent("settings_subscribe")
+                            onNavigateToSubscribe()
+                        },
+                    )
+                    if (globalDailyPicksNotifier.isSupported) {
+                        settingsItem(
+                            icon = Icons.Default.Notifications,
+                            title = { Text(stringResource(Res.string.daily_picks_notification)) },
+                            trailing = {
+                                Switch(
+                                    checked = dailyPicksNotificationEnabled,
+                                    onCheckedChange = { enabled ->
+                                        trackEvent(
+                                            "settings_daily_picks_notification",
+                                            mapOf("enabled" to enabled.toString())
+                                        )
+                                        if (enabled) {
+                                            settingsScope.launch {
+                                                val granted = globalDailyPicksNotifier.enable()
+                                                globalSettingsManager.setDailyPicksNotificationEnabled(granted)
+                                                if (!granted) {
+                                                    val result = snackbarHostState.showSnackbar(
+                                                        message = permissionDeniedMsg,
+                                                        actionLabel = openSystemSettingsLabel,
+                                                    )
+                                                    if (result == SnackbarResult.ActionPerformed) {
+                                                        openAppSettings()
+                                                    }
+                                                }
+                                            }
+                                        } else {
+                                            globalDailyPicksNotifier.disable()
+                                            globalSettingsManager.setDailyPicksNotificationEnabled(false)
+                                        }
+                                    }
+                                )
+                            },
+                        )
+                    }
+                }
+            }
 
             // ③ 通用
-            item(key = "group_general") { SettingsHeader(stringResource(Res.string.settings_group_general)) }
-            // 外链打开方式：行点击与开关同为切换
-            item(key = "open_links") {
-                val toggleOpenLinks = { enabled: Boolean ->
-                    trackEvent("settings_open_links_in_browser", mapOf("enabled" to enabled.toString()))
-                    globalSettingsManager.setOpenLinksInCustomTab(enabled)
+            item(key = "group_general") {
+                SettingsGroup(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    title = stringResource(Res.string.settings_group_general),
+                ) {
+                    // 外链打开方式：行点击与开关同为切换
+                    settingsItem(
+                        icon = Icons.Default.OpenInBrowser,
+                        title = { Text(stringResource(Res.string.open_links_in_browser)) },
+                        description = { Text(stringResource(Res.string.open_links_in_browser_desc)) },
+                        trailing = {
+                            Switch(
+                                checked = openLinksInCustomTab,
+                                onCheckedChange = { enabled ->
+                                    trackEvent("settings_open_links_in_browser", mapOf("enabled" to enabled.toString()))
+                                    globalSettingsManager.setOpenLinksInCustomTab(enabled)
+                                }
+                            )
+                        },
+                        onClick = {
+                            val enabled = !openLinksInCustomTab
+                            trackEvent("settings_open_links_in_browser", mapOf("enabled" to enabled.toString()))
+                            globalSettingsManager.setOpenLinksInCustomTab(enabled)
+                        },
+                    )
+                    settingsItem(
+                        icon = Icons.Default.Feedback,
+                        title = { Text(stringResource(Res.string.feedback)) },
+                        onClick = {
+                            trackEvent("settings_feedback")
+                            onNavigateToFeedback()
+                        },
+                    )
+                    // 关于页同时挂在底栏的「⋯」菜单上——那里是快捷入口，这里是设置的完整清单
+                    settingsItem(
+                        icon = Icons.Default.Info,
+                        title = { Text(stringResource(Res.string.about)) },
+                        onClick = {
+                            trackEvent("settings_about")
+                            onNavigateToAbout()
+                        },
+                    )
                 }
-                ListItem(
-                    headlineContent = { Text(stringResource(Res.string.open_links_in_browser)) },
-                    supportingContent = { Text(stringResource(Res.string.open_links_in_browser_desc)) },
-                    leadingContent = { Icon(Icons.Default.OpenInBrowser, null) },
-                    trailingContent = {
-                        Switch(
-                            checked = openLinksInCustomTab,
-                            onCheckedChange = toggleOpenLinks
-                        )
-                    },
-                    modifier = Modifier.clickable { toggleOpenLinks(!openLinksInCustomTab) }
-                )
-            }
-            item(key = "feedback") {
-                ListItem(
-                    headlineContent = { Text(stringResource(Res.string.feedback)) },
-                    leadingContent = { Icon(Icons.Default.Feedback, null) },
-                    modifier = Modifier.clickable {
-                        trackEvent("settings_feedback")
-                        onNavigateToFeedback()
-                    }
-                )
-            }
-            // 关于页同时挂在底栏的「⋯」菜单上——那里是快捷入口，这里是设置的完整清单
-            item(key = "about") {
-                ListItem(
-                    headlineContent = { Text(stringResource(Res.string.about)) },
-                    leadingContent = { Icon(Icons.Default.Info, null) },
-                    modifier = Modifier.clickable {
-                        trackEvent("settings_about")
-                        onNavigateToAbout()
-                    }
-                )
             }
             item(key = "bottom_spacer") { Spacer(Modifier.height(24.dp)) }
         }
@@ -434,16 +435,6 @@ fun SettingsScreen(
 }
 
 /** 设置分组标题，账户页与设置页共用。 */
-@Composable
-fun SettingsHeader(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelLarge,
-        color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-    )
-}
-
 @Composable
 private fun languageOptionText(language: AppLanguage): String {
     val labelRes = when (language) {


### PR DESCRIPTION
## 背景

三个参照仓库（Echo-Music、Rhythm、EchoFlow）的设置页看起来是同一套风格，我们的不像。梳理后发现差异**在组件范式而非颜色字号**：它们共享「连体卡片式设置组」——每项一张卡片，组内首尾大圆角、中间小圆角、留 4dp 缝，图标装进 40dp 着色容器；Echo 和 Rhythm 甚至有同名文件 `Material3SettingsGroup.kt`。我们用的是裸 `ListItem` + `HorizontalDivider` 的标准 M3 列表。

完整对比与取舍依据见本 PR 新增的 `docs/settings-style-comparison.md`。顺带一个反直觉的结论：**主题层我们不落后**——seed 调色台、对比度档、配色风格档、`SPEC_2025` 是三家都没有的，只缺壁纸动态色（与现有调色台冲突，明确不做）。

## 改动

新增 `shared/.../ui/common/SettingsGroup.kt`，三个页面改用它渲染：

| 页面 | 改动 |
|---|---|
| `SettingsScreen` | 三组共 9 项改为声明式清单，删掉两条分隔线 |
| `AboutScreen` | 六项合成一组，与原列表 1:1 对应，不增不并 |
| `ProfileScreen` | GitHub 入口 / 收藏 / 退出登录三项卡片化，删掉两条分隔线 |

不动的部分：`AppearanceScreen`（主体是主题选择卡）、`AccountHeader` 与 `PlanUsageCard`（特化组件）。

### 为什么用 slot API 而不是抄它们的数据类

参照仓库那套 `SettingsItem` 数据类会随特例不断长字段（Echo 11 个、Rhythm 12 个），而我们的设置项恰恰有 iOS 分支、`Switch`、`DropdownMenu` 锚点这些不规则需求——slot 下它们就是调用处的普通 Compose 代码，组件不必知情。

`content` 不是 `@Composable`，先把每项收集成 lambda（同 `LazyListScope.item` 的做法），收集完才知道总数、才能分配圆角。连带影响：三个下拉的展开态、隐私政策标题提到了页面作用域。

## 规格

| 项 | 值 | 依据 |
|---|---|---|
| 卡片圆角 | 单项 24；首 24/6，中 6，末 6/24 | Echo 与 Rhythm 一致 |
| 项间距 | 4dp | 三家一致 |
| 卡片底色 | `surfaceContainer` | 跟 Rhythm，与统一后的顶栏一致 |
| 行内边距 | h20 / v16 | Echo 20、Rhythm 21，取整 |
| 图标容器 | 40dp 圆形，`secondaryContainer` / `onSecondaryContainer` | 与首页底栏选中药丸同一对 token |
| 标题 / 副标题 | `titleMedium` + `bodyMedium`，间隔 2dp | 三家一致 |

**许可证**：Echo 与 Rhythm 是 GPL-3.0、本仓库是 MIT，本 PR 只照规格数值自己实现，未复制任何代码。

## 验证（Pixel_9_2）

- 浅色 / AMOLED 两档观感正常；
- **下拉菜单锚点**（改造前标记的主要风险点）仍从 trailing 处展开、不出屏；
- 行为全部保留：摘要语言仍是「点行弹说明、点右侧值换语言」；外链项行点击与开关同为切换；「检查更新」三态与 `enabled` 联动；「联系作者」整行不可点、邮箱可长按复制；
- 顺带验掉了 `home-redesign-handover.md` 的待办 B2——模拟器恰为 Pro + 已关联 GitHub 的登录态，「我的」页身份区、额度条、GitHub 入口卡渲染均正常，文档已标记。

## 已定的决策（不必在 review 里再议）

图标容器用圆形；**不做**按压缩放动画（只有 Rhythm 有，属全局手感决策，全 app 其余部分都是 ripple）；长描述换行导致的行高不均不调；退出登录只有文字是 `error` 色、图标不特化。

## 风险

纯 UI 改动，无反射、无新依赖，R8 风险低。发版前照常跑 `scripts/release-smoke.sh`。iOS 端同样吃到这些改动，按既有决策不作验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXBH38vd8BhPVA8qNHJTZY

## Summary by Sourcery

引入可复用且更具表现力的 `SettingsGroup` 组件，并在 Settings、About 和 Profile 界面中统一采用该组件，以实现统一的“设置风格”卡片。

New Features:
- 添加共享的 `SettingsGroup` 可组合组件，用于成组、卡片式的设置项，并支持基于插槽（slot-based）的配置方式。

Enhancements:
- 重构 `SettingsScreen`、`AboutScreen` 和 `ProfileScreen`，使其使用 `SettingsGroup` 替代原先基于 `ListItem`/分割线的设置行布局，从而与 M3 Expressive 卡片视觉风格保持一致。
- 调整设置项中的下拉菜单和开关（switch）处理逻辑，使其适配新的分组卡片布局，同时保持现有行为不变。
- 更新首页改版交接说明，标记“Profile 界面卡片化”任务为已完成。
- 新增文档，对比参考应用中的设置与主题实现，并记录最终选定的卡片式规范。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a reusable expressive SettingsGroup component and adopt it across Settings, About, and Profile screens to unify settings-style cards.

New Features:
- Add a shared SettingsGroup composable for grouped, card-style settings items with slot-based configuration.

Enhancements:
- Refactor SettingsScreen, AboutScreen, and ProfileScreen to use SettingsGroup instead of ListItem/dividers for settings rows, aligning with M3 Expressive card aesthetics.
- Adjust dropdown menu and switch handling in settings items to work with the new grouped card layout while preserving existing behaviors.
- Update home redesign handover notes to mark profile screen cardification as completed.
- Add documentation comparing settings and theme implementations with reference apps and recording the chosen card-style specs.

</details>