### PR TITLE
fix(network): API 类的 HttpClient 收敛为进程级共享单例

### DIFF
--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubApi.kt
@@ -134,16 +134,23 @@ private const val CONTRIBUTION_QUERY =
 
 /** GitHub REST 直连：feed 与计数。token 来自 GithubTokenProvider（Secret Vault 取回）。 */
 open class GithubApi {
-    private val client = HttpClient {
-        install(ContentNegotiation) {
-            json(Json { ignoreUnknownKeys = true })
-        }
-        install(HttpTimeout) {
-            requestTimeoutMillis = 15000
-            connectTimeoutMillis = 15000
-            socketTimeoutMillis = 15000
+    private companion object {
+        // 进程级共享、从不 close，理由见 TrendingApi.sharedClient
+        val sharedClient by lazy {
+            HttpClient {
+                install(ContentNegotiation) {
+                    json(Json { ignoreUnknownKeys = true })
+                }
+                install(HttpTimeout) {
+                    requestTimeoutMillis = 15000
+                    connectTimeoutMillis = 15000
+                    socketTimeoutMillis = 15000
+                }
+            }
         }
     }
+
+    private val client get() = sharedClient
 
     private val baseHost = "https://api.github.com"
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubTokenApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/GithubTokenApi.kt
@@ -29,16 +29,7 @@ data class GithubTokenResponse(
  * 凭据是 loginbase 的 access token（后端 requireAuth 的 loginbase 轨道）。
  */
 open class GithubTokenApi {
-    private val client = HttpClient {
-        install(ContentNegotiation) {
-            json(Json { ignoreUnknownKeys = true })
-        }
-        install(HttpTimeout) {
-            requestTimeoutMillis = 15000
-            connectTimeoutMillis = 15000
-            socketTimeoutMillis = 15000
-        }
-    }
+    private val client get() = sharedClient
 
     /**
      * 取 GitHub access token。404 = 该用户没存 token（纯邮箱账号、或撤销过授权），
@@ -58,5 +49,19 @@ open class GithubTokenApi {
 
     private companion object {
         const val API_BASE = "https://api.trendingai.cn"
+
+        // 进程级共享、从不 close，理由见 TrendingApi.sharedClient
+        val sharedClient by lazy {
+            HttpClient {
+                install(ContentNegotiation) {
+                    json(Json { ignoreUnknownKeys = true })
+                }
+                install(HttpTimeout) {
+                    requestTimeoutMillis = 15000
+                    connectTimeoutMillis = 15000
+                    socketTimeoutMillis = 15000
+                }
+            }
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/remote/TrendingApi.kt
@@ -44,22 +44,29 @@ import kotlinx.serialization.json.put
 class ApiException(val statusCode: Int, message: String) : Exception(message)
 
 open class TrendingApi {
-    private val client = HttpClient {
-        install(ContentNegotiation) {
-            json(Json {
-                ignoreUnknownKeys = true
-                coerceInputValues = true
-            })
-        }
-        install(HttpTimeout) {
-            requestTimeoutMillis = 15000
-            connectTimeoutMillis = 15000
-            socketTimeoutMillis = 15000
-        }
-        install(DefaultRequest) {
-            header(HttpHeaders.UserAgent, getUserAgent())
+    private companion object {
+        // 进程级共享、从不 close：每实例自建 client 会随导航反复付连接池/线程池与冷连接 TLS 的成本
+        val sharedClient by lazy {
+            HttpClient {
+                install(ContentNegotiation) {
+                    json(Json {
+                        ignoreUnknownKeys = true
+                        coerceInputValues = true
+                    })
+                }
+                install(HttpTimeout) {
+                    requestTimeoutMillis = 15000
+                    connectTimeoutMillis = 15000
+                    socketTimeoutMillis = 15000
+                }
+                install(DefaultRequest) {
+                    header(HttpHeaders.UserAgent, getUserAgent())
+                }
+            }
         }
     }
+
+    private val client get() = sharedClient
 
     private val baseHost = "https://api.trendingai.cn"
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/TrendingRepository.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/repository/TrendingRepository.kt
@@ -11,10 +11,7 @@ import whl.trending.ai.data.remote.TrendingApi
 open class TrendingRepository(private val api: TrendingApi = TrendingApi()) {
 
     companion object {
-        /**
-         * 进程级共享实例：TrendingApi 每个实例各建一个从不关闭的 HttpClient，组合树里随手 new
-         * 会积累引擎/连接池（仿 ChatApi.shared 的收敛方式）。无状态可安全共享；测试注入仍走构造参数。
-         */
+        /** 无状态、可安全共享的便捷单例；测试注入仍走构造参数。 */
         val shared: TrendingRepository by lazy { TrendingRepository() }
     }
 


### PR DESCRIPTION
Closes #101

## 问题

`TrendingApi` / `GithubApi` / `GithubTokenApi` 在实例构造时各建一个 Ktor `HttpClient`，而创建面远不止 issue 列的 5 处——各 Repository/ViewModel 的默认参数都会默认构造，ViewModel 随导航反复重建意味着**每进一次详情页/解读页就新建一套 OkHttp 连接池与线程池**：连接无法跨页面复用，每个新 client 的首个请求都重付 DNS+TCP+TLS 握手，keep-alive 形同虚设。这比 issue 自评的「资源整洁性」重半档——是用户可感知的冷连接延迟。

## 修法

client 收敛为 companion object 内的 `by lazy` 进程级单例，实例侧 `private val client get() = sharedClient` 引流：

- **调用点零改动**：所有 `TrendingApi()` 默认参数、手动 DI 风格、`open class` 子类测试注入全部原样保留；
- 全进程 HttpClient 从随导航增长降为**恒定 3 个**（三类配置仅差 UA header，是否进一步合一留待后续决策）；
- lazy 化顺带：首帧组合不再在主线程建 client；测试里 `FakeApi : TrendingApi()` 不再触发真实引擎构造；
- 生命周期：全仓无人调用 `close()`，进程级持有即现状合法化。

顺带把 `TrendingRepository.shared` 的过期注释（动机随本改动失效，且引用的 `ChatApi.shared` 类已不存在）缩为一句。

## 验证

- `:shared:compileAndroidMain` / `:shared:testAndroidHostTest` / `:androidApp:compileGithubDebugKotlin` 通过
- 模拟器冒烟另附评论

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsYB8PixAUFfQFTyUwoeuW

## Sourcery 总结

将 API HTTP 客户端整合为进程级延迟单例，以提高连接复用率并避免不必要的客户端初始化。

错误修复：
- 在不同 API 实例之间复用进程级 HTTP 客户端，避免在导航过程中重复创建连接池和建立冷连接。

改进：
- 延迟初始化三个 API 专用的共享客户端，同时保留现有的构造方式和依赖注入接口。
- 更新 TrendingRepository 共享实例文档，以反映简化生命周期设计的原因。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Consolidate API HTTP clients into lazy process-level singletons to improve connection reuse and avoid unnecessary client initialization.

Bug Fixes:
- Reuse process-level HTTP clients across API instances to avoid repeated connection-pool creation and cold connection setup during navigation.

Enhancements:
- Lazily initialize the three API-specific shared clients while preserving existing construction and dependency-injection interfaces.
- Refresh the TrendingRepository shared-instance documentation to reflect the simplified lifecycle rationale.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved network resource reuse by sharing HTTP connections across API operations.
  - Reduced unnecessary client initialization while preserving existing request configuration.

- **Maintenance**
  - Clarified internal documentation for shared networking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->