### PR TITLE
feat(readme): 「一键解读」提到 FAB 主位，下掉另两个 chat 入口

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -90,11 +90,6 @@ class ChatViewModel(
     fun toggleWebSearch() = toggleMode(ChatMode.WebSearch)
     fun toggleDeepResearch() = toggleMode(ChatMode.DeepResearch)
 
-    /** README 详情页「深度调研」入口：定向开启（非 toggle——重进已开启的会话不能反把模式关掉） */
-    fun enableDeepResearch() {
-        _chatMode.value = ChatMode.DeepResearch
-    }
-
     private fun toggleMode(mode: ChatMode) {
         _chatMode.value = if (_chatMode.value == mode) ChatMode.Normal else mode
     }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -109,15 +109,10 @@ fun ChatScreen(
         }
     }
 
-    // README 详情页「深度调研」入口：只预选模式 + 预填主题，发送仍由用户确认——
-    // research 计价高（10 credits），不做自动触发（有别于解读入口的 auto 语义）
+    // 解读卡尾部「深度调研此项目」升级漏斗的调研主题（见下方 onResearchUpsell）。
+    // README 详情页曾有一个冷入口（进 chat 即预选 research 模式 + 预填主题），2026-08-12 下线——
+    // 11 天仅 2 次点击，且这里的热入口位置更靠后、转化语义更顺（读完解读才升级）
     val researchPrefill = stringResource(R.string.chat_research_repo_prefill)
-    LaunchedEffect(entryKey) {
-        if (initialContext?.autoDeepResearch == true) {
-            viewModel.enableDeepResearch()
-            if (viewModel.uiState.value.input.isBlank()) viewModel.updateInput(researchPrefill)
-        }
-    }
 
     // AI 一开始回复就收起键盘：把屏幕让给正文，用户不用先手动关键盘才能读回复。
     // clearFocus 同时清焦点（而非只 hide），避免留下「键盘没了但光标还在闪」的中间态。

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -123,9 +123,7 @@
     <string name="subscribe_error">网络错误，请稍后重试</string>
     <string name="view_on_github">在 GitHub 中查看</string>
     <string name="share_to_ai">分享</string>
-    <string name="readme_fab_chat">AI 对话</string>
     <string name="readme_fab_detail_summary">一键解读</string>
-    <string name="readme_fab_deep_research">深度调研</string>
     <string name="share_ai_text_full">请帮我解读这条技术资讯并提炼核心要点：\n\n标题：%1$s\n\n摘要：%2$s\n\n原文：%3$s</string>
     <string name="share_ai_text_brief">请帮我解读这条技术资讯并提炼核心要点：\n\n标题：%1$s\n\n原文：%2$s</string>
     <string name="readme_no_content">该仓库暂无 README 文件。</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -123,9 +123,7 @@
     <string name="subscribe_error">Network error, please try again</string>
     <string name="view_on_github">View on GitHub</string>
     <string name="share_to_ai">Share</string>
-    <string name="readme_fab_chat">AI Chat</string>
     <string name="readme_fab_detail_summary">In-depth read</string>
-    <string name="readme_fab_deep_research">Deep research</string>
     <string name="share_ai_text_full">Please help me read and summarize this tech update:\n\nTitle: %1$s\n\nSummary: %2$s\n\nSource: %3$s</string>
     <string name="share_ai_text_brief">Please help me read and summarize this tech update:\n\nTitle: %1$s\n\nSource: %2$s</string>
     <string name="readme_no_content">No README found for this repository.</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/chat/ChatIntegration.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/chat/ChatIntegration.kt
@@ -10,8 +10,6 @@ import androidx.compose.runtime.Composable
  * @param externalId 条目在数据源内的 ID（GitHub 为 `owner/repo`），detail-summary API 入参
  * @param readmeLength README 正文长度估计（ReadmeScreen 进 chat 时填充；未加载完为 null → chip 不显示）
  * @param autoDetailSummary 进入 chat 后是否自动触发「一键详细解读」（README 详情页「一键解读」入口置 true）
- * @param autoDeepResearch 进入 chat 后预选 Deep Research 模式并预填调研主题（README 详情页「深度调研」
- *   入口置 true）；只预选不自动发送——research 计价高，发送必须由用户确认
  */
 data class ChatContext(
     val title: String,
@@ -21,7 +19,6 @@ data class ChatContext(
     val externalId: String? = null,
     val readmeLength: Int? = null,
     val autoDetailSummary: Boolean = false,
-    val autoDeepResearch: Boolean = false,
 )
 
 /**

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
@@ -14,20 +14,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.automirrored.outlined.Shortcut
-import androidx.compose.material.icons.filled.AutoAwesome
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.AutoStories
 import androidx.compose.material.icons.outlined.StarBorder
-import androidx.compose.material.icons.outlined.TravelExplore
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.FloatingActionButtonMenu
-import androidx.compose.material3.FloatingActionButtonMenuItem
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
@@ -36,22 +31,15 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
-import androidx.compose.material3.ToggleFloatingActionButton
-import androidx.compose.material3.ToggleFloatingActionButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -61,8 +49,6 @@ import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.action_star
 import trendingai.shared.generated.resources.action_unstar
 import trendingai.shared.generated.resources.back
-import trendingai.shared.generated.resources.readme_fab_chat
-import trendingai.shared.generated.resources.readme_fab_deep_research
 import trendingai.shared.generated.resources.readme_fab_detail_summary
 import trendingai.shared.generated.resources.readme_no_content
 import trendingai.shared.generated.resources.retry
@@ -103,16 +89,15 @@ fun ReadmeScreen(
     val uriHandler = LocalUriHandler.current
     // README 摘录涉及多次正则替换，缓存结果避免每次重组重算（分享栏与 FAB 共用）
     val summary = remember(uiState.html) { readmeExcerpt(uiState.html) }
-    // README 正文长度估计（HTML 去标签）；未加载完为 null → 解读 chip / 「一键解读」子项不显示
+    // README 正文长度估计（HTML 去标签）；未加载完为 null → 解读 chip / 「一键解读」FAB 不显示
     val readmeLength = remember(uiState.html) {
         uiState.html
             .takeIf { it.isNotBlank() }
             ?.replace(Regex("<[^>]+>"), "")
             ?.length
     }
-    // 构造进入 chat 的上下文；autoDetailSummary=true 时进 chat 自动触发「一键详细解读」，
-    // autoDeepResearch=true 时预选 Deep Research 模式 + 预填主题（发送由用户确认）
-    fun buildChatContext(autoDetailSummary: Boolean = false, autoDeepResearch: Boolean = false) = ChatContext(
+    // 构造进入 chat 的上下文：本页只有「一键解读」一个 chat 入口，故 autoDetailSummary 恒为 true
+    fun buildDetailSummaryContext() = ChatContext(
         title = "$owner/$repo",
         // 带上 README 摘录作为依据，让 AI 能介绍冷门项目；未加载完为 null，退化为仅 title + url
         summary = summary,
@@ -121,8 +106,7 @@ fun ReadmeScreen(
         source = "github",
         externalId = "$owner/$repo",
         readmeLength = readmeLength,
-        autoDetailSummary = autoDetailSummary,
-        autoDeepResearch = autoDeepResearch,
+        autoDetailSummary = true,
     )
     // 与 chat 模块 DetailSummaryPolicy.MIN_README_CHARS 保持一致（shared 无法跨模块引用该常量）
     val detailSummaryAvailable = (readmeLength ?: 0) >= 1500
@@ -215,87 +199,31 @@ fun ReadmeScreen(
             )
         },
         floatingActionButton = {
-            if (globalChatScreen != null) {
-                // 点击主按钮展开菜单：「AI 对话」进普通会话，「一键解读」进会话并自动触发详细解读
-                var menuExpanded by rememberSaveable { mutableStateOf(false) }
-                FloatingActionButtonMenu(
-                    expanded = menuExpanded,
-                    button = {
-                        ToggleFloatingActionButton(
-                            checked = menuExpanded,
-                            // 三个 chat 入口都藏在这个菜单里，不展开就看不见——展开量是
-                            // 「用户是否发现了入口」的直接代理，比页面浏览量更贴近转化率分母
-                            onCheckedChange = {
-                                if (it) {
-                                    trackEvent(
-                                        "readme_ai_menu_open",
-                                        mapOf("detail_summary_available" to detailSummaryAvailable),
-                                    )
-                                }
-                                menuExpanded = it
-                            },
-                            // 显式配对容器色，避免依赖默认值，保证与下面图标 tint 的对比度
-                            containerColor = ToggleFloatingActionButtonDefaults.containerColor(
-                                MaterialTheme.colorScheme.primaryContainer,
-                                MaterialTheme.colorScheme.primary,
-                            ),
-                        ) {
-                            Icon(
-                                imageVector = if (checkedProgress > 0.5f) {
-                                    Icons.Default.Close
-                                } else {
-                                    Icons.Default.Menu
-                                },
-                                contentDescription = "AI",
-                                // 图标色随展开进度从「容器上前景」过渡到「主色上前景」，
-                                // 避免展开态深紫背景上 ✕ 对比度不足
-                                tint = lerp(
-                                    MaterialTheme.colorScheme.onPrimaryContainer,
-                                    MaterialTheme.colorScheme.onPrimary,
-                                    checkedProgress,
-                                ),
-                            )
-                        }
+            // 「一键解读」独占主动作位，一次点击直达（2026-08-12 起）。
+            // 此前三个 chat 入口都藏在 FAB 二级菜单里：147 次进页只有 27 次展开（发现率 18%），
+            // 但展开后有 41% 点了解读——瓶颈在发现而非意愿，故把解读提到一级、另两个入口下掉：
+            // 「AI 对话」11 天仅 1 次且首页 FAB 同期 100 次（纯冗余）；「深度调研」11 天 2 次，
+            // 且解读卡尾部已有更靠后的热入口（MessageItem 的 research 升级漏斗），冷入口是重复。
+            //
+            // 埋点 from 值保持 "readme_detail_summary" 不变——改版前后的转化率要可比
+            // （基线 11/147 = 7.5%）。ExtendedFAB 常驻展开：WebView 滚动不进 nestedScroll 链，
+            // 收不到滚动信号，正好文字一直在（图标本身没有心智）。
+            //
+            // README 正文过短（< 1500 字）时整颗 FAB 不渲染，与 chat 里 chip 的显示规则一致；
+            // 此时本页没有 AI 入口，属预期——实测仅约 7% 的条目命中。
+            if (globalChatScreen != null && detailSummaryAvailable) {
+                ExtendedFloatingActionButton(
+                    onClick = {
+                        trackEvent("chat_entry_click", mapOf("from" to "readme_detail_summary"))
+                        onNavigateToChat(buildDetailSummaryContext())
                     },
-                ) {
-                    FloatingActionButtonMenuItem(
-                        onClick = {
-                            menuExpanded = false
-                            trackEvent("chat_entry_click", mapOf("from" to "readme_chat"))
-                            onNavigateToChat(buildChatContext())
-                        },
-                        icon = {
-                            Icon(Icons.AutoMirrored.Filled.Chat, contentDescription = null)
-                        },
-                        text = { Text(stringResource(Res.string.readme_fab_chat)) },
-                    )
-                    // README 正文过短（< 1500 字）时不提供「一键解读」，与 chat 里 chip 显示规则一致
-                    if (detailSummaryAvailable) {
-                        FloatingActionButtonMenuItem(
-                            onClick = {
-                                menuExpanded = false
-                                trackEvent("chat_entry_click", mapOf("from" to "readme_detail_summary"))
-                                onNavigateToChat(buildChatContext(autoDetailSummary = true))
-                            },
-                            icon = {
-                                Icon(Icons.Default.AutoAwesome, contentDescription = null)
-                            },
-                            text = { Text(stringResource(Res.string.readme_fab_detail_summary)) },
-                        )
-                    }
-                    // 「深度调研」不受 README 长度限制：research 联网检索，不依赖 README 正文
-                    FloatingActionButtonMenuItem(
-                        onClick = {
-                            menuExpanded = false
-                            trackEvent("chat_entry_click", mapOf("from" to "readme_deep_research"))
-                            onNavigateToChat(buildChatContext(autoDeepResearch = true))
-                        },
-                        icon = {
-                            Icon(Icons.Outlined.TravelExplore, contentDescription = null)
-                        },
-                        text = { Text(stringResource(Res.string.readme_fab_deep_research)) },
-                    )
-                }
+                    icon = {
+                        // 摊开的书：与首页 chat FAB 的 AutoAwesome(✨) 区分开——✨ 是开放式对话，
+                        // 这里通往的是一篇可读完的解读。也不与 DigestScreen 的 Description（读原文）撞形。
+                        Icon(Icons.Outlined.AutoStories, contentDescription = null)
+                    },
+                    text = { Text(stringResource(Res.string.readme_fab_detail_summary)) },
+                )
             }
         }
     ) { innerPadding ->

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
@@ -199,18 +199,15 @@ fun ReadmeScreen(
             )
         },
         floatingActionButton = {
-            // 「一键解读」独占主动作位，一次点击直达（2026-08-12 起）。
-            // 此前三个 chat 入口都藏在 FAB 二级菜单里：147 次进页只有 27 次展开（发现率 18%），
-            // 但展开后有 41% 点了解读——瓶颈在发现而非意愿，故把解读提到一级、另两个入口下掉：
-            // 「AI 对话」11 天仅 1 次且首页 FAB 同期 100 次（纯冗余）；「深度调研」11 天 2 次，
-            // 且解读卡尾部已有更靠后的热入口（MessageItem 的 research 升级漏斗），冷入口是重复。
+            // 「一键解读」独占主动作位，一次点击直达（2026-08-12 起）。此前三个 chat 入口
+            // 都藏在 FAB 二级菜单里，埋点显示瓶颈在发现而非意愿（进页后仅 18% 展开菜单，
+            // 但展开者有 41% 点了解读），故把它提到一级；「AI 对话」与首页 FAB 重复、
+            // 「深度调研」在解读卡尾部已有更靠后的热入口，两者一并下掉，别再加回来。
             //
-            // 埋点 from 值保持 "readme_detail_summary" 不变——改版前后的转化率要可比
-            // （基线 11/147 = 7.5%）。ExtendedFAB 常驻展开：WebView 滚动不进 nestedScroll 链，
-            // 收不到滚动信号，正好文字一直在（图标本身没有心智）。
-            //
-            // README 正文过短（< 1500 字）时整颗 FAB 不渲染，与 chat 里 chip 的显示规则一致；
-            // 此时本页没有 AI 入口，属预期——实测仅约 7% 的条目命中。
+            // 三条约束：
+            // - 埋点 from 值不可改动，改版前后的转化率要可比（基线 7.5%）
+            // - 常驻展开态：WebView 滚动不进 nestedScroll 链，收不到收起信号
+            // - README < 1500 字时整颗 FAB 不渲染（与 chat 内 chip 同规则），此时本页无 AI 入口
             if (globalChatScreen != null && detailSummaryAvailable) {
                 ExtendedFloatingActionButton(
                     onClick = {


### PR DESCRIPTION
## 背景

README 详情页的三个 chat 入口原本都藏在 FAB 的二级菜单（汉堡）里。埋点显示**瓶颈在发现而非意愿**（1.0.0+，08-01 → 08-11，147 次进页）：

```
进入 README 页              147
├ 展开 AI FAB 菜单            27   ← 发现率 18%
│  ├ 一键解读                 11   ← 展开后转化 41%  ★
│  ├ 深度调研                  2
│  └ AI 对话                   1
└ 顶栏「分享」                13   ← 一次点击可达，9%
```

41% 的展开后转化很高——看见了就有四成人用。发现率低有个具体原因：FAB 主按钮是 `Icons.Default.Menu`（汉堡），在 FAB 位置等于不告诉用户里面是什么。

同期 GitHub 条目上「甩给外部 AI」是「用 App 内解读」的 2.9 倍（232 vs 79，全版本口径），详见父仓库 `github-digest-评估.md`。

## 改动

- **「一键解读」升为 `ExtendedFloatingActionButton`**，一次点击直达、带文字（图标本身没有心智）
- **图标改 `Icons.Outlined.AutoStories`**：原 `AutoAwesome`(✨) 与首页 chat FAB 重复；且这里通往的是一篇可读完的解读，不是开放式对话。也不与 `DigestScreen` 的 `Description`（读原文）撞形
- **下掉「AI 对话」**：11 天仅 1 次，首页 FAB 同期 100 次，纯冗余
- **下掉「深度调研」**：11 天 2 次，且解读卡尾部已有位置更靠后的热入口（`MessageItem` 的 research 升级漏斗，读完解读才升级），冷入口是重复

## 连带清理的死代码

删掉上面两个入口后，这些成了孤儿：

- `ChatContext.autoDeepResearch` 字段（ReadmeScreen 是唯一生产者）
- `ChatScreen` 里消费它的 `LaunchedEffect` 分支
- `ChatViewModel.enableDeepResearch()`（唯一调用者就是上面那个分支）
- `readme_fab_chat` / `readme_fab_deep_research` 字符串（zh + en 共 4 条）

## 两处刻意保留

- **`chat_research_repo_prefill` 及 `researchPrefill`** —— 它不只服务被删的冷入口，解读卡尾部的热入口也在用（`ChatScreen.kt` 的 `onResearchUpsell`）。删了会打断升级漏斗
- **`toggleDeepResearch()`** —— 输入栏的 research 模式开关和 11 个测试用例都在用，只删了 `enableDeepResearch()`

## 埋点

**`from` 值保持 `"readme_detail_summary"` 不变**，改版前后转化率可比。观察 `readme_view → chat_entry_click(from=readme_detail_summary)`，基线 **11/147 = 7.5%**。

`readme_ai_menu_open` 一并删除——没有二级菜单后「发现率」这个中间概念不存在了。

## 已知行为变化

README 正文 < 1500 字时整颗 FAB 不渲染（此前菜单还在、只是少一项），该页将没有 AI 入口。实测 27 次展开里仅 2 次命中此分支（约 7%），且这么短的 README 本也没什么可解读的。

## 验证

- `:androidLibrary:chat:testDebugUnitTest` —— **109 个测试全绿**
- `:androidApp:compilePlayDebugKotlin` —— 通过
- `:shared:compileKotlinIosSimulatorArm64` —— 通过

## 后续

这是「入口位置」这一个变量的实验。若转化率涨到 20%+，说明位置假设成立，再评估投钱做 GitHub 条目预生成解读（$8–34/月，见 `github-digest-评估.md`）；若涨幅有限，说明问题在落点是聊天页而非入口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDLYuWV2xRQGZPcMdayemF

## Summary by Sourcery

将 README 的「一键总结」提升为主要悬浮操作按钮入口，并从 README 详情页面中移除使用率较低的聊天和深度研究入口。

New Features:
- 当 README 内容充足时，将 README 深度总结以单击扩展悬浮操作按钮的形式暴露出来。

Enhancements:
- 简化从 README 页面进入聊天的上下文，使其始终触发深度总结。
- 更新 README AI 入口的图标设计，使其更好地体现总结行为，并与通用聊天区分开来。

Chores:
- 移除未使用的深度研究自动入口逻辑及相关字符串和上下文字段，因为 README 冷启动入口已被弃用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Promote README "one-click summary" to the primary floating action button entry and remove low-usage chat and deep research entries from the README detail page.

New Features:
- Expose README in-depth summary as a single-click extended floating action button when sufficient README content is available.

Enhancements:
- Simplify chat entry context from the README page to always trigger an in-depth summary.
- Update README AI entry iconography to better reflect the summary behavior and distinguish it from generic chat.

Chores:
- Remove unused deep research auto-entry wiring and related strings and context fields now that the README cold entry is deprecated.

</details>