### PR TITLE
feat(feed): PH 列表项支持多图，图库改为轮播

### DIFF
--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/FeedResponse.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/FeedResponse.kt
@@ -51,17 +51,31 @@ data class FeedItem(
     }
 
     /**
-     * Product Hunt 产品主视觉，取图库首图。
+     * Product Hunt 产品图库，整组按显示宽度请求，顺序与接口一致（首张即主视觉）。
      * fit=max 只按宽度约束、不裁剪，原始比例交给调用方按图片实际尺寸排布。
      * 原图大到 4MB，必须带尺寸参数；这里显式要 webp 而不是 auto=format——
      * 图库多为界面截图，auto 会选无损 png，同尺寸下比 webp 大好几倍。
-     * 2026-07-30 之前入库的条目没有 gallery，返回 null 由调用方降级。
+     * 2026-07-30 之前入库的条目没有 gallery，返回空列表由调用方降级。
+     *
+     * [limit] 兜住接口万一放开条数：列表里一条目前最多 5 张，超出的不值得占轮播位。
+     * 注意返回的每一张都只是 URL，实际下载由调用方按需触发（轮播只加载当前页）。
      */
-    fun heroImageUrl(widthPx: Int): String? {
-        if (source != "producthunt") return null
-        val raw = extra?.gallery?.firstOrNull()?.takeIf { it.isNotBlank() } ?: return null
-        val separator = if ('?' in raw) "&" else "?"
-        return "$raw${separator}fm=webp&q=70&w=$widthPx&fit=max"
+    fun galleryImageUrls(widthPx: Int, limit: Int = GALLERY_MAX): List<String> {
+        if (source != "producthunt") return emptyList()
+        val raws = extra?.gallery ?: return emptyList()
+        return raws.asSequence()
+            .filter { it.isNotBlank() }
+            .take(limit)
+            .map { raw ->
+                val separator = if ('?' in raw) "&" else "?"
+                "$raw${separator}fm=webp&q=70&w=$widthPx&fit=max"
+            }
+            .toList()
+    }
+
+    companion object {
+        /** 单条最多展示的图库张数。 */
+        const val GALLERY_MAX = 5
     }
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -58,6 +60,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
@@ -78,6 +81,9 @@ private const val HERO_REQUEST_PX = 720
 private const val HERO_PLACEHOLDER_RATIO = 16f / 9f
 private const val HERO_MIN_RATIO = 0.75f
 private const val HERO_MAX_RATIO = 3f
+
+/** 图库轮播的圆点指示器尺寸。 */
+private val INDICATOR_DOT_SIZE = 6.dp
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -191,7 +197,7 @@ private fun FeedItemCard(
     onOpenDigest: (DigestPage) -> Unit,
     onToggleFavorite: () -> Unit
 ) {
-    val heroImage = item.heroImageUrl(HERO_REQUEST_PX)
+    val gallery = item.galleryImageUrls(HERO_REQUEST_PX)
     val clickModifier = Modifier.clickable {
         trackItemClick(
             source = item.source,
@@ -224,7 +230,7 @@ private fun FeedItemCard(
                 item = item,
                 isFavorite = isFavorite,
                 onToggleFavorite = onToggleFavorite,
-                heroImage = heroImage
+                gallery = gallery
             )
         }
     }
@@ -233,7 +239,7 @@ private fun FeedItemCard(
 /**
  * 标题以下的公共部分：描述、AI 摘要、元信息 + 操作菜单。
  *
- * [heroImage] 是 Product Hunt 的产品主视觉：有摘要时收进摘要块内部，
+ * [gallery] 是 Product Hunt 的产品图库：有摘要时收进摘要块内部，
  * 没摘要时单独成块——总之跟在描述之后，不再单独占卡片顶部。
  */
 @Composable
@@ -241,7 +247,7 @@ private fun FeedItemBody(
     item: FeedItem,
     isFavorite: Boolean,
     onToggleFavorite: () -> Unit,
-    heroImage: String? = null
+    gallery: List<String> = emptyList()
 ) {
     if (!item.description.isNullOrBlank()) {
         Text(
@@ -256,11 +262,11 @@ private fun FeedItemBody(
     if (!item.summary.isNullOrBlank()) {
         AiSummaryBox(
             summary = item.summary,
-            media = heroImage?.let { url -> { HeroImage(url = url) } }
+            media = gallery.takeIf { it.isNotEmpty() }?.let { urls -> { HeroGallery(urls = urls) } }
         )
-    } else if (heroImage != null) {
-        HeroImage(
-            url = heroImage,
+    } else if (gallery.isNotEmpty()) {
+        HeroGallery(
+            urls = gallery,
             modifier = Modifier.clip(RoundedCornerShape(12.dp))
         )
     }
@@ -291,30 +297,97 @@ private fun FeedItemBody(
 }
 
 /**
- * 产品主视觉。按图片实际比例排布，不裁成固定画幅——图库里既有 16:9 的演示图
- * 也有接近方形的宣传图，统一裁会切掉半张。加载完成前用 16:9 占位，避免高度从
- * 0 弹开；比例只在极端长图时才夹住，正常横图不受影响。
+ * 产品图库。一屏一图、左右滑动切换，多图时底部叠圆点指示器。
+ *
+ * 画幅按首图的实际比例排布，不裁成固定值——图库里既有 16:9 的演示图也有接近方形的
+ * 宣传图，统一裁会切掉半张。加载完成前用 16:9 占位，避免高度从 0 弹开；比例只在极端
+ * 长图时才夹住，正常横图不受影响。整组共用首图的比例：同一条内各图尺寸实测基本一致，
+ * 而逐页改高度会让列表在滑动中上下跳。
+ *
+ * 后几张只在翻到时才由 [HorizontalPager] 组合、进而触发下载，
+ * 静止在首图的用户不会为多图多付流量。
  */
 @Composable
-private fun HeroImage(url: String, modifier: Modifier = Modifier) {
-    val painter = rememberAsyncImagePainter(url)
-    val state by painter.state.collectAsState()
-    val ratio = (state as? AsyncImagePainter.State.Success)
+private fun HeroGallery(urls: List<String>, modifier: Modifier = Modifier) {
+    val firstPainter = rememberAsyncImagePainter(urls.first())
+    val firstState by firstPainter.state.collectAsState()
+    val ratio = (firstState as? AsyncImagePainter.State.Success)
         ?.painter
         ?.intrinsicSize
         ?.takeIf { it.width > 0f && it.height > 0f }
         ?.let { (it.width / it.height).coerceIn(HERO_MIN_RATIO, HERO_MAX_RATIO) }
         ?: HERO_PLACEHOLDER_RATIO
 
-    Image(
-        painter = painter,
-        contentDescription = null,
-        contentScale = ContentScale.Crop,
+    if (urls.size == 1) {
+        Image(
+            painter = firstPainter,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = modifier
+                .fillMaxWidth()
+                .aspectRatio(ratio)
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+        )
+        return
+    }
+
+    val pagerState = rememberPagerState(pageCount = { urls.size })
+    Box(modifier = modifier) {
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(ratio)
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+        ) { page ->
+            // 首页复用外层那个 painter：比例已经从它身上读过，再建一个只是重复请求
+            if (page == 0) {
+                Image(
+                    painter = firstPainter,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                AsyncImage(
+                    model = urls[page],
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+        GalleryIndicator(
+            pageCount = urls.size,
+            currentPage = pagerState.currentPage,
+            modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 8.dp)
+        )
+    }
+}
+
+/**
+ * 图库页码指示器。截图底色深浅不定，圆点垫一层半透明黑底才在两种图上都看得清，
+ * 因此这里用固定的黑/白而不是主题色。
+ */
+@Composable
+private fun GalleryIndicator(pageCount: Int, currentPage: Int, modifier: Modifier = Modifier) {
+    Row(
         modifier = modifier
-            .fillMaxWidth()
-            .aspectRatio(ratio)
-            .background(MaterialTheme.colorScheme.surfaceVariant)
-    )
+            .clip(CircleShape)
+            .background(Color.Black.copy(alpha = 0.35f))
+            .padding(horizontal = 8.dp, vertical = 5.dp),
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        repeat(pageCount) { page ->
+            Box(
+                modifier = Modifier
+                    .size(INDICATOR_DOT_SIZE)
+                    .clip(CircleShape)
+                    .background(Color.White.copy(alpha = if (page == currentPage) 1f else 0.45f))
+            )
+        }
+    }
 }
 
 /**

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
@@ -309,7 +309,9 @@ private fun FeedItemBody(
  */
 @Composable
 private fun HeroGallery(urls: List<String>, modifier: Modifier = Modifier) {
-    val firstPainter = rememberAsyncImagePainter(urls.first())
+    // 调用点已按 isNotEmpty 把关，这里再兜一次：空列表就什么都不画，而不是抛异常
+    val first = urls.firstOrNull() ?: return
+    val firstPainter = rememberAsyncImagePainter(first)
     val firstState by firstPainter.state.collectAsState()
     val ratio = (firstState as? AsyncImagePainter.State.Success)
         ?.painter

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/model/FeedItemTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/model/FeedItemTest.kt
@@ -3,6 +3,7 @@ package whl.trending.ai.data.model
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class FeedItemTest {
     private val json = Json { ignoreUnknownKeys = true }
@@ -78,5 +79,56 @@ class FeedItemTest {
         """.trimIndent()
         val item = json.decodeFromString<FeedItem>(payload)
         assertEquals("https://example.com/", item.openUrl)
+    }
+
+    @Test
+    fun producthunt_gallery_keeps_order_and_appends_size_params() {
+        val payload = """
+            {"source":"producthunt","externalId":"p4","title":"Product",
+            "url":"https://example.com/",
+            "extra":{"gallery":["https://ph-files.imgix.net/a.png?auto=format",
+            "https://ph-files.imgix.net/b.png"]}}
+        """.trimIndent()
+        val item = json.decodeFromString<FeedItem>(payload)
+        assertEquals(
+            listOf(
+                "https://ph-files.imgix.net/a.png?auto=format&fm=webp&q=70&w=720&fit=max",
+                "https://ph-files.imgix.net/b.png?fm=webp&q=70&w=720&fit=max"
+            ),
+            item.galleryImageUrls(720)
+        )
+    }
+
+    @Test
+    fun producthunt_gallery_drops_blank_entries_and_caps_count() {
+        val urls = (1..7).joinToString(",") { "\"https://ph-files.imgix.net/$it.png\"" }
+        val payload = """
+            {"source":"producthunt","externalId":"p5","title":"Product",
+            "url":"https://example.com/","extra":{"gallery":["",$urls]}}
+        """.trimIndent()
+        val item = json.decodeFromString<FeedItem>(payload)
+        val gallery = item.galleryImageUrls(720)
+        assertEquals(FeedItem.GALLERY_MAX, gallery.size)
+        assertEquals("https://ph-files.imgix.net/1.png?fm=webp&q=70&w=720&fit=max", gallery.first())
+    }
+
+    @Test
+    fun producthunt_item_without_gallery_has_no_images() {
+        val payload = """
+            {"source":"producthunt","externalId":"p6","title":"Legacy product",
+            "url":"https://example.com/","extra":{"ph_url":"https://www.producthunt.com/x"}}
+        """.trimIndent()
+        val item = json.decodeFromString<FeedItem>(payload)
+        assertTrue(item.galleryImageUrls(720).isEmpty())
+    }
+
+    @Test
+    fun non_producthunt_item_has_no_gallery_images() {
+        val payload = """
+            {"source":"hackernews","externalId":"h9","title":"Story",
+            "url":"https://example.com/","extra":{"gallery":["https://img.example/a.png"]}}
+        """.trimIndent()
+        val item = json.decodeFromString<FeedItem>(payload)
+        assertTrue(item.galleryImageUrls(720).isEmpty())
     }
 }


### PR DESCRIPTION
## 背景

PH 条目此前只展示图库首图，接口每条最多返回 5 张，后面几张用户看不到。

## 改动

- `FeedItem.heroImageUrl` → `galleryImageUrls`：返回整组图库 URL（过滤空串、按 `GALLERY_MAX` = 5 封顶、imgix 尺寸参数与原来一致）
- 列表图块改为 `HorizontalPager` 一屏一图，多图时底部叠圆点指示器；单图仍走原来的 `Image`，视觉与之前完全一致
- 画幅统一取首图比例，不逐页改高度——同一条内各图尺寸实测基本一致（多为 1.67），逐页改高度会让列表在翻页时上下跳
- 圆点指示器用固定黑底/白点而非主题色：截图底色深浅不定，垫半透明黑底才在两种图上都看得清

## 流量

后几张只在翻到时才由 pager 组合、才发请求，静止在首图的用户不会为多图多付流量。

## 验证

- `:shared:testAndroidHostTest` 通过，`FeedItemTest` 新增 4 个用例：顺序与 imgix 参数、空串过滤与 5 张上限、无 gallery 的老条目、非 PH 源
- Pixel_9_2 模拟器实机：PH tab 首屏轮播与 5 个圆点正常，左滑到第 2/3 张指示器跟随，图上纵向拖动仍能滚列表，点击图片仍打开 PH 原帖



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UGuXuTW7mT56bk85nzy2K

## Summary by Sourcery

在信息流中支持多图 Product Hunt 图库，并以可滑动轮播的形式展示，同时提供内联指示器。

新功能：
- 为每个信息流条目暴露一个 Product Hunt 图库图片 URL 列表，而不是单一主图，并对图片数量设置最大上限。
- 在信息流中将 Product Hunt 图库图片渲染为水平分页轮播组件，为每个条目显示页面指示器，同时保留单图展示方式。

改进：
- 根据首张图片统一图库的纵横比，并为多图条目添加专用的高对比度圆点指示器覆盖层。

测试：
- 添加针对 Product Hunt 图库 URL 转换、空条目过滤、条目数量限制，以及无图库条目或非 Product Hunt 来源条目处理的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support multi-image Product Hunt galleries in feed items and present them as a swipeable carousel with an inline indicator.

New Features:
- Expose a list of Product Hunt gallery image URLs per feed item instead of a single hero image, capped to a maximum number of images.
- Render Product Hunt gallery images in the feed as a horizontal pager carousel with per-item page indicators while preserving single-image presentation.

Enhancements:
- Unify gallery aspect ratio based on the first image and add a dedicated, high-contrast dot indicator overlay for multi-image items.

Tests:
- Add unit tests around Product Hunt gallery URL transformation, blank-entry filtering, item limit enforcement, and handling of items without galleries or from non-Product Hunt sources.

</details>
