### PR TITLE
feat(home): 底栏跟随滚动隐藏（设置项开关，默认关）

### DIFF
--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -50,6 +50,8 @@
     <string name="new_only_hint">24 小时内首次登上 GitHub 日榜（全语言）的新项目</string>
     <string name="default_home_tab">默认首页</string>
     <string name="default_home_tab_desc">启动时进入的标签页</string>
+    <string name="hide_bottom_bar_on_scroll">滚动时隐藏底栏</string>
+    <string name="hide_bottom_bar_on_scroll_desc">向下滑动收起底栏、向上滑动恢复 · 让内容多占一点屏幕</string>
     <string name="daily_picks_notification">每日精选提醒</string>
     <string name="daily_picks_notification_desc">每日精选更新后本地通知提醒，无需推送服务</string>
     <string name="notification_permission_denied">未获得通知权限，请在系统设置中允许通知</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -50,6 +50,8 @@
     <string name="new_only_hint">First appeared on the GitHub daily (all languages) list within 24 hours</string>
     <string name="default_home_tab">Default home tab</string>
     <string name="default_home_tab_desc">Which tab the app opens to at launch</string>
+    <string name="hide_bottom_bar_on_scroll">Hide bottom bar on scroll</string>
+    <string name="hide_bottom_bar_on_scroll_desc">Scroll down to tuck the bar away, scroll up to bring it back · Gives content more room</string>
     <string name="daily_picks_notification">Daily Picks reminder</string>
     <string name="daily_picks_notification_desc">A local notification when the day&#8217;s AI picks are ready — no push service required</string>
     <string name="notification_permission_denied">Notification permission is off. Allow it in system settings to get reminders.</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -134,6 +134,7 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val PICKS_NEWSLETTER_BANNER_DISMISSED_KEY = "prefs_picks_newsletter_banner_dismissed"
     private val DEFAULT_HOME_TAB_KEY = "prefs_default_home_tab"
     private val TRENDING_SOURCE_KEY = "prefs_trending_source"
+    private val HIDE_BOTTOM_BAR_ON_SCROLL_KEY = "prefs_hide_bottom_bar_on_scroll"
 
     /**
      * 安装级匿名标识：首次访问时生成并持久化，之后保持不变（卸载重装才会重新生成）。
@@ -548,6 +549,19 @@ class SettingsManager(private val settings: ObservableSettings) {
 
     fun setOpenLinksInCustomTab(value: Boolean) {
         settings.putBoolean(OPEN_LINKS_IN_CUSTOM_TAB_KEY, value)
+    }
+
+    /**
+     * 首页悬浮底栏是否跟随滚动隐藏。默认 false——底栏常驻是四个 tab 的稳定锚点，
+     * 藏起来换到的那点屏幕空间不值得让所有人默认承担「想切 tab 得先往回滑」的代价，
+     * 留给需要的人自己打开。关闭时首页不会接入任何滚动监听（见 HomeFloatingBarScrollHide）。
+     */
+    val hideBottomBarOnScroll: Flow<Boolean> = settings.getBooleanFlow(HIDE_BOTTOM_BAR_ON_SCROLL_KEY, false)
+
+    fun currentHideBottomBarOnScroll(): Boolean = settings.getBoolean(HIDE_BOTTOM_BAR_ON_SCROLL_KEY, false)
+
+    fun setHideBottomBarOnScroll(value: Boolean) {
+        settings.putBoolean(HIDE_BOTTOM_BAR_ON_SCROLL_KEY, value)
     }
 
     /**

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
@@ -100,6 +100,9 @@ internal data class HomeBarItem(
  * 工具栏用 `widthIn(max)` 收住宽度，FAB 放在工具栏自带的槽位里。
  * 选中态是一块跟着选中项滑动的药丸（见 [SlidingPillItems]）；只有图标、没有文字标签
  * ——Echo 那边 `showSelectedLabels` 写死为 false。
+ *
+ * 组件本身不接 `scrollBehavior`：滚动隐藏由调用方（`HomeScreen`）自己算隐藏距离并施加
+ * `translationY`，原因见那边的注释——M3 内建那套只按胶囊自身高度位移，藏不干净。
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBar.kt
@@ -101,8 +101,9 @@ internal data class HomeBarItem(
  * 选中态是一块跟着选中项滑动的药丸（见 [SlidingPillItems]）；只有图标、没有文字标签
  * ——Echo 那边 `showSelectedLabels` 写死为 false。
  *
- * 组件本身不接 `scrollBehavior`：滚动隐藏由调用方（`HomeScreen`）自己算隐藏距离并施加
- * `translationY`，原因见那边的注释——M3 内建那套只按胶囊自身高度位移，藏不干净。
+ * 组件本身不接 `scrollBehavior`：可选的「跟随滚动隐藏」（设置项开关，默认关）由调用方施加
+ * `translationY`，理由见 [HomeFloatingBarHideState]——M3 内建那套的位移量按胶囊到**父布局**
+ * 底边算，够不到这层 [BoxWithConstraints] 之外的外边距与导航栏 inset，藏不干净。
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBarScrollHide.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeFloatingBarScrollHide.kt
@@ -1,0 +1,114 @@
+package whl.trending.ai.ui.home
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.spring
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FloatingToolbarDefaults
+import androidx.compose.material3.FloatingToolbarExitDirection
+import androidx.compose.material3.FloatingToolbarState
+import androidx.compose.material3.rememberFloatingToolbarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+
+/**
+ * 首页悬浮底栏「跟随滚动隐藏」的全部实现，由设置项开关
+ * （`SettingsManager.hideBottomBarOnScroll`，默认关）决定要不要接入。
+ *
+ * 关闭时调用方传 null：[homeBarHideNestedScroll] 与 [homeBarHideOffset] 原样返回 receiver，
+ * 首页那两处 modifier 链与接入前逐字节相同——没有 nestedScroll 分发、没有额外渲染层；
+ * [rememberHomeFloatingBarHideState] 也不会被调用，state / behavior / effect 一概不进组合树。
+ *
+ * ## 为什么不直接把 behavior 交给 `HorizontalFloatingToolbar`
+ *
+ * M3 的 [FloatingToolbarDefaults.exitAlwaysScrollBehavior] 自带的位移
+ * （`floatingScrollBehavior()`）把 `offsetLimit` 取成「胶囊到**其父布局**底边的距离」。
+ * 官方 sample 里胶囊直接挂在铺满屏幕的 Box 上，那个距离恰好等于「滑出屏幕」；而我们的胶囊外面
+ * 还包着一层固定高度的 `BoxWithConstraints`（[HomeFloatingBar] 照搬 Echo 的结构），外边距与
+ * 导航栏 inset 都在这层之外，behavior 量不到——实测直接接上只滑下去胶囊自身高度，顶部还露出约一半。
+ *
+ * 所以这里只复用它的**曲线**（跟手 1:1、抛掷衰减、松手吸附到全显示/全隐藏），
+ * 隐藏距离与位移自己算、自己施加。
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+class HomeFloatingBarHideState internal constructor(
+    internal val toolbarState: FloatingToolbarState,
+    internal val connection: NestedScrollConnection,
+) {
+    /** 动画收回显示态。切 tab / 切子源这类「换了一屏内容」的时机调用。 */
+    internal suspend fun reveal() {
+        if (toolbarState.offset != 0f) {
+            animate(
+                initialValue = toolbarState.offset,
+                targetValue = 0f,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = Spring.StiffnessMediumLow,
+                ),
+            ) { value, _ -> toolbarState.offset = value }
+        }
+    }
+}
+
+/**
+ * 挂在包住各 tab 内容的容器上，让列表的滚动事件冒上来驱动底栏位移。
+ * [state] 为 null（开关关闭）时原样返回，不产生任何 modifier 节点。
+ */
+fun Modifier.homeBarHideNestedScroll(state: HomeFloatingBarHideState?): Modifier =
+    if (state == null) this else nestedScroll(state.connection)
+
+/**
+ * 挂在底栏上施加位移。读 offset 落在 draw 阶段，滚动全程不触发重组。
+ * offset 为负（[FloatingToolbarState] 的约定：0 = 全显示，offsetLimit = 全隐藏），
+ * 往屏幕外推要取反。[state] 为 null（开关关闭）时原样返回。
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+fun Modifier.homeBarHideOffset(state: HomeFloatingBarHideState?): Modifier =
+    if (state == null) this
+    else graphicsLayer { translationY = -state.toolbarState.offset }
+
+/**
+ * 建立底栏滚动隐藏所需的状态。**只在开关打开时调用**——关闭时整个组合分支都不存在。
+ *
+ * @param hiddenDistance 胶囊从常驻位到完全滑出屏幕的距离：胶囊高 + 外边距 + 导航栏 inset。
+ *   胶囊底边在「屏幕底 − (inset + 外边距)」，顶边再往上一个高度，推这么多顶边正好落到屏幕底沿。
+ * @param revealKeys 这些值一变就把底栏收回显示态（切 tab、切子源）：不把上一屏滑到一半的隐藏量
+ *   带过去，也免得新一屏内容不足一屏时底栏没机会自己回来。
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun rememberHomeFloatingBarHideState(
+    hiddenDistance: Dp,
+    vararg revealKeys: Any?,
+): HomeFloatingBarHideState {
+    val toolbarState = rememberFloatingToolbarState()
+    val behavior = FloatingToolbarDefaults.exitAlwaysScrollBehavior(
+        exitDirection = FloatingToolbarExitDirection.Bottom,
+        state = toolbarState,
+    )
+    val hiddenDistancePx = with(LocalDensity.current) { hiddenDistance.toPx() }
+
+    SideEffect {
+        toolbarState.offsetLimit = -hiddenDistancePx
+        // offset 只在写入时 coerce：隐藏距离变了（转屏、手势导航切三键导航改的是 inset）
+        // 得把已有位移夹回新区间，否则会一直停在按旧区间算出来的那个值上
+        toolbarState.offset = toolbarState.offset.coerceAtLeast(-hiddenDistancePx)
+    }
+
+    val state = remember(toolbarState, behavior) {
+        HomeFloatingBarHideState(toolbarState, behavior)
+    }
+
+    @Suppress("SpreadOperator")
+    LaunchedEffect(state, *revealKeys) { state.reveal() }
+
+    return state
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -1,6 +1,9 @@
 package whl.trending.ai.ui.home
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -37,6 +40,8 @@ import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledIconToggleButton
+import androidx.compose.material3.FloatingToolbarDefaults
+import androidx.compose.material3.FloatingToolbarExitDirection
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -49,10 +54,12 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberFloatingToolbarState
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -63,7 +70,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -113,7 +123,7 @@ import kotlin.time.Clock
  *
  * AI 对话是入口不是落点：点它直接推全屏聊天页，底栏选中态仍留在原 tab（见 [HomeTab.Chat]）。
  */
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun HomeScreen(
     onNavigateToDetail: (owner: String, repo: String) -> Unit,
@@ -259,7 +269,41 @@ fun HomeScreen(
         // 内容层不做底部 padding，列表才能滚到底栏之下。
         val contentModifier = Modifier.padding(top = innerPadding.calculateTopPadding())
         val barBottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+        // 内容底部留白按「底栏常驻」算，不跟着底栏藏起来一起缩——否则每次隐藏都要重排一次列表，
+        // 滚动中途的重排比露出的那点空间刺眼得多。
         val contentBottomPadding = barBottomInset + FloatingBarHeight + FloatingBarBottomMargin * 2
+
+        // 底栏跟手隐藏：内容往上滚（看后面的）胶囊顺着滑出屏幕，往下滚立刻跟回来，位移与手指 1:1；
+        // 松手时按剩余速度做衰减、再吸附到全显示/全隐藏，不会停在半截。
+        //
+        // 复用 M3 的 exitAlways 行为拿这套跟手 + 抛掷 + 吸附的曲线，但**不把它交给**
+        // [HorizontalFloatingToolbar]：组件内部那套位移只按胶囊自身高度算，胶囊底下的外边距和系统
+        // 导航栏 inset 不在里面，藏到底仍会露出一截。这里自己定隐藏距离（胶囊高 + 外边距 + inset），
+        // 位移用 graphicsLayer 施加——读 offset 落在 draw 阶段，滚动全程不触发重组。
+        val barState = rememberFloatingToolbarState()
+        val barScrollBehavior = FloatingToolbarDefaults.exitAlwaysScrollBehavior(
+            exitDirection = FloatingToolbarExitDirection.Bottom,
+            state = barState,
+        )
+        val barHiddenDistancePx = with(LocalDensity.current) {
+            (FloatingBarHeight + FloatingBarBottomMargin + barBottomInset).toPx()
+        }
+        SideEffect { barState.offsetLimit = -barHiddenDistancePx }
+
+        // 换 tab / 换子源等于换了一屏内容，底栏收回显示态：不把上一屏滑到一半的隐藏量带过去，
+        // 也免得新一屏内容不足一屏时底栏没机会自己回来。
+        LaunchedEffect(selectedTab, selectedSource) {
+            if (barState.offset != 0f) {
+                animate(
+                    initialValue = barState.offset,
+                    targetValue = 0f,
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioNoBouncy,
+                        stiffness = Spring.StiffnessMediumLow,
+                    ),
+                ) { value, _ -> barState.offset = value }
+            }
+        }
 
         val doubleTapMillis = LocalViewConfiguration.current.doubleTapTimeoutMillis
         var lastTapTime by remember { mutableStateOf(0L) }
@@ -353,7 +397,8 @@ fun HomeScreen(
             )
         }
 
-        Box(modifier = Modifier.fillMaxSize()) {
+        // nestedScroll 挂在这一层：四个 tab 的列表都在它下面，滚动事件冒上来才能驱动底栏位移
+        Box(modifier = Modifier.fillMaxSize().nestedScroll(barScrollBehavior)) {
             CompositionLocalProvider(LocalContentBottomPadding provides contentBottomPadding) {
                 // 切 tab 的方向性转场：新页从前进方向滑入 1/8 屏、旧页往反方向滑出，各配 200ms
                 // 淡入淡出。位移量、时长与方向判定照搬 Echo 的 NavHost enter/exitTransition；
@@ -443,6 +488,8 @@ fun HomeScreen(
                 // 高度加在调用处而非组件内部，与 Echo 在 MainActivity 的写法一致。
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
+                    // 滚动隐藏的位移。offset 为负（见 exitAlways 的约定），往下推屏幕外要取反
+                    .graphicsLayer { translationY = -barState.offset }
                     .padding(horizontal = 16.dp)
                     .padding(bottom = barBottomInset + FloatingBarBottomMargin)
                     .height(FloatingBarHeight),

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -288,7 +288,12 @@ fun HomeScreen(
         val barHiddenDistancePx = with(LocalDensity.current) {
             (FloatingBarHeight + FloatingBarBottomMargin + barBottomInset).toPx()
         }
-        SideEffect { barState.offsetLimit = -barHiddenDistancePx }
+        SideEffect {
+            barState.offsetLimit = -barHiddenDistancePx
+            // offset 只在写入时 coerce：隐藏距离变了（转屏、手势导航切三键导航改的是 inset）
+            // 得把已有位移夹回新区间，否则会一直停在按旧区间算出来的那个值上
+            barState.offset = barState.offset.coerceAtLeast(-barHiddenDistancePx)
+        }
 
         // 换 tab / 换子源等于换了一屏内容，底栏收回显示态：不把上一屏滑到一半的隐藏量带过去，
         // 也免得新一屏内容不足一屏时底栏没机会自己回来。

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -1,9 +1,6 @@
 package whl.trending.ai.ui.home
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animate
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -40,8 +37,6 @@ import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledIconToggleButton
-import androidx.compose.material3.FloatingToolbarDefaults
-import androidx.compose.material3.FloatingToolbarExitDirection
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -54,12 +49,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
-import androidx.compose.material3.rememberFloatingToolbarState
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -70,10 +63,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
-import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -123,7 +113,7 @@ import kotlin.time.Clock
  *
  * AI 对话是入口不是落点：点它直接推全屏聊天页，底栏选中态仍留在原 tab（见 [HomeTab.Chat]）。
  */
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
     onNavigateToDetail: (owner: String, repo: String) -> Unit,
@@ -157,6 +147,10 @@ fun HomeScreen(
             }
         }
     }
+    // 底栏跟随滚动隐藏的开关（设置 › 个性化，默认关）
+    val hideBottomBarOnScroll by globalSettingsManager.hideBottomBarOnScroll
+        .collectAsState(globalSettingsManager.currentHideBottomBarOnScroll())
+
     var showFilterSheet by rememberSaveable { mutableStateOf(false) }
     var showHistorySheet by rememberSaveable { mutableStateOf(false) }
 
@@ -273,42 +267,16 @@ fun HomeScreen(
         // 滚动中途的重排比露出的那点空间刺眼得多。
         val contentBottomPadding = barBottomInset + FloatingBarHeight + FloatingBarBottomMargin * 2
 
-        // 底栏跟手隐藏：内容往上滚（看后面的）胶囊顺着滑出屏幕，往下滚立刻跟回来，位移与手指 1:1；
-        // 松手时按剩余速度做衰减、再吸附到全显示/全隐藏，不会停在半截。
-        //
-        // 复用 M3 的 exitAlways 行为拿这套跟手 + 抛掷 + 吸附的曲线，但**不把它交给**
-        // [HorizontalFloatingToolbar]：组件内部那套位移只按胶囊自身高度算，胶囊底下的外边距和系统
-        // 导航栏 inset 不在里面，藏到底仍会露出一截。这里自己定隐藏距离（胶囊高 + 外边距 + inset），
-        // 位移用 graphicsLayer 施加——读 offset 落在 draw 阶段，滚动全程不触发重组。
-        val barState = rememberFloatingToolbarState()
-        val barScrollBehavior = FloatingToolbarDefaults.exitAlwaysScrollBehavior(
-            exitDirection = FloatingToolbarExitDirection.Bottom,
-            state = barState,
-        )
-        val barHiddenDistancePx = with(LocalDensity.current) {
-            (FloatingBarHeight + FloatingBarBottomMargin + barBottomInset).toPx()
-        }
-        SideEffect {
-            barState.offsetLimit = -barHiddenDistancePx
-            // offset 只在写入时 coerce：隐藏距离变了（转屏、手势导航切三键导航改的是 inset）
-            // 得把已有位移夹回新区间，否则会一直停在按旧区间算出来的那个值上
-            barState.offset = barState.offset.coerceAtLeast(-barHiddenDistancePx)
-        }
-
-        // 换 tab / 换子源等于换了一屏内容，底栏收回显示态：不把上一屏滑到一半的隐藏量带过去，
-        // 也免得新一屏内容不足一屏时底栏没机会自己回来。
-        LaunchedEffect(selectedTab, selectedSource) {
-            if (barState.offset != 0f) {
-                animate(
-                    initialValue = barState.offset,
-                    targetValue = 0f,
-                    animationSpec = spring(
-                        dampingRatio = Spring.DampingRatioNoBouncy,
-                        stiffness = Spring.StiffnessMediumLow,
-                    ),
-                ) { value, _ -> barState.offset = value }
-            }
-        }
+        // 底栏跟随滚动隐藏：设置项开关，默认关。关闭时 barHide 为 null，下面两处 modifier
+        // 原样返回、这段状态也不进组合树——首页与没有这个功能时逐字节相同。实现见
+        // [rememberHomeFloatingBarHideState]。
+        val barHide = if (hideBottomBarOnScroll) {
+            rememberHomeFloatingBarHideState(
+                hiddenDistance = FloatingBarHeight + FloatingBarBottomMargin + barBottomInset,
+                selectedTab,
+                selectedSource,
+            )
+        } else null
 
         val doubleTapMillis = LocalViewConfiguration.current.doubleTapTimeoutMillis
         var lastTapTime by remember { mutableStateOf(0L) }
@@ -402,8 +370,9 @@ fun HomeScreen(
             )
         }
 
-        // nestedScroll 挂在这一层：四个 tab 的列表都在它下面，滚动事件冒上来才能驱动底栏位移
-        Box(modifier = Modifier.fillMaxSize().nestedScroll(barScrollBehavior)) {
+        // 底栏滚动隐藏的 nestedScroll 挂在这一层：四个 tab 的列表都在它下面，滚动事件冒上来
+        // 才能驱动位移。开关关闭时（barHide 为 null）这里不挂任何东西。
+        Box(modifier = Modifier.fillMaxSize().homeBarHideNestedScroll(barHide)) {
             CompositionLocalProvider(LocalContentBottomPadding provides contentBottomPadding) {
                 // 切 tab 的方向性转场：新页从前进方向滑入 1/8 屏、旧页往反方向滑出，各配 200ms
                 // 淡入淡出。位移量、时长与方向判定照搬 Echo 的 NavHost enter/exitTransition；
@@ -493,8 +462,7 @@ fun HomeScreen(
                 // 高度加在调用处而非组件内部，与 Echo 在 MainActivity 的写法一致。
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
-                    // 滚动隐藏的位移。offset 为负（见 exitAlways 的约定），往下推屏幕外要取反
-                    .graphicsLayer { translationY = -barState.offset }
+                    .homeBarHideOffset(barHide)
                     .padding(horizontal = 16.dp)
                     .padding(bottom = barBottomInset + FloatingBarBottomMargin)
                     .height(FloatingBarHeight),

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.OpenInBrowser
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.SwipeVertical
 import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
@@ -60,6 +61,8 @@ import trendingai.shared.generated.resources.chat_title
 import trendingai.shared.generated.resources.daily_picks_notification
 import trendingai.shared.generated.resources.default_home_tab
 import trendingai.shared.generated.resources.default_home_tab_desc
+import trendingai.shared.generated.resources.hide_bottom_bar_on_scroll
+import trendingai.shared.generated.resources.hide_bottom_bar_on_scroll_desc
 import trendingai.shared.generated.resources.feedback
 import trendingai.shared.generated.resources.feedback_email_invalid
 import trendingai.shared.generated.resources.feedback_email_placeholder
@@ -136,6 +139,7 @@ fun SettingsScreen(
     val appLanguage by globalSettingsManager.appLanguage.collectAsState(AppLanguage.FOLLOW_SYSTEM)
     val summaryLanguage by globalSettingsManager.summaryLanguage.collectAsState(SummaryLanguage.FOLLOW_SYSTEM)
     val openLinksInCustomTab by globalSettingsManager.openLinksInCustomTab.collectAsState(true)
+    val hideBottomBarOnScroll by globalSettingsManager.hideBottomBarOnScroll.collectAsState(false)
     val defaultHomeTab by globalSettingsManager.defaultHomeTab.collectAsState(
         remember { globalSettingsManager.currentDefaultHomeTab() }
     )
@@ -329,6 +333,26 @@ fun SettingsScreen(
                             }
                         },
                         onClick = { homeTabMenuExpanded = true },
+                    )
+                    // 底栏跟随滚动隐藏：默认关。行点击与开关同为切换（与「外链打开方式」一致）
+                    settingsItem(
+                        icon = Icons.Default.SwipeVertical,
+                        title = { Text(stringResource(Res.string.hide_bottom_bar_on_scroll)) },
+                        description = { Text(stringResource(Res.string.hide_bottom_bar_on_scroll_desc)) },
+                        trailing = {
+                            Switch(
+                                checked = hideBottomBarOnScroll,
+                                onCheckedChange = { enabled ->
+                                    trackEvent("settings_hide_bottom_bar_on_scroll", mapOf("enabled" to enabled.toString()))
+                                    globalSettingsManager.setHideBottomBarOnScroll(enabled)
+                                }
+                            )
+                        },
+                        onClick = {
+                            val enabled = !hideBottomBarOnScroll
+                            trackEvent("settings_hide_bottom_bar_on_scroll", mapOf("enabled" to enabled.toString()))
+                            globalSettingsManager.setHideBottomBarOnScroll(enabled)
+                        },
                     )
                 }
             }


### PR DESCRIPTION
## 做了什么

首页悬浮胶囊底栏支持跟随滚动隐藏：向下滚动顺着滑出屏幕，向上滚动立刻跟回来。位移与手指 1:1，松手后按剩余速度衰减、再吸附到全显示 / 全隐藏，不会停在半截。

**做成设置项开关（设置 › 个性化），默认关。** 底栏常驻是四个 tab 的稳定锚点，藏起来换到的那点屏幕空间不值得让所有人默认承担「想切 tab 得先往回滑」的代价。

## 关闭时代码是干净的

实现整体收在 `HomeFloatingBarScrollHide.kt`，对外只暴露一个状态和两个 Modifier 扩展。开关关闭时调用方传 `null`：

- `Modifier.homeBarHideNestedScroll(null)` / `homeBarHideOffset(null)` **原样返回 receiver** —— 首页那两处 modifier 链与没有这个功能时逐字节相同，没有 nestedScroll 分发，也没有额外渲染层；
- `rememberHomeFloatingBarHideState` 根本不被调用，state / behavior / `SideEffect` / `LaunchedEffect` 一概不进组合树。

## 实现要点

1. **跟手曲线复用 M3**：`FloatingToolbarDefaults.exitAlwaysScrollBehavior(Bottom)` 提供跟手、抛掷衰减、松手吸附。
2. **但不把 behavior 交给 `HorizontalFloatingToolbar`**：它自带位移的 `offsetLimit` 取的是「胶囊到**其父布局**底边的距离」。官方 sample 里胶囊直接挂在铺满屏幕的 Box 上，那个距离恰好等于滑出屏幕；我们的胶囊外面还包着一层固定高度的 `BoxWithConstraints`（照搬 Echo 的结构），外边距与导航栏 inset 都在这层之外——**实测直接接上只滑下去胶囊自身高度，顶部还露出约一半**。所以隐藏距离（胶囊高 + 外边距 + inset）自己算。
3. **位移用 `graphicsLayer { translationY = ... }`**：offset 的读取落在 draw 阶段，滚动全程不触发重组。
4. 内容底部留白仍按「底栏常驻」算，不跟着一起缩，避免滚动中途重排列表；换 tab / 换子源时用 spring 收回显示态。
5. 隐藏距离变化时（转屏、手势导航切三键导航改的是 inset）把已有位移夹回新区间——`offset` 只在写入时 coerce，不补这一下会停在按旧区间算出来的值上。

## 验证（Pixel_9_2 模拟器，github 渠道 debug 包）

| 场景 | 结果 |
|---|---|
| **默认（开关关）滚动列表** | 底栏纹丝不动 |
| 开关打开 → 向下滚动 | 胶囊完整滑出屏幕，不留边 |
| 开关打开 → 向上滚动 | 立刻跟回，滚到顶时已完全归位 |
| 慢拖 20% 后抬手 | 吸附回全显示 |
| 慢拖 60% 后抬手 | 吸附到全隐藏 |
| 底栏隐藏时切子源 tab | 动画收回显示态 |
| **底栏正藏着时关掉开关** | 立刻回到常驻位，无残留位移；再滚动不再隐藏 |
| 「我的」这类不满一屏的页面 | 底栏常驻，无异常 |
| 崩溃日志 | 无 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aaRqkUK47agKPjDg8kfaF