### PR TITLE
chat: 通用入口默认新会话，续接边界改为进程

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -126,22 +126,30 @@ class ChatViewModel(
     /**
      * 入口进入（Screen 每个新入口调用一次）。
      *
-     * **通用入口一律新会话**（对齐 ChatGPT / Gemini / Grok）：对话是一次性任务单元，
+     * **通用入口默认新会话**（对齐 ChatGPT / Gemini / Grok）：对话是一次性任务单元，
      * 历史进抽屉、不进现场。此前「永远续同一条 general 会话」的代价是——不相关的话题
      * 堆进同一上下文窗口（最近 12 条 / 16k 字符会被上一话题连同 4000 字解读占满，答非
      * 所问），抽屉里长期只有一条会话（多会话功能形同虚设），欢迎区与快捷问因 messages
      * 非空而永久消失。线上 95% 的对话都走通用入口，这条路径的收益最大。
      *
+     * 「新会话」的边界是**进程**，不是页面：本 VM 挂在 Activity 作用域（`viewModel(key="chat")`
+     * 的 owner 是 Activity，退出 chat 页不销毁），所以返回首页查个东西再进来，[_currentThreadId]
+     * 还指着刚才那条会话——此时保持现状即可，不必重新开一条。进程被杀后 VM 随之消失，
+     * 下次进来自然是新会话，无需任何额外标记或时间窗口。
+     *
      * **条目入口（`repo:*`）仍恢复**：回到同一个项目继续追问是真实需求，且会话里已有的
      * 解读全文可以复用，不必重新生成。
      *
-     * 纯内存模式只切 context，不动 initialMessages。
+     * 纯内存模式只切 context，不动 initialMessages（该模式下不建线，续接分支恒不触发）。
      */
     fun enterEntry(context: ChatContext?) {
         viewModelScope.launch {
+            val isGeneralEntry = ChatStore.entryKeyOf(context) == ChatStore.ENTRY_GENERAL
+            // 进程内续接。判断必须在 activeContext 被覆盖之前——它此刻的值代表「上次停在哪」，
+            // null 才说明停在通用会话上（停在 repo 会话时走通用入口，应当开新会话而非续那条）
+            if (isGeneralEntry && activeContext == null && _currentThreadId.value != null) return@launch
             activeContext = context
             val s = store ?: return@launch
-            val isGeneralEntry = ChatStore.entryKeyOf(context) == ChatStore.ENTRY_GENERAL
             val id = if (isGeneralEntry) null else s.resolveLatestThread(context)
             if (id != null) {
                 openThread(id, fallbackContext = context)

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -120,18 +120,29 @@ class ChatViewModel(
         viewModelScope.launch {
             _catalog.value = runCatching { loadModels() }.getOrDefault(ChatModelsResponse())
         }
+        viewModelScope.launch { resumeAllPendingResearch() }
     }
 
     /**
-     * 入口进入（Screen 每个新入口调用一次）：恢复该入口最近会话（跨进程延续原
-     * sessionKey 的「再次进入恢复」体验）；无历史则以该 context 呈现空会话态。
+     * 入口进入（Screen 每个新入口调用一次）。
+     *
+     * **通用入口一律新会话**（对齐 ChatGPT / Gemini / Grok）：对话是一次性任务单元，
+     * 历史进抽屉、不进现场。此前「永远续同一条 general 会话」的代价是——不相关的话题
+     * 堆进同一上下文窗口（最近 12 条 / 16k 字符会被上一话题连同 4000 字解读占满，答非
+     * 所问），抽屉里长期只有一条会话（多会话功能形同虚设），欢迎区与快捷问因 messages
+     * 非空而永久消失。线上 95% 的对话都走通用入口，这条路径的收益最大。
+     *
+     * **条目入口（`repo:*`）仍恢复**：回到同一个项目继续追问是真实需求，且会话里已有的
+     * 解读全文可以复用，不必重新生成。
+     *
      * 纯内存模式只切 context，不动 initialMessages。
      */
     fun enterEntry(context: ChatContext?) {
         viewModelScope.launch {
             activeContext = context
             val s = store ?: return@launch
-            val id = s.resolveLatestThread(context)
+            val isGeneralEntry = ChatStore.entryKeyOf(context) == ChatStore.ENTRY_GENERAL
+            val id = if (isGeneralEntry) null else s.resolveLatestThread(context)
             if (id != null) {
                 openThread(id, fallbackContext = context)
             } else {
@@ -141,6 +152,27 @@ class ChatViewModel(
                     it.copy(messages = emptyList(), isSending = false, pendingImages = emptyList())
                 }
             }
+        }
+    }
+
+    /**
+     * 跨进程恢复**所有**未完成的 research 轮询，不依赖「进入时恢复了哪个会话」。
+     *
+     * 通用入口不再恢复会话之后，那条挂着任务的会话不会被打开——恢复若仍挂在
+     * [openThread] 上，后台被杀再回来就没人接这 10 credits 的任务了（服务端跑完也没人
+     * 写回）。轮询照常落库，用户从抽屉切过去就能看到完整报告。
+     *
+     * 落在 init 而非 [enterEntry]：Activity 被系统重建时 Screen 侧的 `enteredKey`
+     * （rememberSaveable）已恢复、`enterEntry` 不会再调，而那恰恰是最需要恢复的场景。
+     * 此刻尚无当前线，所以不区分——随后 [openThread] 对当前线补 searching 转圈标记，
+     * 它重复发起的轮询由 [researchJobs] 的在途判定拦下。
+     */
+    private suspend fun resumeAllPendingResearch() {
+        val s = store ?: return
+        s.threadsWithPendingResearch().forEach { threadId ->
+            val messages = messagesByThread[threadId]
+                ?: s.loadMessages(threadId).also { messagesByThread[threadId] = it }
+            resumeResearchIfAny(threadId, messages)
         }
     }
 

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -145,9 +145,15 @@ class ChatViewModel(
     fun enterEntry(context: ChatContext?) {
         viewModelScope.launch {
             val isGeneralEntry = ChatStore.entryKeyOf(context) == ChatStore.ENTRY_GENERAL
-            // 进程内续接。判断必须在 activeContext 被覆盖之前——它此刻的值代表「上次停在哪」，
-            // null 才说明停在通用会话上（停在 repo 会话时走通用入口，应当开新会话而非续那条）
-            if (isGeneralEntry && activeContext == null && _currentThreadId.value != null) return@launch
+            // 进程内续接。两点讲究：
+            // 1. 判断必须在 activeContext 被覆盖之前——它此刻的值代表「上次停在哪」；
+            //    停在 repo 会话时走通用入口，应当开新会话而非把那条续过来。
+            // 2. 「上次是不是通用会话」与 isGeneralEntry 走同一个 entryKeyOf，避免两处口径不一：
+            //    entryKeyOf 把「有 title 但无 externalId」的 context（HN/PH 场景）也算 general，
+            //    裸写 activeContext == null 会把它判成非通用，将来给 HN/PH 加入口就会分歧。
+            val wasOnGeneralThread = ChatStore.entryKeyOf(activeContext) == ChatStore.ENTRY_GENERAL &&
+                _currentThreadId.value != null
+            if (isGeneralEntry && wasOnGeneralThread) return@launch
             activeContext = context
             val s = store ?: return@launch
             val id = if (isGeneralEntry) null else s.resolveLatestThread(context)

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/db/ChatDatabase.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/db/ChatDatabase.kt
@@ -109,6 +109,16 @@ interface MessageDao {
 
     @Query("DELETE FROM chat_messages WHERE id = :id")
     suspend fun deleteById(id: Long)
+
+    /**
+     * 仍有未完成 research 占位（空内容）的会话 id。
+     *
+     * 恢复轮询不能只覆盖「当前打开的会话」：通用入口进入即新会话，之前那条挂着任务的
+     * 会话不会被打开，任务就没人接了。runId 存在 segmentsJson 里，SQL 侧只筛到「空内容
+     * 的 research 行」，由 [whl.trending.chat.ChatViewModel] 再按 runId 过滤。
+     */
+    @Query("SELECT DISTINCT threadId FROM chat_messages WHERE kind = :kind AND content = ''")
+    suspend fun threadsWithPendingResearch(kind: String): List<Long>
 }
 
 @Database(entities = [ThreadEntity::class, MessageEntity::class], version = 1, exportSchema = true)

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/store/ChatStore.kt
@@ -128,6 +128,10 @@ class ChatStore(
     /** research 失败：删占位行（服务端已退款；留着会让重启误续轮询死任务） */
     suspend fun deleteMessage(messageId: Long) = db.messageDao().deleteById(messageId)
 
+    /** 仍挂着未完成 research 的会话 id（跨进程恢复轮询用，与「当前打开哪个会话」无关） */
+    suspend fun threadsWithPendingResearch(): List<Long> =
+        db.messageDao().threadsWithPendingResearch(MessageKind.DEEP_RESEARCH.name)
+
     suspend fun renameThread(threadId: Long, title: String) =
         db.threadDao().rename(threadId, title.trim().take(MAX_TITLE_LENGTH))
 

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
@@ -28,6 +28,7 @@ import whl.trending.chat.store.ChatStore
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -384,14 +385,40 @@ class ChatViewModelPersistenceTest {
         // 只让创建完成、不推进轮询到终局：先切走再回来模拟重开
         advanceUntilIdle()
 
-        // 新 VM（模拟进程重启）：占位行在库里 → enterEntry 恢复轮询
+        val threadId = store.threads().first()[0].id
+
+        // 新 VM（模拟进程重启）：通用入口进来是**新会话**，那条挂着任务的会话并不会被打开——
+        // 恢复轮询因此不能挂在会话恢复上，否则这 10 credits 的任务永远没人接。
+        // 任务照常跑完落库，用户从抽屉切过去就能看到完整报告。
         val engine2 = ResearchEngine(mutableListOf(
             whl.trending.chat.model.ResearchRun("run-77", "completed", "迟到的报告", null),
         ))
         val v2 = vm(engine2)
         advanceUntilIdle()
 
-        assertEquals("迟到的报告", v2.uiState.value.messages.last().content)
+        assertTrue(v2.uiState.value.messages.isEmpty())
+        assertEquals("迟到的报告", db.messageDao().messagesFor(threadId).last().content)
+    }
+
+    @Test
+    fun `通用入口进入即新会话，不续上次；历史仍在抽屉可切回`() = runTest(dispatcher) {
+        val first = vm(GatedEngine(reply = "答一"))
+        advanceUntilIdle()
+        first.updateInput("问一")
+        first.send()
+        advanceUntilIdle()
+        val threadId = store.threads().first()[0].id
+
+        val second = vm(GatedEngine())
+        advanceUntilIdle()
+        assertTrue(second.uiState.value.messages.isEmpty())
+        assertNull(second.currentThreadId.value)
+
+        // 历史没丢：抽屉里还在，切回去内容完整
+        assertEquals(1, second.threads.value.size)
+        second.switchThread(threadId)
+        advanceUntilIdle()
+        assertEquals(listOf("问一", "答一"), second.uiState.value.messages.map { it.content })
     }
 
     @Test

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
@@ -401,6 +401,41 @@ class ChatViewModelPersistenceTest {
     }
 
     @Test
+    fun `进程内再次进入通用入口：续接当前会话，不重置`() = runTest(dispatcher) {
+        val v = vm(GatedEngine(reply = "答"))
+        advanceUntilIdle()
+        v.updateInput("问")
+        v.send()
+        advanceUntilIdle()
+        val threadId = v.currentThreadId.value
+        assertNotNull(threadId)
+
+        // 模拟「返回首页再进 chat」：VM 挂在 Activity 作用域仍存活，而 Screen 侧 enteredKey
+        // 随新 NavEntry 重置 → enterEntry 会再被调一次。此时应保持现状，不另开会话
+        v.enterEntry(null)
+        advanceUntilIdle()
+
+        assertEquals(threadId, v.currentThreadId.value)
+        assertEquals(listOf("问", "答"), v.uiState.value.messages.map { it.content })
+        assertEquals(1, store.threads().first().size)
+    }
+
+    @Test
+    fun `停在条目会话时走通用入口：开新会话，不把 repo 会话当通用会话续上`() = runTest(dispatcher) {
+        val v = vm(GatedEngine(reply = "答"), repoContext)
+        advanceUntilIdle()
+        v.updateInput("问")
+        v.send()
+        advanceUntilIdle()
+
+        v.enterEntry(null)
+        advanceUntilIdle()
+
+        assertNull(v.currentThreadId.value)
+        assertTrue(v.uiState.value.messages.isEmpty())
+    }
+
+    @Test
     fun `通用入口进入即新会话，不续上次；历史仍在抽屉可切回`() = runTest(dispatcher) {
         val first = vm(GatedEngine(reply = "答一"))
         advanceUntilIdle()


### PR DESCRIPTION
## 背景

进 chat 一直会恢复上次的会话，导致通用入口下用户永远在**同一条会话**里累积上下文。线上数据（近 14 天 / 全时段）：

- 95% 的对话走通用入口（`has_context=0`：978 条 / 161 人 vs 条目入口 52 条 / 27 人）
- 34% 的 chat 请求输入 ≥3000 tokens（276/815），最大 10971——系统提示 + 单条提问通常不到 500 token，其余都是历史累积
- 计费按次（`chat=1 credit`），长上下文不多扣用户额度，**只多花我们的钱**

产生的问题：① 新问题的第一轮就带着上一话题的最近 6 轮（可能含 4000 字解读全文），答非所问；② 恢复语义主动阻止新会话产生，抽屉里长期只有一条，多会话功能形同虚设；③ 欢迎区与快捷问的条件是 `messages` 为空，老会话恢复后永久看不到。

## 改动

**通用入口默认新会话，续接的边界是进程而不是页面。**

- 重启 app 后进 chat → 新会话
- chat 页返回首页再进来 → 续上刚才那条（最高频的「被打断」场景）
- 停在某个 repo 会话时走通用入口 → 新会话，不会把条目会话误当通用会话续上
- **条目入口（`repo:*`）维持原样**：回到同一个项目继续追问是真实需求，会话里的解读全文也可复用

实现上没有引入时间窗口，也没有新增任何标记：`ChatViewModel` 挂在 Activity 作用域（`viewModel(key="chat")` 的 owner 是 Activity，退出 chat 页不销毁——实测 `chatMode` 的 chip 跨页面存活可证），`_currentThreadId` 本身就是「本次使用停在哪条会话」的现成记忆，进程被杀 VM 随之消失。所以改动是让 `enterEntry` **少做一件事**：

```kotlin
val isGeneralEntry = ChatStore.entryKeyOf(context) == ChatStore.ENTRY_GENERAL
// 判断必须在 activeContext 被覆盖之前——它此刻的值代表「上次停在哪」
if (isGeneralEntry && activeContext == null && _currentThreadId.value != null) return@launch
```

### 连带必须一起改的一处：Deep Research 恢复

Deep Research 的跨进程恢复原本挂在会话恢复上（`enterEntry` → `openThread` → `resumeResearchIfAny`）。通用入口不再恢复会话后，那条挂着任务的会话不会被打开，**10 credits 的任务就没人接了**——服务端跑完也没人写回。

改为在 VM `init` 扫描库里所有未完成的 research 占位（新增 `threadsWithPendingResearch` 查询）并恢复轮询，与「打开了哪个会话」解耦。轮询照常落库，用户从抽屉切过去就能看到完整报告。

放 `init` 而非 `enterEntry`：Activity 被系统重建时 Screen 侧的 `enteredKey`（`rememberSaveable`）已恢复、`enterEntry` 不会再调，而那恰恰是最需要恢复的场景。**这一条在改动前就是坏的**（既有 bug），一并修掉。

## 验证

单测 109 个全过，新增 3 条、改 1 条：

- 新增：进程内续接、repo 会话边界、通用入口新会话且历史仍可从抽屉切回
- 改：`重开会话发现未完成占位→恢复轮询直至完成`——断言从「UI 上能看到报告」改为「UI 是新会话 + 报告已落库」，正是新语义

模拟器（Pixel_9_2）实跑：

| 场景 | 结果 |
|---|---|
| 冷启动进 chat | 空会话 + 欢迎区 + 快捷问 |
| 发消息 → 返回首页 → 再进 | 会话续上 |
| `force-stop` 重启 → 进 chat | 空会话 |
| 抽屉 | 三条历史完好，切回内容完整 |
| README → AI Chat（条目入口） | 仍恢复该 repo 的历史会话与解读 chip |

## 已知代价

进程什么时候被杀用户看不见也控制不了——激进后台策略的机型上（如 HyperOS），切出去几分钟回来可能就是新会话。换来的是零时钟依赖、零额外状态。找回路径（抽屉第一条）一直在。

按讨论**未做**：固定时长的短窗续接、顶栏「新对话」按钮。

## 附带发现（不在本 PR 范围）

真机验证时复现了线上问题：AI 回复报错「当前网络区域不可用」，即 `usage_events` 里的 `upstream_region_blocked`。detail_summary 自 7-30 起零成功，chat 主路径 8-05 也有约 22% 失败率。待单独排查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmU6qwy1gcRA1Hqmn9w9uV

## Summary by Sourcery

更改聊天会话行为，使常规入口在每个进程中始终开启新的会话，同时保留针对代码仓库（repo）会话的恢复能力；并将 Deep Research 的恢复与线程恢复解耦，以确保在进程重启后仍能继续未完成的任务。

Enhancements:
- 更新 `ChatViewModel`，使常规聊天入口在非同一进程中视为新会话，而在同一进程内继续时仍视为同一会话；同时保持仓库特定入口可以恢复其上一次的线程。
- 添加一个进程级的 `resumeAllPendingResearch` 流程，用于扫描所有含有未完成研究任务的线程，并独立于当前打开的线程恢复轮询。
- 扩展 `ChatStore` 和 `MessageDao`，新增查询以查找仍包含未完成 Deep Research 占位符的线程，从而支持跨进程恢复。

Tests:
- 新增并调整 `ChatViewModel` 的持久化测试，以覆盖以下场景：受进程绑定的常规入口行为、常规会话与仓库会话的区分，以及 Deep Research 恢复将结果持久化到存储（而不仅仅是当前激活的 UI）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Change chat session behavior so the general entry always starts a new conversation per process while preserving repo-specific session restoration, and decouple Deep Research recovery from thread restoration to ensure pending tasks resume after process restarts.

Enhancements:
- Update ChatViewModel to treat general chat entry as a new session unless continuing within the same process, while keeping repo-specific entries restoring their last thread.
- Add a process-wide resumeAllPendingResearch flow that scans all threads with pending research and resumes polling independent of the currently opened thread.
- Extend ChatStore and MessageDao with a query to find threads that still have unfinished Deep Research placeholders for cross-process recovery.

Tests:
- Add and adjust ChatViewModel persistence tests to cover process-bound general entry behavior, separation between general and repo sessions, and Deep Research recovery persisting results to storage rather than only the active UI.

</details>