### PR TITLE
fix(analytics): 1.4.0 首发读数查出的埋点缺陷——版本号恒 1.0.0 与登录漏斗双报

### DIFF
--- a/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/MainActivity.kt
@@ -41,7 +41,8 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-        whl.trending.ai.core.platform.AndroidContextHolder.initialize(this)
+        // AndroidContextHolder 已在 TrendingApplication.onCreate 初始化——必须早于埋点配置读
+        // getAppVersion()，别在这里重复调用（两处初始化正是版本号那次事故后收敛掉的）
 
         // loginbase 全部接线（建单例 + OAuth 发起注入），幂等，重建安全——见其文档
         installLoginbase(this)

--- a/androidApp/src/main/kotlin/whl/trending/ai/TrendingApplication.kt
+++ b/androidApp/src/main/kotlin/whl/trending/ai/TrendingApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import wang.harlon.eventbase.Eventbase
 import wang.harlon.eventbase.init
 import whl.trending.ai.core.analytics.analyticsConfig
+import whl.trending.ai.core.platform.AndroidContextHolder
 import whl.trending.ai.core.platform.ChannelHolder
 
 /**
@@ -17,6 +18,11 @@ class TrendingApplication : Application() {
         super.onCreate()
         // 须在任何埋点 / 网络请求之前：埋点配置与 UA 都读它
         ChannelHolder.set(BuildConfig.CHANNEL)
+        // 同理，且同样是「漏了就静默错」：getAppVersion() 拿不到 context 就只能回落。
+        // 这里是全 app 唯一的初始化点，且必须早于下面读 getAppVersion() 的埋点配置——
+        // 1.4.0 首日它还在 MainActivity（晚于本方法），全部事件的 app_version 因此恒为
+        // 当时的兜底值 1.0.0，版本切片直接作废（读数见父仓 eventbase-首发读数-2026-08-22.md）
+        AndroidContextHolder.initialize(this)
         Eventbase.init(context = this, config = analyticsConfig(isDebug = BuildConfig.DEBUG))
     }
 }

--- a/docs/analytics-notes.md
+++ b/docs/analytics-notes.md
@@ -434,7 +434,15 @@ Play 渠道几乎不留存（新装集中在 IN/NG/ID 的商店闲逛流量）�
 按撞上的概率排序，都不影响主口径，但改埋点时别忘了它们存在：
 
 1. **通知 receiver 的 `Eventbase.flush()` 耗时无上限**。旧实现是 `delay(2_000)`，有确定上界；`flush()` 会循环发到队列清空，单请求超时 20 秒。正常情况队列只有几条、一发就完，但队列积压时可能超过 `goAsync()` 的时限被系统掐掉。真撞上的表现是通知那批事件延到下次启动才上报，不会丢。
-2. **登录面板上旋转屏幕会多出一条 `auth_started`**。`MainActivity` 没声明 `configChanges`，旋转重建 composition，`LaunchedEffect(pendingSource)` 重跑并 `startFlow()` 覆盖掉原来的 flow_id。算登录转化率时分母会略微虚高。
+2. ~~**登录面板上旋转屏幕会多出一条 `auth_started`**~~ → **2026-08-22 已修**（1.4.0 首日读数暴露，见父仓 `eventbase-首发读数-2026-08-22.md`）。
+
+   **「低频/边缘」这个判断是错的，代价在首日就付了**：触发条件不止旋转——**从自定义标签页回跳会重建 Activity**（实测 backStack 回落首页），那是每个 GitHub 登录用户的必经路径。生产上 12 条 `auth_started(method=sheet)` 全是成对的，`auth_finished` 也成对，登录完成率算出 **200%**（4 条 github started 对 8 条 finished）。
+
+   两处一起修：`auth_started` 与 `startFlow()` 移到 `LoginSheetBus.request()`（发起即上报，与 composition 生命周期解耦）；OAuth 结果加 `OAuthResultGuard`，挡住重建期间新旧 composition 双订阅造成的重复消费。**判据是「同一次投递」而非「同一个 flow」**——同一条 flow 内用户可以真的取消两次，按 flow 去重会吞掉第二次（有回归测试锁定）。
+
+   `screen_viewed(login)` 的重复**保留不改**：重建后用户确实重新看到了这个页面，与路由源「不做跨重建去重」的口径一致。
+
+   教训：判定一个埋点缺陷是否「边缘」，要看**触发它的用户路径**，不是看代码分支有多窄。旋转确实少见，但重建不只由旋转引起。
 3. **research 重试可能留下落单的 `ai_requested`**。`retryResearch` 在入口无条件上报，而 `launchResearchPolling` 遇到同一条消息的轮询仍 active 会直接 return。要撞上得在协程结束的瞬间点重试——所有设 error 的路径都会先 `finishResearch()` 摘掉 job，窗口极窄。
 4. **`AccountLink` 的 `not_initialized` 分支拿到的是残留 flow_id**。该分支在 `startFlow()` 之前 return，`currentFlow()` 取到的是上一次登录/绑定留下的。生产上几乎不可达（`globalAuthManager` 初始化后恒为 `LoginbaseAuthManager`）。
 5. **「管理订阅」被协程取消时不补 `subscription_action`**。事件记在 `try` 块内 `openUrl` 之后，取消时 `finally` 只复位点击态。

--- a/shared/src/androidHostTest/kotlin/whl/trending/ai/core/platform/AndroidAppVersionFallbackTest.kt
+++ b/shared/src/androidHostTest/kotlin/whl/trending/ai/core/platform/AndroidAppVersionFallbackTest.kt
@@ -1,0 +1,39 @@
+package whl.trending.ai.core.platform
+
+import whl.trending.ai.update.isVersionBlocked
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * Android 侧 `getAppVersion()` 的**兜底分支**本身——commonTest 里那条
+ * `app_version_fallback_never_blocks` 只锁了常量与 `isVersionBlocked` 的关系，
+ * 绕过常量、在平台实现里直接写回 `"1.0.0"` 它是发现不了的（PR #108 审查指出）。
+ *
+ * 这条走的是真实现：host test 里 `AndroidContextHolder` 从未 `initialize`，
+ * `getAppVersion()` 因此落到 `context == null` 分支——**正是 1.4.0 首日全部事件
+ * 走的那条**（埋点配置在 `Application.onCreate` 读版本号，而 holder 当时还没设）。
+ * 不触碰任何 Android framework API，所以在 JVM 上跑得起来。
+ *
+ * iOS 侧不设对应用例：它读 `NSBundle.mainBundle.infoDictionary`，测试 bundle 里
+ * 有没有 `CFBundleShortVersionString` 不由我们决定，断言兜底会变成断言测试环境。
+ */
+class AndroidAppVersionFallbackTest {
+
+    @Test
+    fun `context 未就绪时兜底为哨兵值，而不是一个像样的版本号`() {
+        assertEquals(
+            UNKNOWN_APP_VERSION,
+            getAppVersion(),
+            "兜底值必须一眼可辨。伪装成真实版本号（曾经是 1.0.0）会让上报的版本切片静默失真",
+        )
+    }
+
+    @Test
+    fun `兜底值不会把用户锁死在强更页`() {
+        assertFalse(
+            isVersionBlocked(current = getAppVersion(), minVersion = "99.0.0"),
+            "isVersionBlocked 的承诺是「解析失败即不拦截」，兜底值必须真的解析不了",
+        )
+    }
+}

--- a/shared/src/androidMain/kotlin/whl/trending/ai/core/platform/Platform.android.kt
+++ b/shared/src/androidMain/kotlin/whl/trending/ai/core/platform/Platform.android.kt
@@ -132,6 +132,9 @@ actual fun getAppVersion(): String {
         val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
         packageInfo.versionName ?: UNKNOWN_APP_VERSION
     } catch (e: Exception) {
+        // 与本文件其余 catch 一致地留一行：包管理器异常与「context 还没就绪」都会落到
+        // 同一个哨兵值上，不记就分不出是哪一种
+        Log.w("Platform", "getAppVersion failed", e)
         UNKNOWN_APP_VERSION
     }
 }

--- a/shared/src/androidMain/kotlin/whl/trending/ai/core/platform/Platform.android.kt
+++ b/shared/src/androidMain/kotlin/whl/trending/ai/core/platform/Platform.android.kt
@@ -125,12 +125,14 @@ actual fun shareText(text: String) {
 }
 
 actual fun getAppVersion(): String {
-    val context = AndroidContextHolder.get() ?: return "1.0.0"
+    // context 在 TrendingApplication.onCreate 就绪，早于任何调用点；真取不到只能是初始化时序被改坏，
+    // 此时宁可上报哨兵值也不要编造一个合法版本号（见 [UNKNOWN_APP_VERSION]）
+    val context = AndroidContextHolder.get() ?: return UNKNOWN_APP_VERSION
     return try {
         val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-        packageInfo.versionName ?: "1.0.0"
+        packageInfo.versionName ?: UNKNOWN_APP_VERSION
     } catch (e: Exception) {
-        "1.0.0"
+        UNKNOWN_APP_VERSION
     }
 }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/auth/LoginbaseAuthManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/auth/LoginbaseAuthManager.kt
@@ -7,11 +7,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import wang.harlon.eventbase.Eventbase
 import wang.harlon.loginbase.AuthClient
 import wang.harlon.loginbase.AuthState as LoginbaseState
 import wang.harlon.loginbase.RefreshOutcome
 import wang.harlon.loginbase.TokenStore
 import whl.trending.ai.core.analytics.AppEvent
+import whl.trending.ai.core.analytics.AuthAction
 import whl.trending.ai.core.analytics.setAnalyticsUser
 import whl.trending.ai.core.analytics.track
 import whl.trending.ai.data.local.globalSettingsManager
@@ -174,10 +176,25 @@ object LoginSheetBus {
     private val _githubResult = MutableStateFlow<GithubAuthResult?>(null)
     val githubResult: StateFlow<GithubAuthResult?> = _githubResult
 
+    /**
+     * 发起一次登录请求。**漏斗起点 `auth_started` 记在这里**，而不是面板的 composition 里：
+     * 面板挂 `LaunchedEffect`，Activity 一重建（旋转、从自定义标签页回跳）就重跑，一次登录
+     * 被记成两条 started、各带一个新 flow_id——1.4.0 首日 12 条 sheet started 全是成对的，
+     * 登录完成率因此翻倍。事件语义本就是「用户发起了登录」，那正是本方法被调用的时刻。
+     *
+     * 同一入口的重复请求直接忽略：面板已经开着，再记一条 started 只会虚高分母。
+     */
     fun request(source: String) {
+        if (_request.value == source) return
         // 每次新请求都从干净状态开始：上一轮遗留的失败若留着，面板一打开就顶着红字
         _githubResult.value = null
         _request.value = source
+        // 开一条 flow 串起本次登录：GitHub 那条要跳浏览器、进程可能已被杀，
+        // 回跳后的终态事件靠落盘的 flow_id 才接得回同一个漏斗
+        track(
+            AppEvent.AuthStarted(AuthAction.SIGN_IN, method = "sheet", source = source),
+            Eventbase.startFlow(),
+        )
     }
 
     fun reportGithubResult(result: GithubAuthResult) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/auth/LoginbaseOAuthLaunch.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/auth/LoginbaseOAuthLaunch.kt
@@ -14,8 +14,43 @@ enum class OAuthMode { SIGN_IN, LINK }
  */
 var globalOAuthLauncher: ((AuthClient, OAuthMode) -> Boolean)? = null
 
-internal fun launchGithubSignIn(client: AuthClient): Boolean =
-    globalOAuthLauncher?.invoke(client, OAuthMode.SIGN_IN) ?: false
+/**
+ * OAuth 回跳结果的**重复消费闸**。
+ *
+ * `client.oauthResults` 是 `replay = 1` 的 SharedFlow，消费者
+ * [whl.trending.ai.ui.common.OAuthOutcomeHost] 挂在 composition 上。从自定义标签页回跳会重建
+ * Activity（实测：backStack 回落首页），重建期间新旧两个 composition 短暂并存、同时订阅，
+ * **同一次投递被消费两次**：1.4.0 首日的 `auth_finished(canceled)` 因此全是成对的，
+ * 登录完成率算出 200%（4 条 started 对 8 条 finished）；`consumePendingSource()` 这类
+ * 一次性读取也会被跑两遍。
+ *
+ * 判据是「同一次投递」而不是「同一个 flow」：同一条 flow 内用户可以真的取消两次
+ * （生产数据里就有，23:33:11 与 23:33:16 各一次），按 flow 去重会把第二次真实取消吞掉。
+ * 靠**每次发起授权时重置**做到这一点——`Cancelled` 是 object 单例，跨轮次的引用相等
+ * 不能说明什么，重置后才可信。
+ */
+internal object OAuthResultGuard {
+    private var lastHandled: Any? = null
 
-internal fun launchGithubLink(client: AuthClient): Boolean =
-    globalOAuthLauncher?.invoke(client, OAuthMode.LINK) ?: false
+    /** 发起新一轮授权，上一轮的结果不再算「已处理」。 */
+    fun reset() {
+        lastHandled = null
+    }
+
+    /** 本轮内首次见到这条结果才为 true。只在 Compose 主线程调用。 */
+    fun shouldHandle(outcome: Any): Boolean {
+        if (lastHandled === outcome) return false
+        lastHandled = outcome
+        return true
+    }
+}
+
+internal fun launchGithubSignIn(client: AuthClient): Boolean {
+    OAuthResultGuard.reset()
+    return globalOAuthLauncher?.invoke(client, OAuthMode.SIGN_IN) ?: false
+}
+
+internal fun launchGithubLink(client: AuthClient): Boolean {
+    OAuthResultGuard.reset()
+    return globalOAuthLauncher?.invoke(client, OAuthMode.LINK) ?: false
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/platform/Platform.kt
@@ -59,6 +59,17 @@ fun openDownloadUrl(url: String) {
 /** 调起系统分享面板，把纯文本交给用户选择的目标 App（AI App / 笔记 / IM 等）。 */
 expect fun shareText(text: String)
 
+/**
+ * 取不到版本号时的兜底值。**必须是解析不出数值段的字符串**：
+ *
+ * - [whl.trending.ai.update.isVersionBlocked] 靠「任一侧解析失败即不拦截」保证兜底值不会把用户
+ *   锁死在强更页，而旧兜底值 `"1.0.0"` 能被正常解析——`isVersionBlocked("1.0.0", "1.4.0")` 返回 true，
+ *   那条保护一直形同虚设；
+ * - 它同时是个显眼的哨兵：埋点里看到 `unknown` 就知道取版本号的时机不对，而 `"1.0.0"` 会伪装成
+ *   真实版本悄悄污染版本切片（2026-08-21 首发当天就这么发生了，见父仓 eventbase-首发读数-2026-08-22.md）。
+ */
+const val UNKNOWN_APP_VERSION: String = "unknown"
+
 expect fun getAppVersion(): String
 
 /** 是否支持切换桌面图标（Android activity-alias 机制）。false 时外观页隐藏「应用图标」整块。 */

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/auth/LoginSheetHost.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/auth/LoginSheetHost.kt
@@ -83,14 +83,8 @@ fun LoginSheetHost() {
     val source by LoginSheetBus.request.collectAsState()
     val pendingSource = source ?: return
 
-    // 开一条 flow 串起本次登录：GitHub 那条要跳浏览器、进程可能已被杀，
-    // 回跳后的终态事件靠落盘的 flow_id 才接得回同一个漏斗
-    LaunchedEffect(pendingSource) {
-        track(
-            AppEvent.AuthStarted(AuthAction.SIGN_IN, method = "sheet", source = pendingSource),
-            Eventbase.startFlow(),
-        )
-    }
+    // auth_started 与 flow 的开启都在 LoginSheetBus.request()——**不要挪回这里**：
+    // 挂在 composition 上的副作用会随 Activity 重建重跑，把漏斗分母做成两倍
 
     LoginSheet(
         source = pendingSource,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/OAuthOutcomeHost.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/OAuthOutcomeHost.kt
@@ -22,6 +22,7 @@ import wang.harlon.loginbase.OAuthOutcome
 import whl.trending.ai.auth.GithubAuthResult
 import whl.trending.ai.auth.LoginSheetBus
 import whl.trending.ai.auth.LoginbaseAuthManager
+import whl.trending.ai.auth.OAuthResultGuard
 import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.core.AccountLink
 import whl.trending.ai.core.analytics.AppEvent
@@ -60,6 +61,10 @@ fun OAuthOutcomeHost() {
 
     LaunchedEffect(client) {
         client?.oauthResults?.collect { outcome ->
+            // 从自定义标签页回跳会重建 Activity，新旧 composition 短暂并存、同时订阅这条
+            // replay=1 的流，同一次投递会被消费两次（埋点成对、一次性读取跑两遍）。
+            // 闸由 launchGithubSignIn / launchGithubLink 在发起时重置，见 [OAuthResultGuard]
+            if (!OAuthResultGuard.shouldHandle(outcome)) return@collect
             // 无论哪一种结果都在这里消费掉：漏一种，它就会滞留到下一次面板打开
             client.consumeOauthResult()
             when (outcome) {

--- a/shared/src/commonTest/kotlin/whl/trending/ai/auth/OAuthResultGuardTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/auth/OAuthResultGuardTest.kt
@@ -1,0 +1,56 @@
+package whl.trending.ai.auth
+
+import wang.harlon.loginbase.OAuthOutcome
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * OAuth 回跳结果的重复消费闸。
+ *
+ * 治的是：从自定义标签页回跳会重建 Activity，`OAuthOutcomeHost` 新旧两个 composition
+ * 短暂并存、同时订阅 `replay = 1` 的 `oauthResults`，同一次投递被消费两次。1.4.0 首日
+ * `auth_finished(canceled)` 全是成对的，登录完成率算出 200%。
+ *
+ * 两条用例是一对权衡：挡住重复投递，但**不能**挡住用户真的取消两次——生产数据里
+ * 同一条 flow 内就有两次真实取消（23:33:11 与 23:33:16），按 flow 去重会把第二次吞掉。
+ */
+class OAuthResultGuardTest {
+
+    // 进程级单例，用例之间会串状态
+    @BeforeTest
+    fun setUp() = OAuthResultGuard.reset()
+
+    @AfterTest
+    fun tearDown() = OAuthResultGuard.reset()
+
+    @Test
+    fun `同一次投递只处理一次——重建期间的第二个订阅者被挡掉`() {
+        assertTrue(OAuthResultGuard.shouldHandle(OAuthOutcome.Cancelled))
+        assertFalse(
+            OAuthResultGuard.shouldHandle(OAuthOutcome.Cancelled),
+            "同一次投递被消费两次：埋点成对，consumePendingSource() 这类一次性读取也会跑两遍",
+        )
+    }
+
+    @Test
+    fun `重新发起授权后，同一种结果仍要处理——用户可以真的取消两次`() {
+        assertTrue(OAuthResultGuard.shouldHandle(OAuthOutcome.Cancelled))
+
+        // launchGithubSignIn / launchGithubLink 在发起时会做这件事
+        OAuthResultGuard.reset()
+
+        assertTrue(
+            OAuthResultGuard.shouldHandle(OAuthOutcome.Cancelled),
+            "Cancelled 是 object 单例，跨轮次的引用相等说明不了什么——重置后必须重新放行",
+        )
+    }
+
+    @Test
+    fun `不同结果各自放行`() {
+        assertTrue(OAuthResultGuard.shouldHandle(OAuthOutcome.Cancelled))
+        assertTrue(OAuthResultGuard.shouldHandle(OAuthOutcome.Failed("github_in_use")))
+    }
+}

--- a/shared/src/commonTest/kotlin/whl/trending/ai/update/MinVersionTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/update/MinVersionTest.kt
@@ -1,5 +1,6 @@
 package whl.trending.ai.update
 
+import whl.trending.ai.core.platform.UNKNOWN_APP_VERSION
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -75,5 +76,15 @@ class MinVersionTest {
     fun malformed_current_version_is_not_blocked() {
         assertFalse(isVersionBlocked(current = "", minVersion = "0.15.0"))
         assertFalse(isVersionBlocked(current = "unknown", minVersion = "0.15.0"))
+    }
+
+    /**
+     * 把 [UNKNOWN_APP_VERSION] 与「解析失败即不拦截」绑死。上面那条测的是字面量 "unknown"，
+     * 而 getAppVersion() 的兜底值一度是可解析的 "1.0.0"——真走到兜底时用户会被锁死在强更页，
+     * 恰是本函数 KDoc 承诺要防的事。兜底值哪天再被改回数值形态，这条会红。
+     */
+    @Test
+    fun app_version_fallback_never_blocks() {
+        assertFalse(isVersionBlocked(current = UNKNOWN_APP_VERSION, minVersion = "99.0.0"))
     }
 }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/update/MinVersionTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/update/MinVersionTest.kt
@@ -81,7 +81,10 @@ class MinVersionTest {
     /**
      * 把 [UNKNOWN_APP_VERSION] 与「解析失败即不拦截」绑死。上面那条测的是字面量 "unknown"，
      * 而 getAppVersion() 的兜底值一度是可解析的 "1.0.0"——真走到兜底时用户会被锁死在强更页，
-     * 恰是本函数 KDoc 承诺要防的事。兜底值哪天再被改回数值形态，这条会红。
+     * 恰是本函数 KDoc 承诺要防的事。
+     *
+     * **本条只锁常量**：绕过常量、在平台实现里直接写回 `"1.0.0"` 它发现不了（PR #108 审查
+     * 指出）。那一层由 `androidHostTest` 的 `AndroidAppVersionFallbackTest` 走真实现覆盖。
      */
     @Test
     fun app_version_fallback_never_blocks() {

--- a/shared/src/iosMain/kotlin/whl/trending/ai/core/platform/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/whl/trending/ai/core/platform/Platform.ios.kt
@@ -76,7 +76,7 @@ actual fun shareText(text: String) {
 
 actual fun getAppVersion(): String {
     val info = NSBundle.mainBundle.infoDictionary
-    return info?.get("CFBundleShortVersionString") as? String ?: "1.0.0"
+    return info?.get("CFBundleShortVersionString") as? String ?: UNKNOWN_APP_VERSION
 }
 
 actual fun isIosPlatform(): Boolean = true


### PR DESCRIPTION
1.4.0 昨晚发版，今早查首日埋点读数时发现两个必须发补丁版才能修的缺陷，外加一个顺带查出的潜伏 bug。完整读数与对账过程在父仓 `eventbase-首发读数-2026-08-22.md`（私有）。

## 1. `app_version` 恒为 `1.0.0`，版本切片全废

首日全部客户端事件的 `app_version` 都是 `"1.0.0"`。根因是代码级确凿的：

- `getAppVersion()` 在 `AndroidContextHolder.get() == null` 时回落 `"1.0.0"`；
- 该 holder 全 app 只在 `MainActivity.onCreate` 初始化；
- 而 `analyticsConfig()` 在 `TrendingApplication.onCreate` 就读它 —— 必然为 null。

同一个方法里 `ChannelHolder` 因为有注释提醒而排对了顺序，这条同类依赖漏了。修法是把 `initialize` 提到 `Eventbase.init` 之前，并删掉 `MainActivity` 里那次重复调用（holder 存的本就是 applicationContext，Application 是它可用的最早时机，也与 `ChannelHolder` 的既有模式一致）。

**实测**：Pixel_9_2 debug 包，`POST /e -> 204`，入库 `app_version=1.4.0-debug`，与 `dumpsys` 的 versionName 一致。删掉 MainActivity 那行后重测仍正确。

已入库的 13 个 install 的 `install_first_seen.app_version` 仍是 `1.0.0`，不回填。

## 2. 登录漏斗双报，完成率算出 200%

首日 12 条 `auth_started(method=sheet)` 全是成对的，`auth_finished` 也成对 —— 4 条 github started 对 8 条 finished。

根因在模拟器上复现坐实：**Activity 重建让挂在 composition 上的一次性副作用重跑**。旋转一次即复现；更要命的是**从自定义标签页回跳同样会重建**（实测 backStack 回落首页），那是每个 GitHub 登录用户的必经路径 —— `docs/analytics-notes.md` 里「低频/边缘，旋转才会撞上」的判断因此是错的，代价首日就付了。

两处一起修：

- `auth_started` 与 `startFlow()` 移到 `LoginSheetBus.request()`。事件语义本就是「用户发起了登录」，那正是该方法被调用的时刻，与 UI 生命周期无关；顺带忽略同一入口的重复请求。
- 新增 `OAuthResultGuard`：重建期间新旧 composition 短暂并存、同时订阅 `replay=1` 的 `oauthResults`，同一次投递被消费两次 —— 不只埋点成对，`consumePendingSource()` 这类一次性读取也会跑两遍。闸由两个 OAuth 发起点在启动授权时重置。

**判据是「同一次投递」而不是「同一个 flow」**：同一条 flow 内用户可以真的取消两次（生产数据 23:33:11 与 23:33:16 各一次），按 flow 去重会把第二次吞掉。这条由 `OAuthResultGuardTest` 锁定。

`screen_viewed(login)` 的重复**保留不改**：重建后用户确实重新看到了该页面，与路由源「不做跨重建去重」的口径一致。

**实测对照**（同一张埋点表可查）：开面板 + 旋转 + 转回，修复前 3 条 `auth_started`、3 个不同 flow；修复后 1 条，flow `0e40906e` 一路贯穿到 `auth_started(github)`，完整漏斗 `sheet → github → finished(success)` 各 1 条。

## 3. 顺带：版本号兜底值让强更保护形同虚设

`isVersionBlocked` 的 KDoc 明写「任一侧解析失败一律不拦截 —— getAppVersion() 的兜底值不能把用户锁死」，但 `"1.0.0"` 能被正常解析：`isVersionBlocked("1.0.0", "1.4.0")` 返回 **true**，真走到兜底时用户会被锁死在强更页，恰是那条注释想防的事。

`MinVersionTest` 里早就有 `current="unknown"` 不拦截的断言，说明测试作者一直假定兜底值是不可解析形态，只是实现给了个数值版本号。改为 `UNKNOWN_APP_VERSION = "unknown"`（android/ios 两侧共三处），新测试用常量而非字面量绑死二者。附带收益：哨兵值在埋点里一眼可见 —— 这次事故能瞒过一整晚读数，正是因为 `"1.0.0"` 伪装成了真实版本号。

## 验证

- Android + iOS 编译通过；`:shared` 全量测试通过（新增 4 条：`OAuthResultGuardTest` ×3、`app_version_fallback_never_blocks` ×1）
- 兜底值那条测试做了反向验证：临时退回 `"1.0.0"` → 构建失败；还原 → 通过。不是摆设断言
- 三处埋点行为都在 Pixel_9_2 上端到端实测，判据是埋点库里的真实数据而非日志

## 不在本 PR 内

`is_cold` 从未实现、四处词汇表漂移 —— 都是 eventbase 文档仓的问题（实现是对的），已随 eventbase `4f986f8` 单独提交，本仓无对应代码改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgYoWH7Mg9L777ixsFKS9v

## Sourcery 摘要

修正分析版本报告问题，并消除应用重建期间重复的登录漏斗处理。

错误修复：
- 确保分析事件报告实际的应用版本，而不是错误的回退值。
- 防止因 Activity 和 UI 重建而导致重复的登录漏斗事件和 OAuth 结果事件。
- 使用明确的未知版本标记值，确保版本解析失败不会意外触发强制更新。

增强功能：
- 将登录漏斗的启动与 UI 组合生命周期解耦，同时保留有效的重复取消事件。

文档：
- 更新分析说明，记录已解决的登录重复问题及其对用户路径的影响。

测试：
- 添加 OAuth 结果去重和非阻塞应用版本回退的回归测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

修复分析数据中的版本报告问题，并消除应用重新创建期间重复处理登录漏斗的问题。

错误修复：
- 在分析事件中报告实际的应用版本，而不是错误的回退值。
- 防止在 activity 或 UI 重新创建时重复触发登录漏斗事件和处理 OAuth 结果。
- 使用明确的未知版本哨兵值，确保版本查询失败不会意外触发强制更新阻止。

增强功能：
- 将登录漏斗的启动与 UI 组合生命周期解耦，同时保留合法的重复 OAuth 取消操作。

文档：
- 更新分析相关说明，记录已解决的登录重复问题及其对用户流程的影响。

测试：
- 增加针对 OAuth 结果去重和非阻塞应用版本回退机制的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix analytics version reporting and eliminate duplicate login funnel processing during application recreation.

Bug Fixes:
- Report the actual application version in analytics events instead of the incorrect fallback value.
- Prevent duplicate login funnel events and OAuth result processing when the activity or UI is recreated.
- Use an explicit unknown-version sentinel so version lookup failures cannot trigger unintended force-update blocking.

Enhancements:
- Decouple login funnel initiation from the UI composition lifecycle while preserving legitimate repeated OAuth cancellations.

Documentation:
- Update analytics notes to document the resolved login duplication issue and its impact on user journeys.

Tests:
- Add regression coverage for OAuth result deduplication and non-blocking application-version fallbacks.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate login and OAuth events during activity recreation or overlapping UI subscriptions.
  * Improved authentication request handling by ignoring duplicate requests and resetting previous sign-in results.
  * Ensured app updates are not incorrectly blocked when the application version cannot be determined.
  * Added a consistent “unknown” fallback for unavailable app version information.

* **Documentation**
  * Updated analytics notes to document the resolved duplicate login event behavior and intentional screen tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->