### PR TITLE
交互层一致性：浮层 / 下拉 / 弹窗统一规格

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,23 @@
   - `TrendingScaffold` 只透传各页实际用到的 `Scaffold` 参数，缺什么补什么。
   - 没有例外页：`ReadmeScreen` 曾因 WebView 滚动不走 nestedScroll、收不到变色事件而保留原生 `Scaffold` + 写死底色，顶栏改为恒定后这个理由消失，已并回统一写法。
 
+- **设置项用卡片组**：设置页 / 关于页 /「我的」页的列表行一律用 `ui/common` 的 `SettingsGroup`，slot API 写法（`settingsItem(...)`），不要再用裸 `ListItem` + `HorizontalDivider`。图标进 40dp 圆形容器（`secondaryContainer`），头像这类自带形状的前导元素走 `leading` slot。规格与取舍见 `docs/settings-style-comparison.md`。
+
+- **弹窗 / 浮层 / 下拉的选型**（见 `docs/interaction-consistency-audit.md`）：
+
+  | 场景 | 用什么 |
+  |---|---|
+  | 破坏性动作确认（删除、退出、清空） | `AlertDialog`，**确认按钮 `error` 色** |
+  | 纯说明 / 引导（一个动作或「知道了」） | `ui/common` 的 `InfoDialog` |
+  | 单选，≤4 项且有明确锚点（某行的当前值） | `ui/common` 的 `TrendingDropdownMenu` |
+  | 单选，>4 项 / 选项带描述或图标 / 需要滚动 | `ui/common` 的 `TrendingBottomSheet` |
+  | 多维筛选（两个及以上维度） | `TrendingBottomSheet` + 分段控件 / Chip |
+  | 系统级选择（日期、时间） | 对应的 `*PickerDialog`，别自绘 |
+
+  - 底部浮层**一律走 `TrendingBottomSheet`**，它固定了标题字号（`titleLarge`）、水平边距（24dp）、底部留白（`navigationBarsPadding()` + 16dp）。别直接用 `ModalBottomSheet`——四处各写各的正是 0.23 之前的状态。
+  - 下拉菜单**一律走 `TrendingDropdownMenu`**（24dp 圆角，与卡片、胶囊同一套大圆角语言）。需要特殊容器色/elevation 时传参，别绕开组件自己写 `DropdownMenu`。
+  - 浮层里的可点选项用 `SettingsGroup` 渲染，与三个页面的卡片语言一致（登录方式选择就是这么做的）。
+
 ## 发布前冒烟（必做）
 
 **打 tag 前必须跑 `scripts/release-smoke.sh` 并看到 PASS。** 它构建 r2 渠道 release 包（与线上同样开 R8 minify）、安装到 Pixel_9_2 模拟器、启动并检查崩溃日志与进程存活。日常开发全用 debug 包（不混淆），R8 裁剪类问题只有 release 包能暴露——0.20.0 曾因此启动即崩、发布后才发现（room 2.6.1 老 keep 规则 + R8 full mode 裁掉 WorkDatabase_Impl 构造器）。FAIL 时禁止发布，先按崩溃堆栈排查。

--- a/docs/interaction-consistency-audit.md
+++ b/docs/interaction-consistency-audit.md
@@ -1,0 +1,159 @@
+# 交互层一致性盘点：弹窗 / 底部浮层 / 下拉菜单 / 筛选
+
+延续 `settings-style-comparison.md` 那轮的做法，这次查**交互层**：同类交互在不同页面是否用了同一种呈现方式、同一套规格。口径是**内部自洽优先**——先看我们自己一致不一致，参照仓库（`.refs/` 下三个）只在需要仲裁「该统一成哪种」时引用。
+
+2026-08-05 成文，行号以当时的 `main`（`f18a4cf`）为准。**本文只做盘点与建议，未改任何代码。**
+
+---
+
+## 一、现状盘点
+
+### 1.1 弹窗：9 处 `AlertDialog` + 1 处 `DatePickerDialog`
+
+| 位置 | 用途 | 类型 |
+|---|---|---|
+| `SettingsScreen.kt:161` | 摘要语言说明（三个动作：赞助 / 关闭 / 反馈） | 说明 + 多动作 |
+| `AboutScreen.kt:206` | 赞助（`text` 槽里自绘内容） | 内容型 |
+| `FavoriteListScreen.kt:160` | 删除收藏确认 | **危险确认** |
+| `ProfileScreen.kt:142` | 退出登录确认 | **危险确认** |
+| `ProfileScreen.kt:166` | 升级前需先关联 GitHub | 引导 |
+| `SponsorLinkHost.kt:52` | 已赞助但未关联，引导去关联 | 引导 |
+| `SignInHintHost.kt:49` | 登录提示 / 会话过期（`dismissButton` 条件为 null） | 引导 |
+| `TrendingScreen.kt:820` `InfoDialog` | 规则说明（私有组件） | 说明 |
+| `WhatsNewDialog.kt:84` | 版本更新说明 | 内容型 |
+| `TrendingScreen.kt:691` | 日期选择 | 选择 |
+
+### 1.2 底部浮层：4 处 `ModalBottomSheet`
+
+| 位置 | 用途 | 标题写法 | 水平 padding | 底部留白 | `sheetState` |
+|---|---|---|---|---|---|
+| `TrendingScreen.kt:576` | 筛选面板 | `BottomSheetHeader`（`titleLarge` + 帮助图标） | 16dp | 32dp | 显式传入 |
+| `TrendingScreen.kt:709` | 历史批次 | 同上 | 16dp | 32dp | 显式传入 |
+| `GithubProfileScreen.kt:234` | Feed 规则说明 | `FeedRulesSheet` 内部自绘 `titleLarge` | **24dp** | 32dp | 用默认 |
+| `SignInMethodChooserHost.kt:62` | 登录方式选择 | 直接 `Text` + **`titleMedium`** | **24dp** | `navigationBarsPadding()` + 16dp | 用默认 |
+
+### 1.3 下拉菜单：3 处 `DropdownMenu`
+
+| 位置 | 用途 | 样式 |
+|---|---|---|
+| `SettingsScreen.kt` ×3 | 应用语言 / 摘要语言 / 默认首页 tab | 默认 |
+| `ItemActionMenu.kt:70` | 列表项操作 | 默认 |
+| `HomeFloatingBar.kt:282` | 底栏「⋯」菜单 | **`shape = RoundedCornerShape(24.dp)`** |
+
+### 1.4 筛选
+
+只有 Trending 有真正的筛选面板（`TrendingScreen.kt:576`）：`ModalBottomSheet` 内用 `SingleChoiceSegmentedButtonRow` 选时间范围、`FilterChip` 选语言、`DatePickerDialog` 选日期。Feed（HN / PH）与 Picks 没有筛选。
+
+### 1.5 Snackbar
+
+5 处各自 `remember { SnackbarHostState() }`：`SettingsScreen`、`FeedbackScreen`、`SubscribeScreen`、`ReadmeScreen`、`TrendingScreen`。没有全局宿主。
+
+---
+
+## 二、不自洽清单（按可感知度排序）
+
+### ① 「单选」有三套并存的呈现方式 ★★★★★
+
+同样是"从几个选项里挑一个"，我们有三种做法，**选择依据不明**：
+
+| 场景 | 选项数 | 呈现 |
+|---|---|---|
+| 应用语言 / 摘要语言 / 默认首页 tab | 3–4 | `DropdownMenu` |
+| 时间范围 / 历史批次 | 3–5 | `ModalBottomSheet` + `SegmentedButton` |
+| 登录方式 | 2 | `ModalBottomSheet` + `ListItem` |
+
+用户在设置页点"应用语言"弹出贴着行的小菜单，在首页点筛选弹出半屏浮层，在登录处又是另一种浮层——三种模态在同一个 app 里表达同一件事。
+
+**建议**：定一条明确规则（见第三节的决策表），按规则回头核对——核完的结论是**三处都不用改交互模式**：
+
+- 设置页三个下拉：选项 3–4 个、有明确锚点（行右侧当前值）、切换即时生效，**下拉是对的**；
+- Trending 筛选：两个维度同屏比较，**Sheet + 分段控件是对的**；
+- 登录方式：初看"2 个选项用半屏浮层"像是偏重，**但两个选项都带一句关键说明**（"Authorize in your browser"、"We'll send a verification code — no password needed"），而 `DropdownMenuItem` 只有单行 `text` 槽塞不下描述——按决策表「选项带描述 → Sheet」，**它本来就该是 Sheet**。（初版文档把这处判成了唯一的违规项，只数了选项个数、漏了带描述这一条，2026-08-05 截图核对后修正。）
+
+所以这条**没有代码要改**，缺的只是把规则写下来，防止以后新增选择项时随手选一种。真正要动的都在下面的规格层面。
+
+### ② 底部浮层四处规格各不相同 ★★★★☆
+
+上面 1.2 那张表里，**标题字号、水平 padding、底部留白、是否传 `sheetState` 四项没有任何两处完全一致**。用户连续打开筛选面板和登录选择，会看到标题一大一小、内容一窄一宽。
+
+`BottomSheetHeader`（`TrendingScreen.kt:833`）已经是个可复用的头部组件，但它是 `TrendingScreen` 的**私有函数**，另外两处 sheet 用不到，只能各写各的。
+
+**建议**：把 `BottomSheetHeader` 提到 `ui/common`，连同一组固定规格（标题 `titleLarge`、水平 24dp、底部 `navigationBarsPadding() + 16dp`）做成 `TrendingBottomSheet` 包装。工作量：组件约 60 行 + 4 处调用改造，半天。
+
+### ③ 危险确认按钮没有 error 色 ★★★☆☆
+
+`FavoriteListScreen.kt:164`（删除收藏）和 `ProfileScreen.kt:146`（退出登录）的确认按钮都是**普通 `TextButton`**，与"去赞助""去关联"这类引导型弹窗的确认按钮视觉权重完全相同。M3 的破坏性动作应当用 `error` 色区分。
+
+有意思的是，我们在**列表项**上已经这么做了——「我的」页的退出登录文字就是 `error` 色；只有它自己弹出的确认框反而没有。
+
+**建议**：给这两处确认按钮加 `colors = ButtonDefaults.textButtonColors(contentColor = error)`。工作量：10 分钟。这是本清单里**性价比最高**的一条。
+
+### ④ 下拉菜单圆角只有一处定制 ★★☆☆☆
+
+`HomeFloatingBar.kt:285` 把菜单圆角设成 24dp 以呼应悬浮胶囊，另两处（设置页、列表项操作）用 M3 默认。同一个 app 里两种菜单形状。
+
+**建议**：要么把 24dp 提成统一值（与卡片组的大圆角同语言），要么把底栏那处退回默认。倾向前者——我们整个 UI 已经是大圆角语言（卡片 24dp、胶囊全圆）。工作量：改一个默认参数 + 两处调用，20 分钟。
+
+### ⑤ 说明型弹窗有两套写法 ★★☆☆☆
+
+`TrendingScreen` 自己封了一个私有 `InfoDialog(title, content, onDismiss)`（:820），而其他页面要弹说明时直接手写 `AlertDialog`。同样是"标题 + 正文 + 一个确认按钮"，一处有组件、别处没有。
+
+**建议**：把 `InfoDialog` 提到 `ui/common`，`SettingsScreen:161` 那个摘要语言说明是最直接的复用点（虽然它有三个动作，可加可选的第二动作槽）。工作量：半小时。
+
+### ⑥ 「去关联 GitHub」两处独立实现 ★★☆☆☆
+
+`ProfileScreen.kt:166` 与 `SponsorLinkHost.kt:52`：**触发时机不同**（前者是"升级前发现没关联"，后者是"已赞助但没关联"），文案也确实不同，所以**不是重复代码**——但两者的最终动作、按钮结构、视觉完全一样，各写一份 `AlertDialog` 有维护成本，将来改一处容易漏另一处。
+
+**建议**：抽一个 `LinkGithubDialog(title, message, onConfirm, onDismiss)` 共用外壳，文案仍由调用方传。工作量：半小时。**优先级低**，属于代码整洁而非用户可感知。
+
+### ⑦ Snackbar 各页自建宿主 ★☆☆☆☆
+
+5 个页面各建各的 `SnackbarHostState`。这在 Compose 里是常规做法（`Scaffold` 级隔离），**不算问题**；只是首页四个 tab 都没有宿主，如果将来 tab 内要弹 snackbar 需要新接。**建议：不动。** 列在这里是为了说明"查过了、结论是没问题"。
+
+---
+
+## 三、建议补的决策规则
+
+不自洽的根源是没有成文规则，谁写谁定。建议把下面这张表写进 `CLAUDE.md` 的 UI 规范：
+
+| 场景 | 用什么 | 理由 |
+|---|---|---|
+| 破坏性动作确认（删除、退出、清空） | `AlertDialog`，确认按钮 `error` 色 | 必须打断，且要能表达"这一步有代价" |
+| 纯说明 / 引导（一个动作或"知道了"） | `AlertDialog`（统一走 `ui/common` 的 `InfoDialog`） | 轻量、不需要选择 |
+| 单选，≤4 项且有明确锚点（某一行的当前值） | `DropdownMenu` | 贴着触发点弹出，上下文不丢 |
+| 单选，>4 项 / 选项带描述或图标 / 需要滚动 | `ModalBottomSheet` | 下拉塞不下，也读不清 |
+| 多维筛选（两个及以上维度） | `ModalBottomSheet` + 分段控件 / Chip | 需要同屏比较多个维度 |
+| 系统级选择（日期、时间） | 对应的 `*PickerDialog` | 用平台组件，别自绘 |
+
+按这张表回头核对现有实现，**每一处的交互模式都能被规则解释，没有需要改模式的**。这说明问题全部集中在②③④这些**规格层面**——同一种组件的参数各写各的，而不是模式选错。
+
+---
+
+## 四、参照仓库怎么做（仅供仲裁）
+
+三家在这一层的共同点：
+
+- **Rhythm**：设置页的所有选择一律 `ModalBottomSheet`（`GoSettingsScreen.kt` 里 `showServiceSheet` / `showQualitySheet` / `showSheet` 一串），**完全不用 `DropdownMenu`**；
+- **Echo**：有全局的 `BottomSheetMenu` / `BottomSheetPage`（`MainActivity.kt:1319` 挂在根部），任何页面都能调；
+- **EchoFlow**：sheet 有统一封装，规格集中在 `Spacing.kt` / `ExpressiveShapes.kt`。
+
+**它们的共性不是"都用 sheet"，而是"sheet 有统一入口和统一规格"**——这正好对应我们的第②条。至于要不要学 Rhythm 把设置页下拉也换成 sheet，我倾向不学：我们的设置项选项少（3–4 个），下拉贴着行弹出比半屏浮层更快；Rhythm 的选项动辄十几个（音质、服务商），情况不同。
+
+---
+
+## 五、建议的执行顺序
+
+| 优先级 | 条目 | 工作量 | 用户可感知 |
+|---|---|---|---|
+| 1 | ③ 危险确认按钮 `error` 色 | 10 分钟 | 是 |
+| 2 | ② 统一 sheet 规格（提 `TrendingBottomSheet` + `BottomSheetHeader`） | 半天 | 是 |
+| 3 | ④ 下拉菜单圆角统一 | 20 分钟 | 弱 |
+| 4 | 第三节的决策表写进 `CLAUDE.md` | 20 分钟 | 否（防未来漂移） |
+| 5 | ⑤ `InfoDialog` 提到 common | 半小时 | 否 |
+| 6 | ⑥ `LinkGithubDialog` 共用外壳 | 半小时 | 否 |
+| — | ① 交互模式 | 无需改动 | — |
+| — | ⑦ Snackbar | 不动 | — |
+
+前三条加起来不到一天，覆盖了全部"用户能看出来"的部分。
+
+第②条里要一并处理登录方式浮层的三处规格问题（2026-08-05 截图核对发现）：标题 `titleMedium` 比另外三处 sheet 的 `titleLarge` 矮一号；标题左边距 24dp 与下面 `ListItem` 的 16dp 对不齐；两个选项仍是裸 `ListItem`，没跟上刚统一的卡片语言——这处可直接复用 `ui/common/SettingsGroup.kt`，GitHub logo 走 `leading` slot（`tint = Color.Unspecified` 保留原配色）。

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/InfoDialog.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/InfoDialog.kt
@@ -1,0 +1,35 @@
+package whl.trending.ai.ui.common
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.confirm
+
+/**
+ * 纯说明弹窗：标题 + 正文 + 一个「知道了」。
+ *
+ * 原先是 `TrendingScreen` 的私有组件，别处要弹说明只能手写 `AlertDialog`。按
+ * `docs/interaction-consistency-audit.md` 的决策表，说明 / 引导类一律走这里。
+ * 需要第二个动作的说明弹窗（如设置页的摘要语言）不适用——那属于「说明 + 多动作」，
+ * 仍自行组装 `AlertDialog`。
+ */
+@Composable
+fun InfoDialog(
+    title: String,
+    content: String,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = { Text(content) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.confirm))
+            }
+        },
+    )
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/ItemActionMenu.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/ItemActionMenu.kt
@@ -67,7 +67,7 @@ fun ItemActionMenu(
                     tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
-            DropdownMenu(
+            TrendingDropdownMenu(
                 expanded = expanded,
                 onDismissRequest = { expanded = false }
             ) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/LinkGithubDialog.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/LinkGithubDialog.kt
@@ -1,0 +1,44 @@
+package whl.trending.ai.ui.common
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import org.jetbrains.compose.resources.stringResource
+import trendingai.shared.generated.resources.Res
+import trendingai.shared.generated.resources.account_link_github
+import whl.trending.ai.core.AccountLink
+
+/**
+ * 「去关联 GitHub」弹窗的共用外壳。
+ *
+ * 两个触发点的时机与文案不同——「升级前发现没关联」（账户页）与「已赞助但没关联」
+ * （`SponsorLinkHost`）——但主动作完全一样：跳关联页、来源都记 `SOURCE_UPGRADE_DIALOG`。
+ * 此前两处各写一份 `AlertDialog`，改一处容易漏另一处。
+ *
+ * 次按钮差异大（一处是「仍然赞助」并跳赞助页，一处是「稍后」纯关闭），故做成槽位由调用方给。
+ */
+@Composable
+fun LinkGithubDialog(
+    title: String,
+    message: String,
+    onDismissRequest: () -> Unit,
+    dismissButton: @Composable () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text(title) },
+        text = { Text(message) },
+        confirmButton = {
+            TextButton(onClick = {
+                onDismissRequest()
+                // 关联成功后 MainActivity 的 AccountLink 分支会自动补一次 pro/refresh，
+                // 用户不需要再回赞助页，也不需要重启 app。
+                AccountLink.openLinkGithubPage(AccountLink.SOURCE_UPGRADE_DIALOG)
+            }) {
+                Text(stringResource(Res.string.account_link_github))
+            }
+        },
+        dismissButton = dismissButton,
+    )
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SettingsGroup.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SettingsGroup.kt
@@ -147,7 +147,14 @@ private fun SettingsItemRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (leading != null) {
-                leading()
+                // 统一占满图标容器的宽度并居中：leading 的内容尺寸不一（40dp 头像、24dp 品牌 logo），
+                // 不框住的话同一组里各行的文字起点会参差
+                Box(
+                    modifier = Modifier.size(IconContainerSize),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    leading()
+                }
                 Spacer(Modifier.width(16.dp))
             } else icon?.let {
                 Surface(

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SignInMethodChooserHost.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SignInMethodChooserHost.kt
@@ -1,19 +1,11 @@
 package whl.trending.ai.ui.common
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -59,22 +51,18 @@ fun SignInMethodChooserHost() {
         SignInChooserBus.clear()
         globalAuthManager.signIn(pendingSource, method)
     }
-    ModalBottomSheet(
+    TrendingBottomSheet(
         onDismissRequest = {
             trackEvent("sign_in_method_dismiss", mapOf("source" to pendingSource))
             SignInChooserBus.clear()
         },
+        title = stringResource(Res.string.sign_in_method_title),
     ) {
-        Column(Modifier.navigationBarsPadding().padding(bottom = 16.dp)) {
-            Text(
-                text = stringResource(Res.string.sign_in_method_title),
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
-            )
-            ListItem(
-                headlineContent = { Text(stringResource(Res.string.sign_in_method_github)) },
-                supportingContent = { Text(stringResource(Res.string.sign_in_method_github_desc)) },
-                leadingContent = {
+        // 两个选项都带一句说明，下拉塞不下——按决策表这类选择就该走浮层；
+        // 选项行复用全 app 的卡片语言（SettingsGroup），不再是裸 ListItem
+        SettingsGroup {
+            settingsItem(
+                leading = {
                     Icon(
                         painter = githubLogoPainter(),
                         contentDescription = null,
@@ -82,22 +70,15 @@ fun SignInMethodChooserHost() {
                         modifier = Modifier.size(24.dp),
                     )
                 },
-                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                modifier = Modifier.fillMaxWidth().clickable { choose(SignInMethod.GITHUB) },
+                title = { Text(stringResource(Res.string.sign_in_method_github)) },
+                description = { Text(stringResource(Res.string.sign_in_method_github_desc)) },
+                onClick = { choose(SignInMethod.GITHUB) },
             )
-            ListItem(
-                headlineContent = { Text(stringResource(Res.string.sign_in_method_email)) },
-                supportingContent = { Text(stringResource(Res.string.sign_in_method_email_desc)) },
-                leadingContent = {
-                    Icon(
-                        imageVector = Icons.Outlined.Email,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(24.dp),
-                    )
-                },
-                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                modifier = Modifier.fillMaxWidth().clickable { choose(SignInMethod.EMAIL) },
+            settingsItem(
+                icon = Icons.Outlined.Email,
+                title = { Text(stringResource(Res.string.sign_in_method_email)) },
+                description = { Text(stringResource(Res.string.sign_in_method_email_desc)) },
+                onClick = { choose(SignInMethod.EMAIL) },
             )
         }
     }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SponsorLinkHost.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SponsorLinkHost.kt
@@ -49,20 +49,10 @@ fun SponsorLinkHost() {
 
     if (!show) return
 
-    AlertDialog(
+    LinkGithubDialog(
+        title = stringResource(Res.string.sponsor_link_needed_title),
+        message = stringResource(Res.string.sponsor_link_needed_message),
         onDismissRequest = { show = false },
-        title = { Text(stringResource(Res.string.sponsor_link_needed_title)) },
-        text = { Text(stringResource(Res.string.sponsor_link_needed_message)) },
-        confirmButton = {
-            TextButton(onClick = {
-                show = false
-                // 关联成功后，MainActivity 的 AccountLink 分支会自动补一次 pro/refresh，
-                // 用户不需要再回赞助页，也不需要重启 app。
-                AccountLink.openLinkGithubPage(AccountLink.SOURCE_UPGRADE_DIALOG)
-            }) {
-                Text(stringResource(Res.string.account_link_github))
-            }
-        },
         dismissButton = {
             TextButton(onClick = { show = false }) {
                 Text(stringResource(Res.string.sponsor_link_needed_later))

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SponsorLinkHost.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/SponsorLinkHost.kt
@@ -1,6 +1,5 @@
 package whl.trending.ai.ui.common
 
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -15,7 +14,6 @@ import trendingai.shared.generated.resources.account_link_github
 import trendingai.shared.generated.resources.sponsor_link_needed_later
 import trendingai.shared.generated.resources.sponsor_link_needed_message
 import trendingai.shared.generated.resources.sponsor_link_needed_title
-import whl.trending.ai.core.AccountLink
 import whl.trending.ai.core.ProSponsor
 
 /**

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/TrendingBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/TrendingBottomSheet.kt
@@ -1,0 +1,75 @@
+package whl.trending.ai.ui.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * 全 app 统一的底部浮层：固定标题字号、内容边距与底部留白。
+ *
+ * 之前四处 `ModalBottomSheet` 各写各的，标题字号（`titleLarge` / `titleMedium`）、水平边距
+ * （16dp / 24dp）、底部留白（32dp / `navigationBarsPadding` + 16dp）没有任何两处一致，
+ * 连续打开筛选面板和登录选择能看出标题一大一小、内容一窄一宽。规格与取舍见
+ * `docs/interaction-consistency-audit.md`。
+ *
+ * 内容区不自带滚动——需要滚动的浮层（如规则说明）在 [content] 里自己挂 `verticalScroll`。
+ *
+ * @param title 标题，为 null 时不占位（内容自带标题的浮层用这种）
+ * @param titleAction 标题右侧的动作位，目前用于「帮助」图标按钮
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TrendingBottomSheet(
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    sheetState: SheetState = rememberModalBottomSheetState(),
+    titleAction: (@Composable () -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = SheetHorizontalPadding)
+                .navigationBarsPadding()
+                .padding(bottom = SheetBottomPadding),
+        ) {
+            if (title != null) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(text = title, style = MaterialTheme.typography.titleLarge)
+                    titleAction?.invoke()
+                }
+                Spacer(Modifier.height(16.dp))
+            }
+            content()
+        }
+    }
+}
+
+private val SheetHorizontalPadding = 24.dp
+private val SheetBottomPadding = 16.dp

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/TrendingDropdownMenu.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/TrendingDropdownMenu.kt
@@ -1,0 +1,39 @@
+package whl.trending.ai.ui.common
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.MenuDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * 全 app 统一的下拉菜单：固定 24dp 圆角，与卡片组、悬浮胶囊同一套大圆角语言。
+ *
+ * M3 默认圆角很小，此前只有底栏「⋯」菜单单独定制过 24dp，设置页与列表项操作菜单用的是默认值，
+ * 同一个 app 里出现两种菜单形状。见 `docs/interaction-consistency-audit.md`。
+ */
+@Composable
+fun TrendingDropdownMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    containerColor: Color = MenuDefaults.containerColor,
+    tonalElevation: Dp = MenuDefaults.TonalElevation,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        shape = RoundedCornerShape(MenuCorner),
+        containerColor = containerColor,
+        tonalElevation = tonalElevation,
+        content = content,
+    )
+}
+
+private val MenuCorner = 24.dp

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/favorites/FavoriteListScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/favorites/FavoriteListScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -162,10 +163,16 @@ private fun FavoriteCard(item: FavoriteItem, onClick: () -> Unit, onRemove: () -
             title = { Text(stringResource(Res.string.favorites_removed)) },
             text = { Text(stringResource(Res.string.favorites_delete_confirm)) },
             confirmButton = {
-                TextButton(onClick = {
-                    showDeleteDialog = false
-                    onRemove()
-                }) {
+                // 破坏性动作用 error 色与「取消」拉开权重（见 docs/interaction-consistency-audit.md 决策表）
+                TextButton(
+                    onClick = {
+                        showDeleteDialog = false
+                        onRemove()
+                    },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) {
                     Text(stringResource(Res.string.confirm))
                 }
             },

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
@@ -66,6 +66,7 @@ import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.about
 import trendingai.shared.generated.resources.more_label
 import trendingai.shared.generated.resources.settings
+import whl.trending.ai.ui.common.TrendingDropdownMenu
 
 /**
  * 悬浮底栏胶囊本体的高度，不含系统导航栏 inset 与外边距。
@@ -279,10 +280,10 @@ private fun OverflowFab(onOpenSettings: () -> Unit, onOpenAbout: () -> Unit) {
             Icon(Icons.Default.MoreHoriz, contentDescription = stringResource(Res.string.more_label))
         }
 
-        DropdownMenu(
+        // 容器色与 elevation 是底栏特有的「浮在胶囊之上」的观感，圆角走统一组件
+        TrendingDropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
-            shape = RoundedCornerShape(24.dp),
             containerColor = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.96f),
             tonalElevation = 8.dp,
         ) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/GithubProfileScreen.kt
@@ -95,6 +95,7 @@ import trendingai.shared.generated.resources.time_hours_ago
 import trendingai.shared.generated.resources.time_just_now
 import trendingai.shared.generated.resources.time_minutes_ago
 import whl.trending.ai.core.DateTimeUtils
+import whl.trending.ai.ui.common.TrendingBottomSheet
 import whl.trending.ai.ui.common.TrendingScaffold
 import whl.trending.ai.ui.common.TrendingTopAppBar
 
@@ -231,7 +232,10 @@ fun GithubProfileScreen(
     }
 
     if (showRulesSheet) {
-        ModalBottomSheet(onDismissRequest = { showRulesSheet = false }) {
+        TrendingBottomSheet(
+            onDismissRequest = { showRulesSheet = false },
+            title = stringResource(Res.string.feed_rules_title),
+        ) {
             FeedRulesSheet()
         }
     }
@@ -304,15 +308,9 @@ private fun FeedRulesSheet() {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 24.dp)
-            .padding(bottom = 32.dp),
+            .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Text(
-            stringResource(Res.string.feed_rules_title),
-            style = MaterialTheme.typography.titleLarge,
-        )
         FeedRulesSection(
             title = stringResource(Res.string.feed_rules_highlights_title),
             body = stringResource(Res.string.feed_rules_highlights_desc),

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -144,11 +145,17 @@ fun ProfileScreen(
             title = { Text(stringResource(Res.string.sign_out)) },
             text = { Text(stringResource(Res.string.sign_out_confirm)) },
             confirmButton = {
-                TextButton(onClick = {
-                    showSignOutDialog = false
-                    // 停留在 Hub：登出后 VM 监听 authState 落回匿名态（身份区显示登录引导）
-                    viewModel.signOut()
-                }) {
+                // 破坏性动作用 error 色与「取消」拉开权重（见 docs/interaction-consistency-audit.md 决策表）
+                TextButton(
+                    onClick = {
+                        showSignOutDialog = false
+                        // 停留在 Hub：登出后 VM 监听 authState 落回匿名态（身份区显示登录引导）
+                        viewModel.signOut()
+                    },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) {
                     Text(stringResource(Res.string.sign_out))
                 }
             },

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import whl.trending.ai.ui.common.LinkGithubDialog
 import whl.trending.ai.ui.common.LocalContentBottomPadding
 import whl.trending.ai.ui.common.SettingsGroup
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -170,18 +171,10 @@ fun ProfileScreen(
     // 邮箱用户点「升级 Pro」时的拦截：Pro 权益以 GitHub 账户为发放主体，不先关联就会
     // 「钱付了但权益对不上」。次按钮保留直接前往赞助页——有人只是想单纯支持，不图权益。
     if (showLinkGithubDialog) {
-        AlertDialog(
+        LinkGithubDialog(
+            title = stringResource(Res.string.account_link_required_title),
+            message = stringResource(Res.string.account_link_required_message),
             onDismissRequest = { showLinkGithubDialog = false },
-            title = { Text(stringResource(Res.string.account_link_required_title)) },
-            text = { Text(stringResource(Res.string.account_link_required_message)) },
-            confirmButton = {
-                TextButton(onClick = {
-                    showLinkGithubDialog = false
-                    AccountLink.openLinkGithubPage(AccountLink.SOURCE_UPGRADE_DIALOG)
-                }) {
-                    Text(stringResource(Res.string.account_link_github))
-                }
-            },
             dismissButton = {
                 TextButton(onClick = {
                     showLinkGithubDialog = false

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -107,6 +107,7 @@ import whl.trending.ai.data.remote.ApiException
 import whl.trending.ai.data.repository.TrendingRepository
 import whl.trending.ai.notification.globalDailyPicksNotifier
 import whl.trending.ai.ui.common.SettingsGroup
+import whl.trending.ai.ui.common.TrendingDropdownMenu
 import whl.trending.ai.ui.common.TrendingScaffold
 import whl.trending.ai.ui.common.TrendingTopAppBar
 import whl.trending.ai.ui.home.HomeTab
@@ -242,7 +243,7 @@ fun SettingsScreen(
                                         text = languageOptionText(appLanguage),
                                         color = MaterialTheme.colorScheme.primary,
                                     )
-                                    DropdownMenu(
+                                    TrendingDropdownMenu(
                                         expanded = appLanguageMenuExpanded,
                                         onDismissRequest = { appLanguageMenuExpanded = false },
                                     ) {
@@ -277,7 +278,7 @@ fun SettingsScreen(
                                     color = MaterialTheme.colorScheme.primary,
                                     modifier = Modifier.clickable { summaryLanguageMenuExpanded = true },
                                 )
-                                DropdownMenu(
+                                TrendingDropdownMenu(
                                     expanded = summaryLanguageMenuExpanded,
                                     onDismissRequest = { summaryLanguageMenuExpanded = false },
                                 ) {
@@ -310,7 +311,7 @@ fun SettingsScreen(
                                     text = homeTabOptionText(HomeTab.defaultFromName(defaultHomeTab)),
                                     color = MaterialTheme.colorScheme.primary,
                                 )
-                                DropdownMenu(
+                                TrendingDropdownMenu(
                                     expanded = homeTabMenuExpanded,
                                     onDismissRequest = { homeTabMenuExpanded = false },
                                 ) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.outlined.Info
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
@@ -34,7 +33,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import whl.trending.ai.ui.common.InfoDialog
 import whl.trending.ai.ui.common.TrendingBottomSheet
 import whl.trending.ai.ui.common.LocalContentBottomPadding
 import androidx.compose.ui.unit.sp
@@ -802,24 +803,6 @@ private fun HistoryBottomSheet(
                 }
             }
     }
-}
-
-@Composable
-private fun InfoDialog(
-    title: String,
-    content: String,
-    onDismiss: () -> Unit
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(title) },
-        text = { Text(content) },
-        confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(Res.string.confirm))
-            }
-        }
-    )
 }
 
 private fun String.toColorOrNull(): Color? {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import whl.trending.ai.ui.common.TrendingBottomSheet
 import whl.trending.ai.ui.common.LocalContentBottomPadding
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
@@ -573,22 +574,19 @@ private fun FilterBottomSheet(
         )
     }
 
-    ModalBottomSheet(
+    TrendingBottomSheet(
         onDismissRequest = onDismiss,
-        sheetState = sheetState
+        sheetState = sheetState,
+        title = stringResource(Res.string.filter_options),
+        titleAction = {
+            IconButton(onClick = { showHelpDialog = true }) {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    contentDescription = stringResource(Res.string.action_help),
+                )
+            }
+        },
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .padding(bottom = 32.dp)
-        ) {
-            BottomSheetHeader(
-                title = stringResource(Res.string.filter_options),
-                onHelpClick = { showHelpDialog = true }
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
 
             Text(
                 text = stringResource(Res.string.filter_period),
@@ -658,7 +656,6 @@ private fun FilterBottomSheet(
                     Text(stringResource(Res.string.filter_done))
                 }
             }
-        }
     }
 }
 
@@ -706,22 +703,19 @@ private fun HistoryBottomSheet(
         }
     }
 
-    ModalBottomSheet(
+    TrendingBottomSheet(
         onDismissRequest = onDismiss,
-        sheetState = sheetState
+        sheetState = sheetState,
+        title = stringResource(Res.string.history_trending),
+        titleAction = {
+            IconButton(onClick = { showHelpDialog = true }) {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    contentDescription = stringResource(Res.string.action_help),
+                )
+            }
+        },
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .padding(bottom = 32.dp)
-        ) {
-            BottomSheetHeader(
-                title = stringResource(Res.string.history_trending),
-                onHelpClick = { showHelpDialog = true }
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
 
             Text(
                 text = stringResource(Res.string.history_date),
@@ -807,7 +801,6 @@ private fun HistoryBottomSheet(
                     Text(stringResource(Res.string.filter_done))
                 }
             }
-        }
     }
 }
 
@@ -827,30 +820,6 @@ private fun InfoDialog(
             }
         }
     )
-}
-
-@Composable
-private fun BottomSheetHeader(
-    title: String,
-    onHelpClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleLarge
-        )
-        IconButton(onClick = onHelpClick) {
-            Icon(
-                imageVector = Icons.Outlined.Info,
-                contentDescription = stringResource(Res.string.action_help),
-            )
-        }
-    }
 }
 
 private fun String.toColorOrNull(): Color? {


### PR DESCRIPTION
## 背景

延续设置页卡片化那轮，这次查交互层——弹窗、底部浮层、下拉菜单、筛选面板。盘点结论有点反直觉：**交互模式全部选对了，问题集中在规格层面**。四处 `ModalBottomSheet` 的标题字号（`titleLarge` / `titleMedium`）、水平边距（16 / 24dp）、底部留白（32dp / `navigationBarsPadding` + 16dp）、是否传 `sheetState`，**没有任何两处完全一致**。

完整盘点见本 PR 新增的 `docs/interaction-consistency-audit.md`。

## 改动

| 条目 | 内容 |
|---|---|
| 危险确认 | 删除收藏、退出登录的确认按钮改用 `error` 色（「我的」页那行退出登录文字本来就是红的，它自己弹出的确认框反而不是） |
| 底部浮层 | 新增 `ui/common/TrendingBottomSheet.kt`，固定标题字号 / 边距 / 底部留白；四处浮层全部改用它 |
| 下拉菜单 | 新增 `ui/common/TrendingDropdownMenu.kt`，统一 24dp 圆角（此前只有底栏「⋯」定制过，另两处是 M3 默认小圆角） |
| 说明弹窗 | `InfoDialog` 从 `TrendingScreen` 的私有组件提到 `ui/common` |
| 关联 GitHub | 两个触发点（升级拦截 / 已赞助未关联）共用 `LinkGithubDialog` 外壳，次按钮做成槽位 |
| 登录方式浮层 | 标题从 `titleMedium` 升到统一的 `titleLarge`；两个选项从裸 `ListItem` 改用 `SettingsGroup` 卡片组，与设置页 / 关于页 /「我的」页同语言 |
| 规范 | 「什么场景用什么」的决策表写进 `CLAUDE.md` |

### 一处判断修正

登录方式浮层曾被盘点初版判为「2 个选项用半屏浮层偏重」。截图核对后修正：两个选项都带一句关键说明（"Authorize in your browser" / "We'll send a verification code"），`DropdownMenuItem` 单行 `text` 槽塞不下，按决策表本就该走浮层——**交互模式不改，只统一规格**。

## 验证中发现并修掉的 bug

登录浮层改完第一版实测，**GitHub 品牌 logo 是裸 24dp、email 图标是 40dp 圆容器**，同一组里两行的图标中心与文字起点都对不齐——`leading` slot 让调用方「尺寸自理」的后果。已改为组件把 `leading` 框进 40dp 并居中（`6537c2a`）。这个只有跑起来才看得见。

## 验证（Pixel_9_2，逐项实机）

- 筛选浮层 / 登录浮层：标题、边距、底部留白统一，内容与交互无回归；
- 设置页三处下拉 + 列表项操作菜单：圆角已是 24dp；
- 删除收藏确认弹窗：确认按钮为 `error` 色（截图确认）；
- 底栏「⋯」菜单：保留了自己的半透明容器色与 tonalElevation，只有圆角走统一组件。

未能实机截到的一处：**退出登录确认弹窗的 `error` 色**——验证途中模拟器登录态失效（疑似 token 过期），该弹窗需登录态才能触发。同一份改动在删除收藏那处已截图确认，两处改法完全相同。

顺带用像素比对核了底栏与 Echo 的对齐：胶囊、FAB、四个图标中心全部在 1–2px 内一致，无需改动。

## 风险

纯 UI 改动，无反射、无新依赖，R8 风险低。发版前照常跑 `scripts/release-smoke.sh`。iOS 端同样吃到这些改动，按既有决策不作验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXBH38vd8BhPVA8qNHJTZY

## Summary by Sourcery

通过引入共享的底部弹窗、下拉菜单以及信息/链接对话框来统一交互层组件，并在各个页面中进行应用，以实现一致的 UI 行为和样式。

New Features:
- 添加可复用的 `TrendingBottomSheet` 组件，用于标准化底部弹窗的布局和标题栏行为。
- 添加可复用的 `TrendingDropdownMenu` 组件，以在整个应用中统一带圆角的菜单样式。
- 添加共享的 `InfoDialog` 和 `LinkGithubDialog` 组件，用于常见的信息展示和账号关联对话框。

Bug Fixes:
- 对齐设置项中的前置图标/内容，修复在不同尺寸行中图标不对齐的问题。
- 在收藏与个人资料页面的破坏性确认对话框中，使用错误状态颜色的确认按钮。

Enhancements:
- 重构现有的底部弹窗、下拉菜单和对话框，使其使用新的通用组件，以统一排版、间距和形状。
- 更新登录方式选择器，使其使用 `SettingsGroup` 卡片和统一的底部弹窗样式。
- 在 `CLAUDE.md` 和新增的交互一致性审计文档中，记录交互一致性规则以及组件选择指南。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify interaction-layer components by introducing shared bottom sheet, dropdown menu, and info/link dialogs, and apply them across screens for consistent UI behavior and styling.

New Features:
- Add a reusable TrendingBottomSheet component to standardize bottom sheet layout and header behavior.
- Add a reusable TrendingDropdownMenu component to enforce consistent rounded-corner menus across the app.
- Add shared InfoDialog and LinkGithubDialog components for common informational and account-link dialogs.

Bug Fixes:
- Align leading icon/content within settings items to fix misaligned icons in mixed-size rows.
- Use error-colored confirm buttons for destructive confirmation dialogs in favorites and profile screens.

Enhancements:
- Refactor existing sheets, dropdown menus, and dialogs to use new common components for consistent typography, spacing, and shapes.
- Update sign-in method chooser to use SettingsGroup cards and unified sheet styling.
- Document interaction consistency rules and component selection guidelines in CLAUDE.md and a new interaction-consistency audit document.

</details>