### PR TITLE
style(chat): 输入框上方合并为单行「当前配置」，控件换用 M3 Expressive

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatContextRow.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatContextRow.kt
@@ -1,0 +1,96 @@
+package whl.trending.chat.ui
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Science
+import androidx.compose.material.icons.outlined.TravelExplore
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleButtonDefaults
+import androidx.compose.material3.TonalToggleButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import whl.trending.ai.data.model.ChatModelsResponse
+import whl.trending.chat.R
+import whl.trending.chat.model.ChatMode
+
+/**
+ * 输入胶囊正上方的单行「当前配置」区，回答一个问题：**下一条消息会以什么配置发出去**。
+ *
+ * 参照 EchoFlow 的 `ContextChipRow`（`ChatComposer.kt`）：模型与已开启的能力本就是同一类信息，
+ * 排成一行而不是各占一行——改版前它俩各占一行、右侧全是留白，最坏情况能把输入框顶高约 150dp。
+ *
+ * 行内一律用 M3 Expressive 的按钮而不是 chip。原因是圆角：chip 的规范是 32dp 高 + `CornerSmall`
+ * （8dp），下面的输入胶囊是 72dp 高 + 36dp 全圆，两者放一起像方贴纸贴在圆胶囊上。Expressive 的
+ * 按钮默认就是 40dp 高 + `CornerFull`，与胶囊同源。（ChatGPT / Gemini / 千问 / 豆包的同位置
+ * 控件也都是全圆胶囊，没有用小圆角 chip 的。）
+ *
+ * deep research 模式下不显示模型：模型由服务端钉死，摆着选择器会让人以为选了能生效。
+ * 改版前的做法是把整个选择器隐藏，代价是开关 research 时输入框会上下跳位；现在这一行
+ * 有能力按钮撑着，位置不变。
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun ChatContextRow(
+    catalog: ChatModelsResponse,
+    mode: ChatMode,
+    onToggleSearch: () -> Unit,
+    onToggleResearch: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val showModel = mode != ChatMode.DeepResearch && chatModelPickerVisible(catalog)
+    val showCapability = mode != ChatMode.Normal
+    // 两者都无内容时整行缺席：留一个空 Row 会在胶囊上方多出一段说不清来由的留白
+    if (!showModel && !showCapability) return
+
+    Row(
+        // 能力将来变多时横向滚动而不是换行：换行会让输入框在开关能力时上下跳
+        modifier = modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (showModel) ModelPicker(catalog = catalog)
+        if (showCapability) {
+            val isResearch = mode == ChatMode.DeepResearch
+            // 已开启的能力。用 TonalToggleButton 而不是带 × 的 InputChip：Expressive 的表达方式是
+            // 让形状承担状态——选中态是 squircle（CornerMedium），按下时收成 6dp 圆角，撤销那一下
+            // 有形变反馈。它只在能力已开启时出现，所以 checked 恒为 true，点击即回到关闭。
+            TonalToggleButton(
+                checked = true,
+                onCheckedChange = { if (isResearch) onToggleResearch() else onToggleSearch() },
+                // checked 态默认是 secondary 深色实心，摆在这里会变成全屏最重的一块。压到
+                // secondaryContainer 后，它成了这一行**唯一带色相**的元素——这是有意的：能力是
+                // 临时开启、需要被看见的状态，而模型是常驻信息，退在中性梯度里（见 ModelPicker）。
+                colors = ToggleButtonDefaults.tonalToggleButtonColors(
+                    checkedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    checkedContentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                ),
+            ) {
+                Icon(
+                    imageVector = if (isResearch) Icons.Outlined.Science else Icons.Outlined.TravelExplore,
+                    contentDescription = null,
+                    modifier = Modifier.size(ButtonDefaults.IconSize),
+                )
+                Spacer(Modifier.width(ButtonDefaults.IconSpacing))
+                Text(
+                    stringResource(
+                        if (isResearch) R.string.chat_deep_research else R.string.chat_web_search,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -1,6 +1,8 @@
 package whl.trending.chat.ui
 
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,16 +11,16 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
@@ -190,22 +192,21 @@ fun ChatScreen(
                 )
             },
             bottomBar = {
+                val mode by viewModel.chatMode.collectAsState()
+                val catalog by viewModel.catalog.collectAsState()
                 Column {
-                    // 「一键详细解读」chip：GitHub 条目 + README 达标 + 尚无成功解读 → 常驻显示
+                    // ① 建议动作行：点一下立刻发出一条消息，一次性、发完即走。全部用描边样式，
+                    //    与下面填充的「当前配置」行分层——描边 = 建议，填充 = 已生效的状态。
+                    //    两个按钮可能同时出现（GitHub 条目 + 尚无对话），排一行而不是各占一行。
+                    //    用 OutlinedButton 而不是 AssistChip：Expressive 的按钮默认 40dp 高 + 全圆，
+                    //    与输入胶囊同一套圆角语言；chip 的 8dp 小圆角搁在 36dp 的胶囊上方不搭。
+                    //
+                    // 「一键详细解读」：GitHub 条目 + README 达标 + 尚无成功解读 → 常驻显示
                     // （不同于介绍 chip 的「messages 为空才显示」）；生成中置灰，成功一次后隐藏。
-                    if (DetailSummaryPolicy.chipVisible(initialContext, state.messages)) {
-                        val detailPrompt = stringResource(R.string.chat_action_detail_summary)
-                        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp)) {
-                            AssistChip(
-                                onClick = { viewModel.sendDetailSummary(detailPrompt) },
-                                enabled = !state.isSending,
-                                label = { Text(detailPrompt) },
-                            )
-                        }
-                    }
-                    // 尚无对话时在输入框上方显示入口对应的快捷问（label 资源 to prompt 资源）：
-                    // 通用助手入口问能力，README 入口问项目介绍。messages 非空即隐藏，
-                    // 天然覆盖"发送后隐藏"与"恢复历史会话不再显示"。
+                    val detailVisible = DetailSummaryPolicy.chipVisible(initialContext, state.messages)
+                    // 尚无对话时显示入口对应的快捷问（label 资源 to prompt 资源）：通用助手入口问能力，
+                    // README 入口问项目介绍。messages 非空即隐藏，天然覆盖「发送后隐藏」与
+                    // 「恢复历史会话不再显示」。
                     val quickAction = when {
                         initialContext == null ->
                             R.string.chat_action_what_can_you_do to R.string.chat_action_what_can_you_do_prompt
@@ -213,48 +214,43 @@ fun ChatScreen(
                             R.string.chat_action_what_is_this to R.string.chat_action_what_is_this_prompt
                         else -> null
                     }
-                    if (quickAction != null && state.messages.isEmpty()) {
-                        val prompt = stringResource(quickAction.second)
-                        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp)) {
-                            AssistChip(
-                                onClick = { viewModel.sendText(prompt) },
-                                enabled = !state.isSending,
-                                label = { Text(stringResource(quickAction.first)) },
-                            )
+                    val quickVisible = quickAction != null && state.messages.isEmpty()
+                    if (detailVisible || quickVisible) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth()
+                                // 下方留 8dp：与「当前配置」行拉开一档，两组 chip 才读得出是两类东西
+                                .padding(start = 12.dp, end = 12.dp, bottom = 8.dp)
+                                .horizontalScroll(rememberScrollState()),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            if (detailVisible) {
+                                val detailPrompt = stringResource(R.string.chat_action_detail_summary)
+                                OutlinedButton(
+                                    onClick = { viewModel.sendDetailSummary(detailPrompt) },
+                                    enabled = !state.isSending,
+                                ) {
+                                    Text(detailPrompt)
+                                }
+                            }
+                            if (quickAction != null && quickVisible) {
+                                val prompt = stringResource(quickAction.second)
+                                OutlinedButton(
+                                    onClick = { viewModel.sendText(prompt) },
+                                    enabled = !state.isSending,
+                                ) {
+                                    Text(stringResource(quickAction.first))
+                                }
+                            }
                         }
                     }
-                    // 能力 chip 回显区：开启的模式可见可撤（EchoFlow「菜单开启 + chip 回显」范式）
-                    val mode by viewModel.chatMode.collectAsState()
-                    if (mode != whl.trending.chat.model.ChatMode.Normal) {
-                        val isResearch = mode == whl.trending.chat.model.ChatMode.DeepResearch
-                        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 2.dp)) {
-                            androidx.compose.material3.InputChip(
-                                selected = true,
-                                onClick = {
-                                    if (isResearch) viewModel.toggleDeepResearch() else viewModel.toggleWebSearch()
-                                },
-                                label = {
-                                    Text(stringResource(if (isResearch) R.string.chat_deep_research else R.string.chat_web_search))
-                                },
-                                trailingIcon = {
-                                    Icon(
-                                        Icons.Filled.Close,
-                                        contentDescription = stringResource(R.string.chat_dialog_cancel),
-                                        modifier = Modifier.padding(0.dp),
-                                    )
-                                },
-                            )
-                        }
-                    }
-                    // 常驻模型选择器（≤1 个模型时自动隐藏）。research 模式下整个隐藏：
-                    // 模型由服务端钉死，选择器留着会误导用户以为选的模型生效
-                    if (mode != whl.trending.chat.model.ChatMode.DeepResearch) {
-                        val catalog by viewModel.catalog.collectAsState()
-                        ModelPicker(
-                            catalog = catalog,
-                            modifier = Modifier.padding(horizontal = 12.dp),
-                        )
-                    }
+                    // ② 当前配置行：模型 + 已开启的能力，回答「下一条消息以什么配置发出去」
+                    ChatContextRow(
+                        catalog = catalog,
+                        mode = mode,
+                        onToggleSearch = viewModel::toggleWebSearch,
+                        onToggleResearch = viewModel::toggleDeepResearch,
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                    )
                     ChatInputBar(
                         input = state.input,
                         // research 仅支持文本：只有图片没文字时发送会被 VM 忽略，按钮同步禁用（不静默）

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -1,16 +1,19 @@
 package whl.trending.chat.ui
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.AssistChip
-import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SplitButtonDefaults
+import androidx.compose.material3.SplitButtonLayout
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -21,6 +24,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import whl.trending.ai.data.local.globalSettingsManager
@@ -30,7 +34,18 @@ import whl.trending.ai.data.model.ChatModelsResponse
 import whl.trending.ai.data.model.catalogDefaultChatModel
 import whl.trending.ai.data.model.resolveDisplayedChatModel
 import whl.trending.ai.data.model.resolveEffectiveChatModel
+import whl.trending.ai.ui.common.TrendingDropdownMenu
 import whl.trending.chat.R
+
+/**
+ * [ModelPicker] 是否有东西可渲染。
+ *
+ * 抽出来是给 [ChatContextRow] 用的：那一行要在「模型和能力 chip 都没有」时整行缺席，
+ * 而选择器是否出现只有这里知道——组件内部 return 掉的话，外面看到的是一个高度为 0 却
+ * 仍占着 Arrangement 间距的成员。
+ */
+internal fun chatModelPickerVisible(catalog: ChatModelsResponse): Boolean =
+    catalog.models.size > 1 && catalogDefaultChatModel(catalog) != null
 
 /**
  * 常驻模型选择器（对所有用户透出）。未手选时显示目录里的免费默认项；Pro 专属项对免费用户锁定，
@@ -41,6 +56,7 @@ import whl.trending.chat.R
  *
  * 只有一个可选模型时不渲染（无从选择，锁定项也无从触达）。
  */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun ModelPicker(
     catalog: ChatModelsResponse,
@@ -86,14 +102,50 @@ internal fun ModelPicker(
     val current = resolveDisplayedChatModel(catalog, selectedId, isPro) ?: catalogDefault
 
     Box(modifier) {
-        AssistChip(
-            onClick = { expanded = true },
-            label = { Text(current.name) },
-            trailingIcon = {
-                Icon(Icons.Filled.ArrowDropDown, contentDescription = null, modifier = Modifier.size(18.dp))
+        // M3 Expressive 的 SplitButton 而不是 chip：模型名与下拉箭头分成两块，「这是个选择器」
+        // 由形态本身讲清楚，不用靠「能不能点掉」去猜（chip 的老问题）。它天生 40dp 高 + 全圆，
+        // 与下面的输入胶囊同一套圆角语言。
+        //
+        // 配色刻意选中性的 surfaceContainerHigh，而不是 tonal 默认的 secondaryContainer：
+        // 模型是常驻的纯信息，带色相就会跟旁边「已开启的能力」抢注意力。也不能用再深一档的
+        // surfaceContainerHighest——那正是禁用态发送键的容器色（实测浅色下同为 #E7E0EC），
+        // 空输入时同屏会出现两块一样的颜色，一块可点一块禁用。选 High 后浅色梯度是
+        // 背景 #FDF7FE → 胶囊 #F3EDF4（High + 3dp tonal 提亮）→ 模型 #ECE6F0 → 禁用发送键 #E7E0EC。
+        val modelColors = ButtonDefaults.filledTonalButtonColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+        )
+        SplitButtonLayout(
+            leadingButton = {
+                SplitButtonDefaults.LeadingButton(
+                    onClick = { expanded = true },
+                    colors = modelColors,
+                ) {
+                    Text(current.name)
+                }
+            },
+            trailingButton = {
+                SplitButtonDefaults.TrailingButton(
+                    checked = expanded,
+                    onCheckedChange = { expanded = it },
+                    colors = modelColors,
+                ) {
+                    // 展开时箭头转 180°：M3 官方 SplitButton 示例的做法，组件本身不管这个
+                    val rotation by animateFloatAsState(
+                        targetValue = if (expanded) 180f else 0f,
+                        label = "model-picker-arrow",
+                    )
+                    Icon(
+                        imageVector = Icons.Filled.KeyboardArrowDown,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(SplitButtonDefaults.TrailingIconSize)
+                            .graphicsLayer { rotationZ = rotation },
+                    )
+                }
             },
         )
-        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        TrendingDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             models.forEach { model ->
                 val locked = model.proOnly && !isPro
                 DropdownMenuItem(


### PR DESCRIPTION
## 背景

上一个 commit（`a310d0f`，已在 main）把聊天输入框改成了悬浮胶囊。改完发现胶囊**上方**那几行没跟上：

- 最多堆四行（详细解读 / 快捷问 / 能力回显 / 模型选择器），每行只有一个 chip 左对齐、右侧全是留白，最坏情况把输入框顶高约 150dp
- 三类语义（一次性建议 / 已生效的状态 / 设置入口）长得一模一样，都是 `AssistChip`
- chip 规范是 32dp 高 + `CornerSmall`(8dp)，输入胶囊是 72dp 高 + 36dp 全圆 —— 差 4.5 倍，chip 像方贴纸贴在圆胶囊上

## 改动

**结构**：四行收成两行

| 行 | 内容 | 样式 |
|---|---|---|
| 建议动作 | 一键详细解读 / 快捷问 | 描边 |
| 当前配置 | 模型 + 已开启的能力 | 填充 |

规则是「描边 = 建议，填充 = 已生效的状态」。新增 `ChatContextRow.kt` 承载配置行；从 `ModelPicker` 抽出 `chatModelPickerVisible()`，否则外面无从判断选择器是不是自己 return 掉了，会在行里留下一个高度为 0 却仍吃 `Arrangement` 间距的成员。

**控件**：chip → M3 Expressive 按钮（默认 40dp 高 + `CornerFull`，与胶囊同源）

- 建议动作 → `OutlinedButton`
- 模型 → `SplitButtonLayout`（模型名 + 独立下拉块，展开时箭头转 180°）
- 能力开关 → `TonalToggleButton`（选中态 squircle，按下收成 6dp，**形状承担状态**，不再需要 × 图标）

**配色**：整行只留一处色相，且落在真正需要注意的元素上

```
背景 #FDF7FE → 胶囊 #F3EDF4 → 模型 #ECE6F0 → 禁用发送键 #E7E0EC
能力 #E8DEF8（唯一带色相）
```

模型刻意没用更深的 `surfaceContainerHighest` —— 那正是禁用态发送键的容器色，空输入时同屏会出现两块同色、一块可点一块禁用。

**顺带**：`ModelPicker` 的裸 `DropdownMenu` 换成规范要求的 `TrendingDropdownMenu`（仓库里最后一处漏网）。

## 附带修掉的问题

deep research 模式下仍不显示模型（服务端钉死，摆着会误导），但这一行现在由能力按钮撑着 —— 改版前是整行消失，开关 research 时输入框会上下跳位。

## 验证

Pixel_9_2 实测：通用入口默认态、模型下拉展开、开启联网搜索、切深度调研、GitHub 条目入口（两个建议按钮并排）、深色态。浅色深色都逐元素采样确认无相邻撞色。`:androidLibrary:chat:testDebugUnitTest` 通过。

## 已知取舍

- `TonalToggleButton` 最漂亮的是 stadium ⇄ squircle 的形变动画，但能力按钮**只在开启后出现**，`checked` 恒为 true，形变过程看不到。要吃满得把能力按钮常驻显示（关闭 stadium / 开启 squircle），那是行为改动，会与「+」菜单里的两项重复，本 PR 未做。
- 去掉 × 后「怎么关」靠再点一下发现，比显式 × 弱一档。
- `ToggleButton` / `SplitButtonLayout` 都是 `@ExperimentalMaterial3ExpressiveApi`，跟的是 `material3 1.10.0-alpha05`，签名可能变 —— 与已在用的 `LoadingIndicator`、`MaterialShapes` 同级风险。

## 未处理（既有问题，非本 PR 引入）

键盘弹起时点模型下拉，`DropdownMenu` 被键盘挤到只剩一行半，得滚动才看得全。按仓库规范（>4 项或需滚动用 sheet）应改为 `TrendingBottomSheet`，另开一轮。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Huuw6TMf825Po2DBRfwcF4

## Summary by Sourcery

将聊天输入区域的头部统一为一行富有表达性的“当前配置”区，融合模型选择和已启用的能力，并重新设计建议操作，使其符合新的 M3 富表达胶囊样式。

New Features:
- 引入 `ChatContextRow` 组件，在输入栏上方展示当前选择的聊天模型和已启用的能力。
- 添加一个基于 `SplitButton` 的富表达模型选择器，在视觉上将模型标签与下拉触发器分离。

Bug Fixes:
- 在切换深度研究模式时，通过保持上下文行存在并由能力按钮驱动，而不是隐藏整个模型选择器，来防止布局跳动。

Enhancements:
- 将基于“chip”的建议操作替换为可水平滚动的描边按钮，使其与富表达输入胶囊样式保持一致。
- 确保模型选择行只在存在有意义的选择时才渲染，在没有模型或能力时避免产生空白布局间隙。
- 在保持布局稳定性的同时，通过新的上下文行避免深度研究模式显示模型选择器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify the chat input header into a single expressive “current configuration” row combining model selection and active capabilities, and restyle suggestion actions to match the new M3 expressive capsule design.

New Features:
- Introduce a ChatContextRow component that displays the currently selected chat model and active capabilities above the input bar.
- Add an expressive SplitButton-based model picker that visually separates the model label from the dropdown trigger.

Bug Fixes:
- Prevent layout jumping when toggling deep research mode by keeping the context row present and driven by capability buttons rather than hiding the entire model selector.

Enhancements:
- Replace chip-based suggestion actions with horizontally scrollable outlined buttons aligned with the expressive input capsule styling.
- Ensure the model picker row only renders when there is a meaningful choice, avoiding empty layout gaps when no model or capability is present.
- Keep deep research mode from showing the model selector while maintaining layout stability via the new context row.

</details>