### PR TITLE
refactor(nav): DigestPage 迁入 core 包，Route 改 sealed 拿到穷尽检查

### DIFF
--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/App.kt
@@ -15,7 +15,6 @@ import whl.trending.ai.ui.settings.AppearanceScreen
 import whl.trending.ai.ui.settings.ColorLabScreen
 import whl.trending.ai.ui.settings.DataSourcesScreen
 import whl.trending.ai.ui.settings.SettingsScreen
-import whl.trending.ai.ui.digest.DigestPage
 import whl.trending.ai.ui.hiring.HiringScreen
 import whl.trending.ai.ui.digest.DigestScreen
 import whl.trending.ai.ui.subscribe.SubscribeScreen
@@ -89,10 +88,7 @@ data class Chat(val context: ChatContext?) : Route { override val screen = Scree
 /**
  * HN 招聘月度专题。[month] 为 'YYYY-MM'，null = 最新一期（默认入口不带月份）。
  *
- * 与 [whl.trending.ai.ui.digest.DigestPage] 不同，本路由**不兼任数据载体**：
- * 它不从列表带任何内容进来（专题内容整月一次拉取），因此按惯例声明在这里，
- * 而不是跟着页面住在 ui 包——DigestPage 住在别处是被迫的例外（见 Route 的 KDoc），
- * 不是可照抄的范式。
+ * 与 [DigestPage] 不同，本路由不兼任数据载体：专题内容整月一次拉取，不从列表带内容。
  */
 data class Hiring(val month: String? = null) : Route { override val screen = Screen.HIRING }
 
@@ -365,10 +361,6 @@ fun App() {
                                     // 未注册（如 iOS）——入口本应隐藏，兜底直接返回
                                     LaunchedEffect(Unit) { backStack.safePop() }
                                 }
-                            }
-
-                            else -> {
-                                error("Unknown route: $key")
                             }
                             }
                         }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/DigestPage.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/DigestPage.kt
@@ -1,6 +1,5 @@
-package whl.trending.ai.ui.digest
+package whl.trending.ai.core
 
-import whl.trending.ai.core.Route
 import whl.trending.ai.core.analytics.Screen
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.data.model.FeedItem

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/Route.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/Route.kt
@@ -6,12 +6,8 @@ import whl.trending.ai.core.analytics.Screen
  * 导航目的地。实现它是进 backStack 的**唯一**方式（栈的元素类型就是它），
  * 于是「新增页面忘了埋点」变成编译错误——页面浏览事件由导航层自动产生，
  * 页面自己一行 track 都不写（见 `core/analytics/ScreenTracking.kt`）。
- *
- * 不用 `sealed`：[whl.trending.ai.ui.digest.DigestPage] 兼任路由 key 却住在别的包，
- * 而 sealed 的直接实现必须同包。约束力不靠 sealed，靠 backStack 的元素类型——
- * 代价是 `entryProvider` 的 `when` 拿不到穷尽检查，仍需 `else` 兜底。
  */
-interface Route {
+sealed interface Route {
     /**
      * 本页在埋点里的身份。
      *

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestScreen.kt
@@ -55,6 +55,7 @@ import trendingai.shared.generated.resources.digest_read_original
 import trendingai.shared.generated.resources.digest_unavailable_desc
 import trendingai.shared.generated.resources.digest_unavailable_title
 import trendingai.shared.generated.resources.retry
+import whl.trending.ai.core.DigestPage
 import whl.trending.ai.core.analytics.AppEvent
 import whl.trending.ai.core.analytics.ContentActionKind
 import whl.trending.ai.core.analytics.track

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/digest/DigestViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
+import whl.trending.ai.core.DigestPage
 import whl.trending.ai.core.analytics.AppEvent
 import whl.trending.ai.core.analytics.track
 import whl.trending.ai.data.local.SettingsManager

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/favorites/FavoriteListScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/favorites/FavoriteListScreen.kt
@@ -51,13 +51,13 @@ import trendingai.shared.generated.resources.favorites_empty
 import trendingai.shared.generated.resources.favorites_empty_hint
 import trendingai.shared.generated.resources.favorites_removed
 import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.core.DigestPage
+import whl.trending.ai.core.toDigestPage
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.data.repository.globalFavoriteRepository
 import whl.trending.ai.ui.common.AiSummaryBox
 import whl.trending.ai.ui.common.TrendingScaffold
 import whl.trending.ai.ui.common.TrendingTopAppBar
-import whl.trending.ai.ui.digest.DigestPage
-import whl.trending.ai.ui.digest.toDigestPage
 import whl.trending.ai.ui.picks.SourceTag
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/feed/FeedScreen.kt
@@ -53,6 +53,8 @@ import org.jetbrains.compose.resources.stringResource
 import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.no_data
 import trendingai.shared.generated.resources.retry
+import whl.trending.ai.core.DigestPage
+import whl.trending.ai.core.toDigestPage
 import whl.trending.ai.core.analytics.AppEvent
 import whl.trending.ai.core.analytics.ContentActionKind
 import whl.trending.ai.core.analytics.track
@@ -68,8 +70,6 @@ import whl.trending.ai.ui.common.LocalContentTopPadding
 import whl.trending.ai.ui.common.SourceMetaFooter
 import whl.trending.ai.ui.common.aiShareText
 import whl.trending.ai.ui.common.updateStampText
-import whl.trending.ai.ui.digest.DigestPage
-import whl.trending.ai.ui.digest.toDigestPage
 
 /** 左侧标识位尺寸，序号圆圈和产品 logo 共用；请求像素按 3x 屏取整，避免高密度屏上发虚。 */
 private val LEADING_SIZE = 28.dp

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/hiring/HiringScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/hiring/HiringScreen.kt
@@ -75,6 +75,7 @@ import trendingai.shared.generated.resources.hiring_unavailable_desc
 import trendingai.shared.generated.resources.hiring_unavailable_title
 import trendingai.shared.generated.resources.hiring_view_post
 import trendingai.shared.generated.resources.retry
+import whl.trending.ai.core.hnDiscussionUrl
 import whl.trending.ai.core.analytics.AppEvent
 import whl.trending.ai.core.analytics.ContentActionKind
 import whl.trending.ai.core.analytics.ListFilter
@@ -85,7 +86,6 @@ import whl.trending.ai.ui.common.BetaBadge
 import whl.trending.ai.ui.common.TrendingDropdownMenu
 import whl.trending.ai.ui.common.TrendingScaffold
 import whl.trending.ai.ui.common.TrendingTopAppBar
-import whl.trending.ai.ui.digest.hnDiscussionUrl
 import whl.trending.ai.ui.home.HackerNewsOrange
 import whl.trending.ai.ui.home.hackerNewsIcon
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/home/HomeScreen.kt
@@ -50,6 +50,7 @@ import trendingai.shared.generated.resources.icon_producthunt_light
 import trendingai.shared.generated.resources.me_title
 import trendingai.shared.generated.resources.producthunt_title
 import whl.trending.ai.chat.globalChatScreen
+import whl.trending.ai.core.DigestPage
 import whl.trending.ai.core.analytics.trackScreenView
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.repository.ChatModelsProvider
@@ -61,7 +62,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.WorkOutline
 import androidx.compose.material3.IconButton
 import trendingai.shared.generated.resources.hiring_entry
-import whl.trending.ai.ui.digest.DigestPage
 import whl.trending.ai.ui.feed.FeedScreen
 import whl.trending.ai.ui.feed.FeedViewModel
 import whl.trending.ai.ui.picks.PicksScreen

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/picks/PicksScreen.kt
@@ -61,7 +61,9 @@ import trendingai.shared.generated.resources.picks_no_data
 import trendingai.shared.generated.resources.picks_section_debut
 import trendingai.shared.generated.resources.picks_section_deep_dive
 import trendingai.shared.generated.resources.retry
+import whl.trending.ai.core.DigestPage
 import whl.trending.ai.core.DateTimeUtils
+import whl.trending.ai.core.toDigestPage
 import whl.trending.ai.core.analytics.AppEvent
 import whl.trending.ai.core.analytics.ContentActionKind
 import whl.trending.ai.core.analytics.NewsletterActionKind
@@ -77,8 +79,6 @@ import whl.trending.ai.ui.common.LocalContentTopPadding
 import whl.trending.ai.ui.common.SourceMetaFooter
 import whl.trending.ai.ui.common.aiShareText
 import whl.trending.ai.ui.common.generatedStampText
-import whl.trending.ai.ui.digest.DigestPage
-import whl.trending.ai.ui.digest.toDigestPage
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable

--- a/shared/src/commonTest/kotlin/whl/trending/ai/core/DigestPageTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/core/DigestPageTest.kt
@@ -1,4 +1,4 @@
-package whl.trending.ai.ui.digest
+package whl.trending.ai.core
 
 import whl.trending.ai.data.model.FavoriteItem
 import kotlin.test.Test


### PR DESCRIPTION
## 做了什么

解决 #107：`Route` 的 19 个实现里唯一住在 ui 包的 `DigestPage` 挡住了 `sealed`（sealed 直接实现必须同包）。本 PR 取 issue 选项 (b) 的变体——**独立文件平移进 core 包**，不塞进 `App.kt` 路由块，也不做选项 (a) 的路由瘦身：

- `ui/digest/DigestPage.kt` → `core/DigestPage.kt`：类、`hnDiscussionUrl`、三个 `toDigestPage()` 转换器**原样平移，仅改包名**；测试镜像移动到 `commonTest/.../core/`
- `Route` 改 `sealed interface`，`entryProvider` 的 `when` 拿到编译期穷尽检查，删掉 `App.kt` 的 `else -> error("Unknown route")` 运行时兜底
- 顺带收益：新增路由漏接 `entryProvider` 从运行时 crash 变为编译错误（与 #105「忘埋点变编译错误」同一思路的补全）
- 清理两处解释该例外的过时 KDoc（`Route.kt` 的「不用 sealed」段、`Hiring` 的「DigestPage 是被迫例外」段）

## 为什么不瘦身路由（issue 选项 a）

backStack 是普通 `remember { mutableStateListOf }`，胖 key 没有序列化成本；瘦身后头部零等待渲染要靠新的旁路传递机制，在栈内多个 DigestPage 条目等场景下反而更脆。胖是功能不是病，`RepoDetail(owner, repo)` 本就是同一模式的小号版。

## 验收对照（issue 的 5 条）

1. ✅ `Route` 已 sealed，`when` 穷尽检查生效
2. ✅ `else` 兜底与 `Route.kt` 相关 KDoc 已删
3. ✅ 头部零等待渲染不受影响——9 个展示字段原样保留
4. ✅ 三个 `toDigestPage()` 调用点写法零变化（仅 import 行变动）
5. ✅ `DigestPageTest` 3 用例（含 `Sourcery审查回归` 那个存量 externalId 兼容用例）通过；`:shared:allTests`（Android host + iOS simulator）+ `:shared:compileKotlinIosArm64` 全绿

收藏同一性（url 主键 + source/externalId 云同步键）与存量合成键兼容逻辑一行未动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYs6wiBnhb7mvWUqPgq1fv

## Sourcery 总结

将 DigestPage 移至核心导航包，并确保路由处理在编译时进行穷举检查。

改进：
- 将 DigestPage 及其转换工具移至核心包，使所有 Route 实现共享相同的包边界。
- 将 Route 设为 sealed，并依赖编译时的穷举导航处理，而不是运行时回退。
- 移除将 DigestPage 描述为包级例外的过时文档。

测试：
- 将 DigestPage 测试移至核心包，同时保留对现有转换行为的覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move DigestPage into the core navigation package and make route handling exhaustively checked at compile time.

Enhancements:
- Move DigestPage and its conversion utilities into the core package so all Route implementations share the same package boundary.
- Make Route sealed and rely on exhaustive navigation handling at compile time instead of a runtime fallback.
- Remove outdated documentation describing DigestPage as a package-level exception.

Tests:
- Relocate DigestPage tests to the core package while preserving coverage of existing conversion behavior.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved navigation route handling and removed obsolete fallback behavior.
  * Consolidated digest-related functionality into the core application layer.
  * Updated feed, favorites, picks, home, hiring, and digest screens to use the reorganized navigation components.
  * Improved route definition handling for more predictable navigation behavior.

* **Tests**
  * Updated digest tests to reflect the reorganized application structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->