### PR TITLE
feat(chat): 图片张数与压缩预算随服务端配置，默认 9 张

### DIFF
--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -197,7 +197,7 @@ class ChatViewModel(
     /** 追加一张已压缩好的待发图片（本地缓存路径），超过单条上限时忽略。 */
     fun addPendingImage(path: String) {
         _uiState.update {
-            if (it.pendingImages.size >= MAX_IMAGES_PER_MESSAGE || path in it.pendingImages) it
+            if (it.pendingImages.size >= maxImagesPerMessage() || path in it.pendingImages) it
             else it.copy(pendingImages = it.pendingImages + path)
         }
     }
@@ -688,8 +688,8 @@ class ChatViewModel(
     }
 
     companion object {
-        /** 单条消息图片数上限，与服务端及 [whl.trending.chat.engine.ChatWire] 对齐 */
-        const val MAX_IMAGES_PER_MESSAGE = 4
+        /** 单条消息图片数上限：服务端 app-config 下发（KV 单源），未拉到用与服务端一致的默认 */
+        fun maxImagesPerMessage(): Int = globalSettingsManager.chatImagesMaxCount()
 
         /** research 轮询节奏：快轮 8s×90（≈12 分钟）覆盖正常任务时长，慢轮 60s×110（≈110 分钟）
          *  盖过服务端 2h 超龄判死闸——每个任务都能等到服务端终态，不留僵尸占位 */

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/attach/ChatImages.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/attach/ChatImages.kt
@@ -11,6 +11,7 @@ import androidx.exifinterface.media.ExifInterface
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.UUID
+import whl.trending.ai.data.local.globalSettingsManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -21,15 +22,14 @@ import kotlinx.coroutines.withContext
  * → 按 EXIF Orientation 旋正像素 → 长边缩至 ≤[MAX_EDGE] → JPEG 重编码写入私有缓存。
  * 重编码产物不含任何 EXIF（GPS/时间/设备随之剥除）；Orientation 是唯一先消费再丢弃的字段。
  *
- * 单张产物必须 ≤[MAX_JPEG_BYTES]：质量沿 [QUALITY_LADDER] 递降直到达标。预算按服务端
- * 总闸（1.5MB base64）摊到单条消息图片数上限（ChatWire.MAX_IMAGES_PER_MESSAGE）得出——
- * 文字密集的书页/截图在固定 q80 下可达 400KB/张，攒满 4 张会撞闸。
+ * 单张产物必须不超预算（app-config 下发，服务端 KV 单源；未拉到用与服务端一致的默认）：
+ * 质量沿 [QUALITY_LADDER] 递降直到达标。预算 = 服务端图片总闸摊到单条消息张数上限——
+ * 文字密集的书页/截图在固定 q80 下可达 400KB/张，攒满一条消息会撞闸。
  */
 object ChatImages {
 
     private const val TAG = "ChatImages"
     private const val MAX_EDGE = 1568
-    private const val MAX_JPEG_BYTES = 280 * 1024
     private val QUALITY_LADDER = intArrayOf(80, 65, 50)
     private const val DIR = "chat_images"
     private const val MAX_AGE_MS = 24 * 60 * 60 * 1000L
@@ -72,13 +72,14 @@ object ChatImages {
             val upright = applyOrientation(decoded, orientation)
             val scaled = scaleDown(upright)
 
-            // 阶梯走完仍超预算时用最低档结果兜底（1568px q50 实际到不了 280KB，防御性）
+            // 阶梯走完仍超预算时用最低档结果兜底（1568px q50 实际到不了默认 280KB，防御性）
+            val budgetBytes = globalSettingsManager.chatImagesPerImageJpegKb() * 1024
             var bytes: ByteArray? = null
             for (quality in QUALITY_LADDER) {
                 val buf = ByteArrayOutputStream()
                 scaled.compress(Bitmap.CompressFormat.JPEG, quality, buf)
                 bytes = buf.toByteArray()
-                if (bytes.size <= MAX_JPEG_BYTES) break
+                if (bytes.size <= budgetBytes) break
             }
             val out = File(imageDir(context), "${UUID.randomUUID()}.jpg")
             out.writeBytes(bytes!!)

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/attach/ChatImages.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/attach/ChatImages.kt
@@ -7,6 +7,7 @@ import android.graphics.Matrix
 import android.net.Uri
 import android.util.Log
 import androidx.core.content.FileProvider
+import androidx.core.graphics.scale
 import androidx.exifinterface.media.ExifInterface
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -133,11 +134,9 @@ object ChatImages {
         val edge = maxOf(bitmap.width, bitmap.height)
         if (edge <= MAX_EDGE) return bitmap
         val ratio = MAX_EDGE.toFloat() / edge
-        return Bitmap.createScaledBitmap(
-            bitmap,
+        return bitmap.scale(
             (bitmap.width * ratio).toInt().coerceAtLeast(1),
             (bitmap.height * ratio).toInt().coerceAtLeast(1),
-            true,
         )
     }
 }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -37,6 +37,7 @@ import whl.trending.ai.data.model.resolveEffectiveChatModel
 import whl.trending.ai.data.remote.installTrendingAuth
 import whl.trending.ai.data.remote.trackAuthTokenCache
 import whl.trending.ai.data.repository.ChatModelsProvider
+import whl.trending.chat.ChatViewModel
 import whl.trending.chat.model.ChatError
 import whl.trending.chat.model.ChatErrorCategory
 import whl.trending.chat.model.ChatMessage
@@ -152,6 +153,7 @@ class ChatApi(
     ): String {
         val lang = resolveLang()
         val imagePlaceholder = if (lang == "zh") "[图片]" else "[image]"
+        val maxImages = ChatViewModel.maxImagesPerMessage()
         return executeStreaming(path = "chat", onDelta = onDelta, onSearch = onSearch) {
             setBody(
                 ChatRequest(
@@ -162,6 +164,7 @@ class ChatApi(
                                 message = m,
                                 isLast = index == history.lastIndex,
                                 imagePlaceholder = imagePlaceholder,
+                                maxImages = maxImages,
                                 readImageBytes = { path ->
                                     runCatching { File(path).readBytes() }.getOrNull()
                                 },

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatWire.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/engine/ChatWire.kt
@@ -22,13 +22,11 @@ import whl.trending.chat.model.Role
  */
 internal object ChatWire {
 
-    /** 单条消息图片数上限，与服务端 MAX_IMAGES_PER_MSG 对齐 */
-    const val MAX_IMAGES_PER_MESSAGE = 4
-
     fun buildContent(
         message: ChatMessage,
         isLast: Boolean,
         imagePlaceholder: String,
+        maxImages: Int,
         readImageBytes: (String) -> ByteArray?,
     ): JsonElement {
         if (message.images.isEmpty()) return JsonPrimitive(message.content)
@@ -49,7 +47,7 @@ internal object ChatWire {
                 )
             }
             var encoded = 0
-            for (path in message.images.take(MAX_IMAGES_PER_MESSAGE)) {
+            for (path in message.images.take(maxImages)) {
                 val bytes = readImageBytes(path) ?: continue
                 add(
                     buildJsonObject {

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatInputBar.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatInputBar.kt
@@ -121,7 +121,8 @@ fun ChatInputBar(
     var captureTarget by remember { mutableStateOf<Pair<Uri, File>?>(null) }
 
     val failedText = stringResource(R.string.chat_image_processing_failed)
-    val remaining = ChatViewModel.MAX_IMAGES_PER_MESSAGE - pendingImages.size - processingCount
+    val maxImages = remember { ChatViewModel.maxImagesPerMessage() }
+    val remaining = maxImages - pendingImages.size - processingCount
 
     fun ingest(uri: Uri, deleteAfter: File? = null) {
         processingCount++
@@ -138,7 +139,8 @@ fun ChatInputBar(
     }
 
     val albumLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.PickMultipleVisualMedia(ChatViewModel.MAX_IMAGES_PER_MESSAGE),
+        // PickMultipleVisualMedia 要求 maxItems > 1，配置极端收紧到 1 时也不能让它抛
+        ActivityResultContracts.PickMultipleVisualMedia(maxImages.coerceAtLeast(2)),
     ) { uris ->
         // 选择器允许选满上限，剩余名额不足时截断
         uris.take(remaining.coerceAtLeast(0)).forEach { ingest(it) }

--- a/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatInputBar.kt
+++ b/androidLibrary/chat/src/main/kotlin/whl/trending/chat/ui/ChatInputBar.kt
@@ -121,7 +121,7 @@ fun ChatInputBar(
     var captureTarget by remember { mutableStateOf<Pair<Uri, File>?>(null) }
 
     val failedText = stringResource(R.string.chat_image_processing_failed)
-    val maxImages = remember { ChatViewModel.maxImagesPerMessage() }
+    val maxImages = ChatViewModel.maxImagesPerMessage()
     val remaining = maxImages - pendingImages.size - processingCount
 
     fun ingest(uri: Uri, deleteAfter: File? = null) {

--- a/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatWireTest.kt
+++ b/androidLibrary/chat/src/test/kotlin/whl/trending/chat/engine/ChatWireTest.kt
@@ -22,7 +22,7 @@ class ChatWireTest {
 
     @Test
     fun `纯文本消息 content 仍是 JSON string`() {
-        val element = ChatWire.buildContent(user(1, "hi"), isLast = true, imagePlaceholder = "[图片]", readImageBytes = reader)
+        val element = ChatWire.buildContent(user(1, "hi"), isLast = true, imagePlaceholder = "[图片]", maxImages = 4, readImageBytes = reader)
         assertEquals(JsonPrimitive("hi"), element)
     }
 
@@ -31,7 +31,7 @@ class ChatWireTest {
         val element = ChatWire.buildContent(
             user(1, "这是什么", images = listOf("ok1.jpg", "ok2.jpg")),
             isLast = true,
-            imagePlaceholder = "[图片]",
+            imagePlaceholder = "[图片]", maxImages = 4,
             readImageBytes = reader,
         )
         val parts = element.jsonArray
@@ -50,7 +50,7 @@ class ChatWireTest {
         val element = ChatWire.buildContent(
             user(1, "", images = listOf("ok1.jpg")),
             isLast = true,
-            imagePlaceholder = "[图片]",
+            imagePlaceholder = "[图片]", maxImages = 4,
             readImageBytes = reader,
         )
         val parts = element.jsonArray
@@ -63,7 +63,7 @@ class ChatWireTest {
         val element = ChatWire.buildContent(
             user(1, "看这张", images = listOf("ok1.jpg", "ok2.jpg")),
             isLast = false,
-            imagePlaceholder = "[图片]",
+            imagePlaceholder = "[图片]", maxImages = 4,
             readImageBytes = reader,
         )
         assertEquals(JsonPrimitive("看这张 [图片][图片]"), element)
@@ -74,7 +74,7 @@ class ChatWireTest {
         val element = ChatWire.buildContent(
             user(1, "", images = listOf("ok1.jpg")),
             isLast = false,
-            imagePlaceholder = "[image]",
+            imagePlaceholder = "[image]", maxImages = 4,
             readImageBytes = reader,
         )
         assertEquals(JsonPrimitive("[image]"), element)
@@ -85,7 +85,7 @@ class ChatWireTest {
         val element = ChatWire.buildContent(
             user(1, "hi", images = listOf("missing.jpg", "ok1.jpg")),
             isLast = true,
-            imagePlaceholder = "[图片]",
+            imagePlaceholder = "[图片]", maxImages = 4,
             readImageBytes = reader,
         )
         val parts = element.jsonArray
@@ -97,7 +97,7 @@ class ChatWireTest {
         val element = ChatWire.buildContent(
             user(1, "", images = listOf("missing.jpg")),
             isLast = true,
-            imagePlaceholder = "[图片]",
+            imagePlaceholder = "[图片]", maxImages = 4,
             readImageBytes = reader,
         )
         val parts = element.jsonArray
@@ -111,7 +111,7 @@ class ChatWireTest {
         val element = ChatWire.buildContent(
             user(1, "", images = List(6) { "ok$it.jpg" }),
             isLast = true,
-            imagePlaceholder = "[图片]",
+            imagePlaceholder = "[图片]", maxImages = 4,
             readImageBytes = reader,
         )
         assertTrue(element is JsonArray)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -368,16 +368,16 @@ class SettingsManager(private val settings: ObservableSettings) {
         else settings.putString(MIN_VERSION_KEY, version)
     }
 
-    // chat 图片参数：app-config 下发缓存，未拉到用与服务端一致的内置默认；
-    // 读取时 clamp，异常缓存值不外泄（区间与服务端 lib/chat-images.js 一致）
+    // chat 图片参数：app-config 下发缓存（服务端单源见后端 lib/chat-images.js），
+    // 未拉到或值非法时用与服务端一致的内置默认
 
     /** 单条消息图片张数上限 */
     fun chatImagesMaxCount(): Int =
-        settings.getInt(CHAT_IMAGES_MAX_KEY, 9).coerceIn(1, 12)
+        settings.getInt(CHAT_IMAGES_MAX_KEY, 9).takeIf { it > 0 } ?: 9
 
     /** 单张图片压缩预算（KB，JPEG 字节） */
     fun chatImagesPerImageJpegKb(): Int =
-        settings.getInt(CHAT_IMAGES_PER_KB_KEY, 280).coerceIn(64, 375)
+        settings.getInt(CHAT_IMAGES_PER_KB_KEY, 280).takeIf { it > 0 } ?: 280
 
     fun setChatImagesConfig(maxCount: Int?, perImageJpegKb: Int?) {
         if (maxCount != null) settings.putInt(CHAT_IMAGES_MAX_KEY, maxCount)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -151,6 +151,8 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val OPEN_LINKS_IN_CUSTOM_TAB_KEY = "prefs_open_links_in_custom_tab"
     private val TRENDING_NEW_ONLY_DEFAULT_KEY = "prefs_trending_new_only_default"
     private val MIN_VERSION_KEY = "prefs_min_version"
+    private val CHAT_IMAGES_MAX_KEY = "prefs_chat_images_max"
+    private val CHAT_IMAGES_PER_KB_KEY = "prefs_chat_images_per_kb"
     private val DAILY_PICKS_NOTIFICATION_KEY = "prefs_daily_picks_notification"
     private val PICKS_NEWSLETTER_BANNER_DISMISSED_KEY = "prefs_picks_newsletter_banner_dismissed"
     private val DEFAULT_HOME_TAB_KEY = "prefs_default_home_tab"
@@ -364,6 +366,22 @@ class SettingsManager(private val settings: ObservableSettings) {
     fun setCachedMinVersion(version: String?) {
         if (version == null) settings.remove(MIN_VERSION_KEY)
         else settings.putString(MIN_VERSION_KEY, version)
+    }
+
+    // chat 图片参数：app-config 下发缓存，未拉到用与服务端一致的内置默认；
+    // 读取时 clamp，异常缓存值不外泄（区间与服务端 lib/chat-images.js 一致）
+
+    /** 单条消息图片张数上限 */
+    fun chatImagesMaxCount(): Int =
+        settings.getInt(CHAT_IMAGES_MAX_KEY, 9).coerceIn(1, 12)
+
+    /** 单张图片压缩预算（KB，JPEG 字节） */
+    fun chatImagesPerImageJpegKb(): Int =
+        settings.getInt(CHAT_IMAGES_PER_KB_KEY, 280).coerceIn(64, 375)
+
+    fun setChatImagesConfig(maxCount: Int?, perImageJpegKb: Int?) {
+        if (maxCount != null) settings.putInt(CHAT_IMAGES_MAX_KEY, maxCount)
+        if (perImageJpegKb != null) settings.putInt(CHAT_IMAGES_PER_KB_KEY, perImageJpegKb)
     }
 
     /** 最近一次看过更新说明的版本号；null 表示首次安装（从未记录） */

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/AppConfigResponse.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/AppConfigResponse.kt
@@ -10,4 +10,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AppConfigResponse(
     @SerialName("min_version") val minVersion: String? = null,
+    @SerialName("chat_images") val chatImages: ChatImagesRemoteConfig? = null,
+)
+
+/** chat 图片参数（服务端 KV 单源下发，与服务端校验闸同值；见后端 lib/chat-images.js） */
+@Serializable
+data class ChatImagesRemoteConfig(
+    @SerialName("max_count") val maxCount: Int? = null,
+    @SerialName("per_image_jpeg_kb") val perImageJpegKb: Int? = null,
 )

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/ForceUpdateGate.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/ForceUpdateGate.kt
@@ -36,14 +36,14 @@ import whl.trending.ai.core.analytics.track
 import whl.trending.ai.core.platform.getAppVersion
 import whl.trending.ai.core.platform.openUrl
 import whl.trending.ai.data.local.globalSettingsManager
-import whl.trending.ai.data.remote.TrendingApi
 import whl.trending.ai.update.isVersionBlocked
+import whl.trending.ai.update.refreshAppConfig
 
 /**
  * 强制更新门：当前版本低于服务端下发的 min_version 时，整屏替换主界面，
  * 引导用户去官方渠道更新（应对第三方镜像站收录的老包）。
  *
- * - 冷启动拉取 /api/app-config，成功即缓存；失败静默（接口未上线/断网不影响使用）。
+ * - 冷启动经 [refreshAppConfig] 拉取 app-config（各字段的缓存落地在彼处），本组件只消费 min_version。
  * - 初始态用缓存判定，保证强更一旦下发、离线重启也拦得住。
  * - 整屏替换而非弹窗：没有 dismiss 语义可绕过，也天然避免与 What's New 双弹窗叠加。
  */
@@ -53,17 +53,7 @@ fun ForceUpdateGate(content: @Composable () -> Unit) {
     var minVersion by remember { mutableStateOf(globalSettingsManager.getCachedMinVersion()) }
 
     LaunchedEffect(Unit) {
-        runCatching { TrendingApi().fetchAppConfig() }.onSuccess { config ->
-            globalSettingsManager.setCachedMinVersion(config.minVersion)
-            globalSettingsManager.setChatImagesConfig(
-                config.chatImages?.maxCount,
-                config.chatImages?.perImageJpegKb,
-            )
-            minVersion = config.minVersion
-        }.onFailure {
-            // fail-open：接口未上线（404）/断网都不影响使用，仅留日志便于排查服务端误配置
-            println("ForceUpdateGate: fetchAppConfig failed: $it")
-        }
+        refreshAppConfig()?.let { minVersion = it.minVersion }
     }
 
     if (isVersionBlocked(current, minVersion)) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/ForceUpdateGate.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/ForceUpdateGate.kt
@@ -55,6 +55,10 @@ fun ForceUpdateGate(content: @Composable () -> Unit) {
     LaunchedEffect(Unit) {
         runCatching { TrendingApi().fetchAppConfig() }.onSuccess { config ->
             globalSettingsManager.setCachedMinVersion(config.minVersion)
+            globalSettingsManager.setChatImagesConfig(
+                config.chatImages?.maxCount,
+                config.chatImages?.perImageJpegKb,
+            )
             minVersion = config.minVersion
         }.onFailure {
             // fail-open：接口未上线（404）/断网都不影响使用，仅留日志便于排查服务端误配置

--- a/shared/src/commonMain/kotlin/whl/trending/ai/update/AppConfigSync.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/update/AppConfigSync.kt
@@ -1,5 +1,6 @@
 package whl.trending.ai.update
 
+import kotlin.coroutines.cancellation.CancellationException
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.AppConfigResponse
 import whl.trending.ai.data.remote.TrendingApi
@@ -10,13 +11,17 @@ import whl.trending.ai.data.remote.TrendingApi
  * app-config 新增字段的缓存落地写在这里。
  */
 suspend fun refreshAppConfig(): AppConfigResponse? =
-    runCatching { TrendingApi().fetchAppConfig() }
-        .onSuccess { config ->
-            globalSettingsManager.setCachedMinVersion(config.minVersion)
-            globalSettingsManager.setChatImagesConfig(
-                config.chatImages?.maxCount,
-                config.chatImages?.perImageJpegKb,
-            )
-        }
-        .onFailure { println("refreshAppConfig failed: $it") }
-        .getOrNull()
+    try {
+        val config = TrendingApi().fetchAppConfig()
+        globalSettingsManager.setCachedMinVersion(config.minVersion)
+        globalSettingsManager.setChatImagesConfig(
+            config.chatImages?.maxCount,
+            config.chatImages?.perImageJpegKb,
+        )
+        config
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        println("refreshAppConfig failed: $e")
+        null
+    }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/update/AppConfigSync.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/update/AppConfigSync.kt
@@ -1,0 +1,22 @@
+package whl.trending.ai.update
+
+import whl.trending.ai.data.local.globalSettingsManager
+import whl.trending.ai.data.model.AppConfigResponse
+import whl.trending.ai.data.remote.TrendingApi
+
+/**
+ * 拉取 /api/app-config 并把各字段落进本地缓存，返回响应供调用方消费；
+ * 失败返回 null——fail-open，接口未上线（404）/断网都不影响使用，调用方以缓存兜底。
+ * app-config 新增字段的缓存落地写在这里。
+ */
+suspend fun refreshAppConfig(): AppConfigResponse? =
+    runCatching { TrendingApi().fetchAppConfig() }
+        .onSuccess { config ->
+            globalSettingsManager.setCachedMinVersion(config.minVersion)
+            globalSettingsManager.setChatImagesConfig(
+                config.chatImages?.maxCount,
+                config.chatImages?.perImageJpegKb,
+            )
+        }
+        .onFailure { println("refreshAppConfig failed: $it") }
+        .getOrNull()


### PR DESCRIPTION
## 背景

配套服务端 HarlonWang/github-ai-trending-api#45：图片张数上限 4→9，参数收敛到服务端 KV 单源，客户端预检参数改为 app-config 下发、内置默认兜底。

## 改动

- `AppConfigResponse` 新增 `chat_images`（`max_count` / `per_image_jpeg_kb`），`ForceUpdateGate` 冷启拉取成功时缓存进 `SettingsManager`（读取 clamp 1..12 / 64..375，与服务端一致）
- 四个消费点改读配置，未拉到用内置默认 9 张 / 280KB：
  - `ChatViewModel.maxImagesPerMessage()`（原 const 改函数）——入列闸
  - `ChatInputBar`——剩余名额与 Photo Picker（`coerceAtLeast(2)`：PickMultipleVisualMedia 要求 maxItems > 1）
  - `ChatWire.buildContent` 参数化 `maxImages`，保持纯函数（测试传定值）
  - `ChatImages` 单张压缩预算改读 `per_image_jpeg_kb`

## 发布顺序

服务端 PR 先合并部署（闸放宽对老客户端无感），本 PR 后发版。

## 验证

chat 模块编译 + 单测、shared 单测、androidApp 编译通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MgpTykzswR9nfyr3c3spc

## Sourcery 总结

让聊天图片数量限制和压缩预算遵循服务器配置，并在客户端配置不可用时使用安全的默认值。

新功能：
- 支持由服务器配置聊天图片数量限制和单张图片 JPEG 压缩预算；当配置不可用时，默认限制为 9 张图片和 280 KB。

改进：
- 在图片选择、待处理图片验证和外发消息序列化过程中统一应用已配置的图片数量限制。
- 缓存并限制从应用配置中接收的聊天图片设置，同时在配置获取失败时保持安全行为。

测试：
- 更新 ChatWire 测试以提供明确的图片数量限制，同时保留纯函数覆盖范围。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

使聊天图片数量限制和压缩预算遵循服务器配置，并在配置不可用时使用安全的客户端默认值。

新功能：
- 支持由服务器配置聊天图片数量限制和每张图片的 JPEG 压缩预算；配置不可用时，默认限制为 9 张图片和 280 KB。

增强功能：
- 在图片选择、待处理图片验证、压缩和传出消息序列化过程中，始终应用已配置的图片限制。
- 缓存并验证通过应用配置接收的聊天图片设置，同时保留安全的回退行为。

测试：
- 更新 ChatWire 测试以传入明确的图片限制，同时保留纯函数覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使聊天图片数量限制和压缩预算遵循服务器配置，并在客户端配置不可用时使用安全的默认值。

新功能：
- 支持服务器提供的聊天图片数量限制和每张图片的 JPEG 压缩预算；在配置不可用时，默认使用 9 张图片和 280 KB。

增强功能：
- 在图片选择、待处理图片验证、压缩和消息序列化过程中，统一应用已配置的图片限制。
- 集中刷新应用配置，并缓存经过验证的聊天图片设置，以便在离线或发生故障时安全回退。

测试：
- 更新 ChatWire 测试以传入明确的图片限制，同时保留纯函数覆盖范围。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

使聊天图片数量限制和压缩预算遵循服务器配置，并在客户端配置不可用时使用安全的默认值。

新功能：
- 支持服务器提供的聊天图片数量限制和每张图片的 JPEG 压缩预算；在配置不可用时，默认限制为 9 张图片和 280 KB。

改进：
- 在选择、排队、压缩和序列化聊天图片时，统一应用配置的图片数量限制。
- 集中处理应用配置刷新，并缓存经过验证的聊天图片设置，以便在离线和请求失败时回退使用。

测试：
- 更新 ChatWire 测试以传入明确的图片数量限制，同时保留纯函数覆盖范围。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make chat image limits and compression budgets follow server configuration with safe client-side defaults.

New Features:
- Support server-provided chat image count limits and per-image JPEG compression budgets, with defaults of 9 images and 280 KB when unavailable.

Enhancements:
- Apply the configured image limit consistently when selecting, queuing, compressing, and serializing chat images.
- Centralize app-config refreshing and cache validated chat image settings for offline and failed-request fallback behavior.

Tests:
- Update ChatWire tests to pass an explicit image limit while preserving pure-function coverage.

</details>

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat image limits can now be configured through server-provided settings.
  * Added configurable maximum images per message and per-image JPEG size limits.
  * Settings are stored locally with safe fallback values when unavailable.
  * Configuration refreshes automatically while preserving cached settings when updates fail.

* **Bug Fixes**
  * Image selection, encoding, and message validation now consistently respect configured limits.
  * Improved handling when the configured image limit is one or lower.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->