### PR TITLE
feat(home): 沉浸式浏览第 2 步——底栏跟随滚动隐藏（设置项开关，默认关）

### DIFF
--- a/docs/analytics-notes.md
+++ b/docs/analytics-notes.md
@@ -173,6 +173,13 @@ Logto SDK 会**本地缓存 OIDC discovery 配置**。这导致断网登录的�
 | `home_open_settings` | `entry=more` 停产，只剩 `entry=topbar`（顶栏齿轮成为首页唯一设置入口）。看总量不受影响，按 entry 分组时 more 的归零是入口删除，不是行为变化 |
 | `home_open_about` | 整体停产（底栏的关于入口删除）。关于页唯一入口回到设置页内，`settings_about`（`SettingsScreen.kt`）自此**重新覆盖全部进入**——0.23.0 节里「只覆盖部分进入」的告警对 ≥1.1.0 不再成立 |
 
+## 沉浸式浏览：新增 `settings_immersive_toggle`（2026-08-10 实现，尚未发版）
+
+设置 › 个性化「沉浸式浏览」开关的切换事件，属性 `enabled`（"true"/"false"）。默认关，
+事件量 = 主动改动开关的人数上界。滚动中的收起/恢复**不打点**（高频无价值）；「开了的人
+是否在用」暂无直接口径，若需要再评估补一条低频首触发事件。#86 时代拟用的
+`settings_hide_bottom_bar_on_scroll` 从未发出，看板上不会有该名字。
+
 ## 首页重构：`tab_double_tap_refresh` 停产（2026-08-10 实现，尚未发版）
 
 双击底栏 tab 触发刷新的功能（#38）随首页重构整体移除（产品决策，各页自带下拉刷新已覆盖），`tab_double_tap_refresh` 事件随之**整体停产**。看板上该事件归零是功能下线，不是采集回归。

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -50,6 +50,8 @@
     <string name="new_only_hint">24 小时内首次登上 GitHub 日榜（全语言）的新项目</string>
     <string name="default_home_tab">默认首页</string>
     <string name="default_home_tab_desc">启动时进入的标签页</string>
+    <string name="immersive_browsing">沉浸式浏览</string>
+    <string name="immersive_browsing_desc">向下滑动收起底栏、向上滑动恢复 · 让内容多占一点屏幕</string>
     <string name="daily_picks_notification">每日精选提醒</string>
     <string name="daily_picks_notification_desc">每日精选更新后本地通知提醒，无需推送服务</string>
     <string name="notification_permission_denied">未获得通知权限，请在系统设置中允许通知</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -50,6 +50,8 @@
     <string name="new_only_hint">First appeared on the GitHub daily (all languages) list within 24 hours</string>
     <string name="default_home_tab">Default home tab</string>
     <string name="default_home_tab_desc">Which tab the app opens to at launch</string>
+    <string name="immersive_browsing">Immersive browsing</string>
+    <string name="immersive_browsing_desc">Scroll down to tuck the bottom bar away, scroll up to bring it back</string>
     <string name="daily_picks_notification">Daily Picks reminder</string>
     <string name="daily_picks_notification_desc">A local notification when the day&#8217;s AI picks are ready — no push service required</string>
     <string name="notification_permission_denied">Notification permission is off. Allow it in system settings to get reminders.</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -159,6 +159,7 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val PICKS_NEWSLETTER_BANNER_DISMISSED_KEY = "prefs_picks_newsletter_banner_dismissed"
     private val DEFAULT_HOME_TAB_KEY = "prefs_default_home_tab"
     private val TRENDING_SOURCE_KEY = "prefs_trending_source"
+    private val IMMERSIVE_BROWSING_KEY = "prefs_immersive_browsing"
 
     /**
      * 安装级匿名标识：首次访问时生成并持久化，之后保持不变（卸载重装才会重新生成）。
@@ -588,6 +589,20 @@ class SettingsManager(private val settings: ObservableSettings) {
 
     fun setOpenLinksInCustomTab(value: Boolean) {
         settings.putBoolean(OPEN_LINKS_IN_CUSTOM_TAB_KEY, value)
+    }
+
+    /**
+     * 沉浸式浏览：首页各栏跟随滚动收起/恢复（当前阶段为底栏，顶栏与子 tab 行随 #88
+     * 第 3 步接入）。默认 false——常驻的顶/底栏是导航锚点，藏起来换到的屏幕空间不值得
+     * 让所有人默认承担「想操作得先往回滑」的代价，留给需要的人自己打开。
+     * 关闭时首页不接入任何滚动监听（见 ui/home/HomeImmersive.kt 的 null 模式）。
+     */
+    val immersiveBrowsing: Flow<Boolean> = settings.getBooleanFlow(IMMERSIVE_BROWSING_KEY, false)
+
+    fun currentImmersiveBrowsing(): Boolean = settings.getBoolean(IMMERSIVE_BROWSING_KEY, false)
+
+    fun setImmersiveBrowsing(value: Boolean) {
+        settings.putBoolean(IMMERSIVE_BROWSING_KEY, value)
     }
 
     /**

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeImmersive.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeImmersive.kt
@@ -1,0 +1,135 @@
+package whl.trending.ai.ui.home
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.spring
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FloatingToolbarDefaults
+import androidx.compose.material3.FloatingToolbarExitDirection
+import androidx.compose.material3.FloatingToolbarState
+import androidx.compose.material3.rememberFloatingToolbarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+
+/**
+ * 沉浸式浏览（#88）的统一隐藏状态：一条 [NestedScrollConnection] 产出隐藏进度
+ * [ImmersiveState.progress]，各栏按**自己的行程**消费——同一进度 × 不同行程，速率差
+ * 即视差。本阶段只接了底栏（issue 实施切分第 2 步）；顶栏与子 tab 行随第 3 步接入。
+ *
+ * 由设置项开关（`SettingsManager.immersiveBrowsing`，默认关）决定要不要接入。
+ * 关闭时调用方传 null：[immersiveNestedScroll] 与 [immersiveExit] 原样返回 receiver，
+ * 首页的 modifier 链与接入前逐字节相同——没有 nestedScroll 分发、没有额外渲染层；
+ * [rememberImmersiveState] 也不会被调用，state / behavior / effect 一概不进组合树。
+ *
+ * ## 为什么不直接把 behavior 交给 `HorizontalFloatingToolbar`
+ *
+ * M3 的 [FloatingToolbarDefaults.exitAlwaysScrollBehavior] 自带的位移
+ * （`floatingScrollBehavior()`）把 `offsetLimit` 取成「胶囊到**其父布局**底边的距离」。
+ * 官方 sample 里胶囊直接挂在铺满屏幕的 Box 上，那个距离恰好等于「滑出屏幕」；而我们的
+ * 胶囊外面还包着一层固定高度的 `BoxWithConstraints`（[HomeFloatingBar] 照搬 Echo 的
+ * 结构），外边距与导航栏 inset 都在这层之外，behavior 量不到——#86 实测直接接上只滑
+ * 下去胶囊自身高度，顶部还露出约一半。而且它只能驱动工具栏自己，管不到顶栏和子 tab 行。
+ *
+ * 所以这里只复用它的**曲线**（跟手 1:1、抛掷衰减、松手吸附到全显示/全隐藏），
+ * 手势行程与各栏位移自己算、自己施加。
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+class ImmersiveState internal constructor(
+    internal val toolbarState: FloatingToolbarState,
+    internal val connection: NestedScrollConnection,
+) {
+    /**
+     * 隐藏进度：0 = 全显示，1 = 全隐藏。
+     * **只应在 draw 阶段（graphicsLayer lambda）读取**——读进 composition 会把滚动
+     * 变成逐帧重组，这是本机制的性能红线（perf 基线复测时的头号盯防项）。
+     */
+    internal val progress: Float
+        get() {
+            val limit = toolbarState.offsetLimit
+            // offsetLimit 初始为 -Float.MAX_VALUE（SideEffect 首帧后才写入真值），
+            // 此时 offset/limit ≈ 0，天然落在「全显示」，无首帧跳变；仅防 0 除。
+            return if (limit == 0f) 0f else (toolbarState.offset / limit).coerceIn(0f, 1f)
+        }
+
+    /** 动画收回显示态。切 tab / 切子源这类「换了一屏内容」的时机调用。 */
+    internal suspend fun reveal() {
+        if (toolbarState.offset != 0f) {
+            animate(
+                initialValue = toolbarState.offset,
+                targetValue = 0f,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = Spring.StiffnessMediumLow,
+                ),
+            ) { value, _ -> toolbarState.offset = value }
+        }
+    }
+}
+
+/** 沉浸时该栏从哪条屏幕边缘退场，决定位移方向。 */
+enum class ImmersiveEdge { Top, Bottom }
+
+/**
+ * 挂在包住各 tab 内容的容器上，让列表的滚动事件冒上来驱动隐藏进度。
+ * [state] 为 null（开关关闭）时原样返回，不产生任何 modifier 节点。
+ */
+fun Modifier.immersiveNestedScroll(state: ImmersiveState?): Modifier =
+    if (state == null) this else nestedScroll(state.connection)
+
+/**
+ * 挂在要退场的栏上施加位移：[travel] 是该栏从常驻位到完全出屏的距离，[edge] 决定方向。
+ * 读 progress 落在 draw 阶段，滚动全程不触发重组。[state] 为 null（开关关闭）时原样返回。
+ */
+fun Modifier.immersiveExit(state: ImmersiveState?, edge: ImmersiveEdge, travel: Dp): Modifier =
+    if (state == null) this
+    else graphicsLayer {
+        val ty = state.progress * travel.toPx()
+        translationY = if (edge == ImmersiveEdge.Top) -ty else ty
+    }
+
+/**
+ * 建立沉浸式所需的状态。**只在开关打开时调用**——关闭时整个组合分支都不存在。
+ *
+ * @param gestureTravel 手势行程：滚动累计这么多距离后进度走满。取**所有栏中最长的行程**
+ *   （Home 的子 tab 行：状态栏 + 顶栏 + tab 行），让最长行程那个元素 1:1 跟手，
+ *   其余栏按行程比例减速——这正是第 3 步视差的来源。
+ * @param revealKeys 这些值一变就收回显示态（切 tab、切子源）：不把上一屏滑到一半的
+ *   隐藏量带过去，也免得新一屏内容不足一屏时各栏没机会自己回来。
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun rememberImmersiveState(
+    gestureTravel: Dp,
+    vararg revealKeys: Any?,
+): ImmersiveState {
+    val toolbarState = rememberFloatingToolbarState()
+    val behavior = FloatingToolbarDefaults.exitAlwaysScrollBehavior(
+        exitDirection = FloatingToolbarExitDirection.Bottom,
+        state = toolbarState,
+    )
+    val gestureTravelPx = with(LocalDensity.current) { gestureTravel.toPx() }
+
+    SideEffect {
+        toolbarState.offsetLimit = -gestureTravelPx
+        // offset 只在写入时 coerce：行程变了（转屏、手势导航切三键导航改的是 inset）
+        // 得把已有位移夹回新区间，否则会一直停在按旧区间算出来的那个值上（#86 的 6be03ad）
+        toolbarState.offset = toolbarState.offset.coerceAtLeast(-gestureTravelPx)
+    }
+
+    val state = remember(toolbarState, behavior) {
+        ImmersiveState(toolbarState, behavior)
+    }
+
+    @Suppress("SpreadOperator")
+    LaunchedEffect(state, *revealKeys) { state.reveal() }
+
+    return state
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -49,6 +50,7 @@ import trendingai.shared.generated.resources.me_title
 import trendingai.shared.generated.resources.producthunt_title
 import whl.trending.ai.chat.globalChatScreen
 import whl.trending.ai.core.platform.trackEvent
+import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.ChatModelsProvider
 import whl.trending.ai.ui.common.LocalContentBottomPadding
 import whl.trending.ai.ui.common.LocalContentTopPadding
@@ -95,6 +97,11 @@ fun HomeScreen(
     val selectedTab by homeViewModel.selectedTab.collectAsState()
     val selectedSource by homeViewModel.selectedSource.collectAsState()
 
+    // 沉浸式浏览开关（设置 › 个性化，默认关）。初值同步读，避免已开启用户冷启动闪一帧关闭态
+    val immersiveEnabled by globalSettingsManager.immersiveBrowsing.collectAsState(
+        remember { globalSettingsManager.currentImmersiveBrowsing() }
+    )
+
     // 系统返回键/手势在非 Home tab 上先降级回 Home，再退才交给路由出栈（Material 底栏规范）。
     // 与 NavDisplay 共用同一 NavigationEventDispatcher；本 handler 只在 Home entry 位于栈顶时
     // 在组合树里，二级页在顶时不会误拦。
@@ -134,6 +141,16 @@ fun HomeScreen(
         // 它是内容 contentPadding 的输入，实测 onSizeChanged 回写会引入首帧跳动。
         val topBarBottom = statusBarTop + TopBarHeight
 
+        // 沉浸式状态：开关关闭时为 null，下游 modifier 全部原样返回（零开销，见 HomeImmersive）。
+        // 手势行程取所有栏中最长的行程（Home 的子 tab 行底缘），它将 1:1 跟手、其余栏按行程
+        // 比例减速——第 3 步的视差即由此来；本阶段只接了底栏这一个消费点。
+        val immersiveState = if (immersiveEnabled) {
+            rememberImmersiveState(
+                topBarBottom + SourceTabRowHeight,
+                selectedTab, selectedSource,
+            )
+        } else null
+
         val barItems = homeTabSpecs.map { spec ->
             HomeBarItem(
                 key = spec.tab,
@@ -145,7 +162,7 @@ fun HomeScreen(
             )
         }
 
-        Box(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize().immersiveNestedScroll(immersiveState)) {
             CompositionLocalProvider(LocalContentBottomPadding provides contentBottomPadding) {
                 // 切 tab 的方向性转场：新页从前进方向滑入 1/8 屏、旧页往反方向滑出，各配 200ms
                 // 淡入淡出。位移量、时长与方向判定照搬 Echo 的 NavHost enter/exitTransition；
@@ -305,6 +322,12 @@ fun HomeScreen(
                 // 高度加在调用处而非组件内部，与 Echo 在 MainActivity 的写法一致。
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
+                    // 沉浸位移：行程 = 胶囊高 + 外边距 + 导航栏 inset（胶囊顶边正好推到屏幕底沿）
+                    .immersiveExit(
+                        immersiveState,
+                        ImmersiveEdge.Bottom,
+                        travel = FloatingBarHeight + FloatingBarBottomMargin + barBottomInset,
+                    )
                     .padding(horizontal = 16.dp)
                     .padding(bottom = barBottomInset + FloatingBarBottomMargin)
                     .height(FloatingBarHeight),

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.OpenInBrowser
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.SwipeVertical
 import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
@@ -60,6 +61,8 @@ import trendingai.shared.generated.resources.chat_title
 import trendingai.shared.generated.resources.daily_picks_notification
 import trendingai.shared.generated.resources.default_home_tab
 import trendingai.shared.generated.resources.default_home_tab_desc
+import trendingai.shared.generated.resources.immersive_browsing
+import trendingai.shared.generated.resources.immersive_browsing_desc
 import trendingai.shared.generated.resources.feedback
 import trendingai.shared.generated.resources.feedback_email_invalid
 import trendingai.shared.generated.resources.feedback_email_placeholder
@@ -136,6 +139,7 @@ fun SettingsScreen(
     val appLanguage by globalSettingsManager.appLanguage.collectAsState(AppLanguage.FOLLOW_SYSTEM)
     val summaryLanguage by globalSettingsManager.summaryLanguage.collectAsState(SummaryLanguage.FOLLOW_SYSTEM)
     val openLinksInCustomTab by globalSettingsManager.openLinksInCustomTab.collectAsState(true)
+    val immersiveBrowsing by globalSettingsManager.immersiveBrowsing.collectAsState(false)
     val defaultHomeTab by globalSettingsManager.defaultHomeTab.collectAsState(
         remember { globalSettingsManager.currentDefaultHomeTab() }
     )
@@ -329,6 +333,26 @@ fun SettingsScreen(
                             }
                         },
                         onClick = { homeTabMenuExpanded = true },
+                    )
+                    // 沉浸式浏览：默认关。行点击与开关同为切换（与「外链打开方式」一致）
+                    settingsItem(
+                        icon = Icons.Default.SwipeVertical,
+                        title = { Text(stringResource(Res.string.immersive_browsing)) },
+                        description = { Text(stringResource(Res.string.immersive_browsing_desc)) },
+                        trailing = {
+                            Switch(
+                                checked = immersiveBrowsing,
+                                onCheckedChange = { enabled ->
+                                    trackEvent("settings_immersive_toggle", mapOf("enabled" to enabled.toString()))
+                                    globalSettingsManager.setImmersiveBrowsing(enabled)
+                                },
+                            )
+                        },
+                        onClick = {
+                            val enabled = !immersiveBrowsing
+                            trackEvent("settings_immersive_toggle", mapOf("enabled" to enabled.toString()))
+                            globalSettingsManager.setImmersiveBrowsing(enabled)
+                        },
                     )
                 }
             }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/local/SettingsManagerTest.kt
@@ -159,4 +159,17 @@ class SettingsManagerTest {
         val rebuilt = SettingsManager(settings)
         assertEquals("HackerNews", rebuilt.currentTrendingSource())
     }
+
+    @Test
+    fun immersiveBrowsing_defaults_off_and_persists() = runTest {
+        // 默认关：常驻顶/底栏是导航锚点，沉浸式留给需要的人自己打开
+        assertEquals(false, manager.currentImmersiveBrowsing())
+
+        manager.setImmersiveBrowsing(true)
+        assertEquals(true, manager.currentImmersiveBrowsing())
+
+        // 模拟应用重启：开关状态要能带回来
+        val rebuilt = SettingsManager(settings)
+        assertEquals(true, rebuilt.currentImmersiveBrowsing())
+    }
 }


### PR DESCRIPTION
## 背景

#88 实施切分第 2 步：把 #86（已关闭未合入，关闭原因是范围决策而非技术问题）的底栏隐藏移植到 #92/#93 之后的新骨架上。state 直接按最终形态设计——**统一隐藏进度 × 各栏行程表**——本阶段只接底栏一个消费点，第 3 步接顶栏 / 子 tab 行 / scrim 时纯增量、零返工。

## 实现

- **`HomeImmersive.kt`**：`ImmersiveState` 借 M3 `exitAlwaysScrollBehavior` 的曲线（跟手 1:1、抛掷衰减、松手吸附到全显/全隐，不自写手势物理），手势行程与各栏位移自己算；含 #86 审查中修的 offset 夹取（行程变化时夹回新区间）。`progress` 只在 `graphicsLayer` lambda（draw 阶段）读取——**滚动全程零重组**，这是性能红线，代码注释已标。
- **手势行程 = 最长行程**（Home 子 tab 行底缘 ≈ 状态栏 + 112dp）：该元素将 1:1 跟手，其余栏按行程比例减速——同一进度不同行程，第 3 步的视差即由此来。本阶段底栏行程 = 胶囊高 + 外边距 + 导航栏 inset。
- **revealKeys = selectedTab / selectedSource**：切 tab、切子源、通知深链、back 降级四条换屏路径全部自动回显（#92 把状态收口进 HomeViewModel 的红利）。
- **开关**：设置 › 个性化「沉浸式浏览」，默认关；关闭时 state 为 null，`immersiveNestedScroll` / `immersiveExit` 原样返回 receiver——modifier 链与关闭前逐字节相同，无滚动监听、无渲染层（#86 验证过的零开销模式）。
- 埋点仅 `settings_immersive_toggle`（enabled 维度），滚动收放不打点；口径已记 `docs/analytics-notes.md`。

## 验证（Pixel_9_2）

- **关闭态**（默认）：与 main 同时间窗逐像素对比 **0 差异**（期间恰逢 PM 批次数据换代，重做同窗口对比后归零）。
- **开启态**：快速下滑底栏完全滑出屏；上滑跟回；录屏抽帧确认渐进位移（胶囊逐帧升回，非瞬现）。
- **回显**：藏起后切子源，底栏自动弹回。
- **恢复**：关闭开关后滚动，底栏恒定常驻。
- `:shared:testAndroidHostTest` 全绿（含新增 `immersiveBrowsing` 持久化用例）。

性能：本阶段滚动热路径与 #86 同构（draw 阶段读 offset）；完整三态基线复测（`docs/perf-home-scroll-baseline.md`）按计划在第 3 步完成后执行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjGAq1c3J1snPQhPnbz3Q7

## Summary by Sourcery

在主屏幕中引入可选的沉浸式浏览模式：在滚动时隐藏底部栏，同时在该模式关闭时保留默认行为。

New Features:
- 添加主屏幕沉浸式浏览模式，根据滚动驱动的进度将底部栏平移至屏幕外，并通过共享的 `ImmersiveState` 进行连接。
- 在「设置 › 个性化」中暴露一个“沉浸式浏览”开关，默认关闭，用于控制沉浸式行为是否生效。

Enhancements:
- 通过嵌套滚动修饰符将沉浸式滚动处理集成到主屏幕布局中，以便未来顶部栏和标签行的视差效果可以共享同一状态。

Documentation:
- 在分析说明中记录新的 `settings_immersive_toggle` 分析事件及其语义。

Tests:
- 添加一个 `SettingsManager` 测试，用于验证沉浸式浏览标志默认关闭且能在应用重启之间保持持久化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an optional immersive browsing mode on the home screen that hides the bottom bar on scroll while preserving default behavior when disabled.

New Features:
- Add a home-screen immersive browsing mode that translates the bottom bar off-screen based on scroll-driven progress, wired through a shared ImmersiveState.
- Expose an “Immersive browsing” toggle in Settings › Personalization, defaulting off and controlling whether the immersive behavior is active.

Enhancements:
- Integrate immersive scroll handling into the home screen layout via a nested scroll modifier so future top bar and tab row parallax can share the same state.

Documentation:
- Document the new `settings_immersive_toggle` analytics event and its semantics in the analytics notes.

Tests:
- Add a SettingsManager test to verify the immersive browsing flag defaults off and persists across app restarts.

</details>