### PR TITLE
refactor(chat): VM/Store 收拢并发与真相源——串行变更、单一 id 空间、错误落库

### DIFF
--- a/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
+++ b/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
@@ -1,8 +1,10 @@
 package whl.trending.chat
 
+import androidx.lifecycle.viewModelScope
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -15,17 +17,19 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import whl.trending.chat.ChatContext
 import whl.trending.chat.engine.ChatEngine
 import whl.trending.chat.engine.ChatException
 import whl.trending.chat.engine.DetailSummaryResult
 import whl.trending.chat.db.ChatDatabase
+import whl.trending.chat.host.ChatAiEvent
+import whl.trending.chat.host.ChatAiKind
+import whl.trending.chat.host.ChatAiOutcome
 import whl.trending.chat.model.ChatError
 import whl.trending.chat.model.ChatModelsResponse
 import whl.trending.chat.model.ChatErrorCategory
 import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.Role
-import whl.trending.chat.store.ChatStore
+import whl.trending.chat.store.RoomChatStore
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -33,8 +37,9 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * VM × 持久化联动：懒建落库 / 终局一次写 / 入口恢复 / 会话切换 / 后台流完成落库。
- * 真 ChatStore + 内存 Room（Robolectric，sdk 钉 35 同前）；引擎为可编程假实现。
+ * VM × 持久化联动：懒建落库 / 终局一次写（成功全文、失败错误行）/ 会话切换取消在途流 /
+ * 入口即新会话 / research 占位与跨进程恢复。
+ * 真 RoomChatStore + 内存 Room（Robolectric，sdk 钉 35 同前）；引擎为可编程假实现。
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [35])
@@ -43,7 +48,7 @@ class ChatViewModelPersistenceTest {
     private val dispatcher = StandardTestDispatcher()
     private lateinit var db: ChatDatabase
     private lateinit var imagesDir: File
-    private lateinit var store: ChatStore
+    private lateinit var store: RoomChatStore
 
     private val repoContext = ChatContext(
         title = "octo/demo", source = "github", externalId = "octo/demo", readmeLength = 5000,
@@ -87,7 +92,7 @@ class ChatViewModelPersistenceTest {
             .allowMainThreadQueries()
             .build()
         imagesDir = File.createTempFile("imgs", null).apply { delete(); mkdirs() }
-        store = ChatStore(db, imagesDir.absolutePath, clock = { 1000L })
+        store = RoomChatStore(db, imagesDir.absolutePath, clock = { 1000L })
     }
 
     @After
@@ -98,9 +103,12 @@ class ChatViewModelPersistenceTest {
     }
 
     /** 构造并执行入口进入（Screen 的 enterEntry 时序在测试里显式驱动） */
-    private fun vm(engine: ChatEngine, context: ChatContext? = null) =
-        ChatViewModel(engine, context, store = store, loadModels = { ChatModelsResponse() }, track = {}, selectedModelId = { "gpt-5.5" })
-            .also { it.enterEntry(context) }
+    private fun vm(
+        engine: ChatEngine,
+        context: ChatContext? = null,
+        track: (ChatAiEvent) -> Unit = {},
+    ) = ChatViewModel(engine, context, store = store, loadModels = { ChatModelsResponse() }, track = track, selectedModelId = { "gpt-5.5" })
+        .also { it.enterEntry(context) }
 
     @Test
     fun `首条发送懒建线程，user 与 assistant 终局各落一行，model 记录在案`() = runTest(dispatcher) {
@@ -120,33 +128,40 @@ class ChatViewModelPersistenceTest {
     }
 
     @Test
-    fun `失败回复不落库，user 消息保留`() = runTest(dispatcher) {
+    fun `失败回复落错误行：重启后仍可见可重试`() = runTest(dispatcher) {
         val v = vm(GatedEngine(failWith = ChatError(ChatErrorCategory.NETWORK)))
         advanceUntilIdle()
         v.updateInput("hi")
         v.send()
         advanceUntilIdle()
 
-        val threads = store.threads().first()
-        val rows = db.messageDao().messagesFor(threads[0].id)
-        assertEquals(listOf("user"), rows.map { it.role })
         // UI 上错误条可见可重试
         assertNotNull(v.uiState.value.messages.last().error)
+
+        // 落库往返：错误行随会话持久化
+        val threads = store.threads().first()
+        val loaded = store.loadMessages(threads[0].id)
+        assertEquals(listOf(Role.USER, Role.ASSISTANT), loaded.map { it.role })
+        assertEquals(ChatErrorCategory.NETWORK, loaded.last().error?.category)
     }
 
     @Test
-    fun `入口恢复：同 repo 再次构造 VM 载入历史消息`() = runTest(dispatcher) {
+    fun `repo 入口不恢复历史：再次进入是新会话，历史在抽屉可切回`() = runTest(dispatcher) {
         val first = vm(GatedEngine(reply = "答一"), repoContext)
         advanceUntilIdle()
         first.updateInput("问一")
         first.send()
         advanceUntilIdle()
+        val threadId = store.threads().first()[0].id
 
         val second = vm(GatedEngine(), repoContext)
         advanceUntilIdle()
-        val restored = second.uiState.value.messages
-        assertEquals(listOf("问一", "答一"), restored.map { it.content })
-        assertEquals(listOf(Role.USER, Role.ASSISTANT), restored.map { it.role })
+        assertTrue(second.uiState.value.messages.isEmpty())
+        assertNull(second.currentThreadId.value)
+
+        second.switchThread(threadId)
+        advanceUntilIdle()
+        assertEquals(listOf("问一", "答一"), second.uiState.value.messages.map { it.content })
     }
 
     @Test
@@ -158,6 +173,7 @@ class ChatViewModelPersistenceTest {
         advanceUntilIdle()
 
         v.startNewThread()
+        advanceUntilIdle()
         assertTrue(v.uiState.value.messages.isEmpty())
         v.updateInput("第二线")
         v.send()
@@ -167,7 +183,7 @@ class ChatViewModelPersistenceTest {
     }
 
     @Test
-    fun `switchThread 载入目标线程消息与 id 续位`() = runTest(dispatcher) {
+    fun `switchThread 载入目标线程消息与 context`() = runTest(dispatcher) {
         val v = vm(GatedEngine(reply = "答A"), repoContext)
         advanceUntilIdle()
         v.updateInput("问A")
@@ -176,6 +192,7 @@ class ChatViewModelPersistenceTest {
         val threadA = store.threads().first()[0].id
 
         v.startNewThread()
+        advanceUntilIdle()
         v.updateInput("问B")
         v.send()
         advanceUntilIdle()
@@ -186,31 +203,48 @@ class ChatViewModelPersistenceTest {
     }
 
     @Test
-    fun `切换会话时后台流继续完成并落库，切回可见全文`() = runTest(dispatcher) {
+    fun `切换会话取消在途流：原会话落中断错误行，切回可重试`() = runTest(dispatcher) {
         val gate = kotlinx.coroutines.CompletableDeferred<Unit>()
         val v = vm(GatedEngine(reply = "慢答案", gate = gate), repoContext)
         advanceUntilIdle()
         v.updateInput("慢问题")
         v.send()
-        advanceUntilIdle() // 流启动，卡在 gate
+        testScheduler.runCurrent() // 流启动，卡在 gate
         val threadA = store.threads().first()[0].id
         assertTrue(v.uiState.value.isSending)
 
-        v.startNewThread() // 切走：A 的流在后台继续
+        v.startNewThread() // 切走：在途流取消，已渲染部分丢弃
+        advanceUntilIdle()
         assertEquals(false, v.uiState.value.isSending)
 
-        gate.complete(Unit)
-        advanceUntilIdle()
+        // A 落了中断错误行（user + 错误 assistant），没有幽灵全文
+        val rows = store.loadMessages(threadA)
+        assertEquals(listOf(Role.USER, Role.ASSISTANT), rows.map { it.role })
+        assertEquals(ChatError.CODE_STREAM_INTERRUPTED, rows.last().error?.code)
 
-        // A 已终局落库
-        val rows = db.messageDao().messagesFor(threadA)
-        assertEquals(listOf("user", "assistant"), rows.map { it.role })
-        assertEquals("慢答案", rows[1].content)
-
-        // 切回 A 看到全文
+        // 切回 A 看到可重试的中断条
         v.switchThread(threadA)
         advanceUntilIdle()
-        assertEquals("慢答案", v.uiState.value.messages.last().content)
+        assertNotNull(v.uiState.value.messages.last().error)
+        assertTrue(v.uiState.value.messages.last().error!!.category.retryable)
+    }
+
+    @Test
+    fun `取消在途流补 interrupted 终态：与 requested 成对`() = runTest(dispatcher) {
+        val events = mutableListOf<ChatAiEvent>()
+        val gate = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val v = vm(GatedEngine(gate = gate), track = { events.add(it) })
+        advanceUntilIdle()
+        v.updateInput("hi")
+        v.send()
+        testScheduler.runCurrent()
+
+        v.startNewThread()
+        advanceUntilIdle()
+
+        assertEquals(1, events.filterIsInstance<ChatAiEvent.Requested>().size)
+        val completed = events.filterIsInstance<ChatAiEvent.Completed>()
+        assertEquals(listOf(ChatAiOutcome.INTERRUPTED to "canceled"), completed.map { it.outcome to it.reason })
     }
 
     @Test
@@ -234,6 +268,7 @@ class ChatViewModelPersistenceTest {
     /** 带搜索事件的假引擎 */
     private class SearchEngine(var reply: String = "答案") : ChatEngine {
         var lastSearchFlag = false
+        var lastHistory: List<ChatMessage>? = null
         override suspend fun send(
             history: List<ChatMessage>,
             context: ChatContext?,
@@ -242,6 +277,7 @@ class ChatViewModelPersistenceTest {
             onSearch: (whl.trending.chat.model.SearchEvent) -> Unit,
         ): String {
             lastSearchFlag = search
+            lastHistory = history
             if (search) {
                 onSearch(whl.trending.chat.model.SearchEvent.Started)
                 onSearch(whl.trending.chat.model.SearchEvent.Done("q"))
@@ -355,7 +391,7 @@ class ChatViewModelPersistenceTest {
     }
 
     @Test
-    fun `research 失败→删占位行→错误条可见`() = runTest(dispatcher) {
+    fun `research 失败→占位行转错误行落库（runId 置空，不再触发恢复轮询）`() = runTest(dispatcher) {
         val engine = ResearchEngine(mutableListOf(
             whl.trending.chat.model.ResearchRun("run-77", "failed", null, "failed"),
         ))
@@ -368,13 +404,15 @@ class ChatViewModelPersistenceTest {
 
         assertNotNull(v.uiState.value.messages.last().error)
         val threadId = store.threads().first()[0].id
-        val rows = db.messageDao().messagesFor(threadId)
-        // 占位行已删，只剩 user 消息
-        assertEquals(listOf("user"), rows.map { it.role })
+        val loaded = store.loadMessages(threadId)
+        assertEquals(listOf(Role.USER, Role.ASSISTANT), loaded.map { it.role })
+        assertNotNull(loaded.last().error)
+        assertNull(loaded.last().researchRunId)
+        assertTrue(store.pendingResearch().isEmpty())
     }
 
     @Test
-    fun `重开会话发现未完成占位→恢复轮询直至完成`() = runTest(dispatcher) {
+    fun `进程死亡后重启：resumeAll 接手未完成任务，落库不依赖会话被打开`() = runTest(dispatcher) {
         val engine = ResearchEngine(mutableListOf(
             whl.trending.chat.model.ResearchRun("run-77", "running", null, null),
         ))
@@ -383,12 +421,12 @@ class ChatViewModelPersistenceTest {
         v.toggleDeepResearch()
         v.updateInput("长任务")
         v.send()
-        // 只让创建完成、不推进轮询到终局：先切走再回来模拟重开
-        advanceUntilIdle()
+        testScheduler.runCurrent() // 提交完成、占位已落库；轮询首拍（8s）未到
 
         val threadId = store.threads().first()[0].id
+        v.viewModelScope.cancel() // 模拟进程死亡：轮询随 VM 一起消失
 
-        // 新 VM（模拟进程重启）：通用入口进来是**新会话**，那条挂着任务的会话并不会被打开——
+        // 新 VM（进程重启）：通用入口进来是**新会话**，那条挂着任务的会话并不会被打开——
         // 恢复轮询因此不能挂在会话恢复上，否则这 10 credits 的任务永远没人接。
         // 任务照常跑完落库，用户从抽屉切过去就能看到完整报告。
         val engine2 = ResearchEngine(mutableListOf(
@@ -399,6 +437,26 @@ class ChatViewModelPersistenceTest {
 
         assertTrue(v2.uiState.value.messages.isEmpty())
         assertEquals("迟到的报告", db.messageDao().messagesFor(threadId).last().content)
+    }
+
+    @Test
+    fun `research 轮询不阻塞发送：任务在途时仍可正常对话`() = runTest(dispatcher) {
+        val engine = ResearchEngine(mutableListOf(
+            whl.trending.chat.model.ResearchRun("run-77", "running", null, null),
+        ))
+        val v = vm(engine)
+        advanceUntilIdle()
+        v.toggleDeepResearch()
+        v.updateInput("长任务")
+        v.send()
+        testScheduler.runCurrent()
+        assertEquals(false, v.uiState.value.isSending) // 提交落定即解锁
+
+        v.toggleDeepResearch() // 回 Normal
+        v.updateInput("顺便问个问题")
+        v.send()
+        testScheduler.runCurrent()
+        assertNotNull(engine.lastHistory) // chat 请求真的发出去了
     }
 
     @Test
@@ -458,7 +516,7 @@ class ChatViewModelPersistenceTest {
     }
 
     @Test
-    fun `research 空报告视同失败：删占位行、错误可重试、不留恢复哨兵`() = runTest(dispatcher) {
+    fun `research 空报告视同失败：错误可重试、runId 置空不留恢复哨兵`() = runTest(dispatcher) {
         val engine = ResearchEngine(mutableListOf(
             whl.trending.chat.model.ResearchRun("run-77", "completed", "", null),
         ))
@@ -472,14 +530,12 @@ class ChatViewModelPersistenceTest {
         val last = v.uiState.value.messages.last()
         assertNotNull(last.error)
         assertEquals(null, last.researchRunId)
-        // 占位行已删：库里只剩 user，重开会话不会再触发恢复轮询
-        val threadId = store.threads().first()[0].id
-        assertEquals(listOf("user"), db.messageDao().messagesFor(threadId).map { it.role })
+        // 错误行落库但 runId 已清：重启不会再触发恢复轮询
+        assertTrue(store.pendingResearch().isEmpty())
     }
 
     @Test
-    fun `error 条占过内存 id 后，research 占位 id 不与已有消息重号`() = runTest(dispatcher) {
-        // 第一次提交失败：error 条占用内存 id 但不落库 → Room 自增从此落后于内存序列
+    fun `消息 id 全局唯一：错误行与后续占位不重号`() = runTest(dispatcher) {
         val engine = ResearchEngine(
             statuses = mutableListOf(whl.trending.chat.model.ResearchRun("run-77", "completed", "# 报告", null)),
             failCreate = ChatError(ChatErrorCategory.SERVER),
@@ -525,7 +581,7 @@ class ChatViewModelPersistenceTest {
 
         assertEquals(1, engine.created)
         assertEquals("# 报告", v.uiState.value.messages.last().content)
-        // user 提问只有一条，未被重试复制
+        // user 提问只有一条，未被重试复制；错误行已被替换
         val threadId = store.threads().first()[0].id
         assertEquals(listOf("user", "assistant"), db.messageDao().messagesFor(threadId).map { it.role })
     }

--- a/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
+++ b/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelPersistenceTest.kt
@@ -625,6 +625,24 @@ class ChatViewModelPersistenceTest {
     }
 
     @Test
+    fun `恢复轮询撞上不支持 research 的引擎：不崩溃，占位转错误行（runId 保留）`() = runTest(dispatcher) {
+        // 库里躺着一条待恢复占位（上个版本/正式引擎留下的）
+        val threadId = store.createThread(null, "老任务")
+        store.appendResearchPlaceholder(threadId, runId = "run-old")
+
+        // GatedEngine 未覆写 pollResearch → 默认实现抛 UnsupportedOperationException；
+        // resumeAll 接手轮询后必须收口为错误终局而不是让异常逃逸出 launch
+        val v = vm(GatedEngine())
+        advanceUntilIdle()
+
+        assertTrue(v.uiState.value.messages.isEmpty()) // 没崩、也没打开那条会话
+        val row = store.loadMessages(threadId).last()
+        assertNotNull(row.error)
+        assertEquals("run-old", row.researchRunId)
+        assertTrue(store.pendingResearch().isEmpty()) // 不再反复恢复
+    }
+
+    @Test
     fun `空 assistant 行（research 错误条）不进后续 chat history`() = runTest(dispatcher) {
         val engine = ResearchEngine(failCreate = ChatError(ChatErrorCategory.SERVER))
         val v = vm(engine)

--- a/chat/src/androidHostTest/kotlin/whl/trending/chat/db/ChatDatabaseTest.kt
+++ b/chat/src/androidHostTest/kotlin/whl/trending/chat/db/ChatDatabaseTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * schema 特征测试：钉住表结构契约（入口恢复查询 / 排序 / 级联删除 / 字段往返）。
+ * schema 特征测试：钉住表结构契约（research 恢复查询 / 排序 / 级联删除 / 字段往返）。
  * Robolectric 内存库，行为即真实 SQLite。
  * sdk 钉 35：Robolectric 4.16.x 不支持 37，SDK 36 沙箱又要求 Java 21（测试 JVM 为 17）
  */
@@ -46,13 +46,17 @@ class ChatDatabaseTest {
         )
 
     @Test
-    fun `入口恢复：latestByEntry 返回该入口最近活跃的会话`() = runTest {
-        db.threadDao().insert(thread(entryKey = "repo:octo/demo", updatedAt = 100))
-        val newer = db.threadDao().insert(thread(entryKey = "repo:octo/demo", updatedAt = 200))
-        db.threadDao().insert(thread(entryKey = "general", updatedAt = 300))
+    fun `pendingResearchRows 只取空内容的 research 行`() = runTest {
+        val t = db.threadDao().insert(thread())
+        db.messageDao().insert(message(t)) // user 行不入
+        val pending = db.messageDao().insert(
+            message(t, role = "assistant", content = "").copy(kind = "DEEP_RESEARCH"),
+        )
+        db.messageDao().insert(
+            message(t, role = "assistant", content = "# 报告").copy(kind = "DEEP_RESEARCH"),
+        )
 
-        val latest = db.threadDao().latestByEntry("repo:octo/demo")
-        assertEquals(newer, latest?.id)
+        assertEquals(listOf(pending), db.messageDao().pendingResearchRows("DEEP_RESEARCH").map { it.id })
     }
 
     @Test

--- a/chat/src/androidHostTest/kotlin/whl/trending/chat/store/ChatStoreTest.kt
+++ b/chat/src/androidHostTest/kotlin/whl/trending/chat/store/ChatStoreTest.kt
@@ -190,9 +190,12 @@ class ChatStoreTest {
         assertEquals(ChatErrorCategory.TIMEOUT, errored.error?.category)
         assertEquals("run-1", errored.researchRunId)
 
+        now = 2000L
         store.resetResearchPlaceholder(id, placeholder.id, "run-1")
         assertEquals(listOf(PendingResearch(id, placeholder.id, "run-1")), store.pendingResearch())
         assertNull(store.loadMessages(id).last().error)
+        // 会话冒泡：reset 与其他写路径一样 touch 线程
+        assertEquals(2000L, db.threadDao().getById(id)!!.updatedAt)
     }
 
     @Test
@@ -222,6 +225,22 @@ class ChatStoreTest {
         assertFalse(storedFile.exists())
         assertNull(db.threadDao().getById(id))
         assertTrue(db.messageDao().messagesFor(id).isEmpty())
+    }
+
+    @Test
+    fun `deleteThread 不删 store 目录之外的文件（迁移失败回退的源路径）`() = runTest {
+        // 发送时源文件不存在 → copyIntoStore 跳过迁移、原路径入库（失败回退分支）
+        val outside = File(cacheDir, "keep.jpg").absolutePath
+        val id = store.createThread(null, firstMessageText = "看图")
+        val persisted = store.appendUserMessage(id, "看图", images = listOf(outside))
+        assertEquals(outside, persisted.images[0])
+
+        File(outside).writeBytes(byteArrayOf(1)) // 文件随后出现在 store 之外
+
+        store.deleteThread(id)
+
+        assertTrue(File(outside).exists()) // 只删 imagesDir 名下的文件
+        assertNull(db.threadDao().getById(id))
     }
 
     @Test

--- a/chat/src/androidHostTest/kotlin/whl/trending/chat/store/ChatStoreTest.kt
+++ b/chat/src/androidHostTest/kotlin/whl/trending/chat/store/ChatStoreTest.kt
@@ -2,7 +2,6 @@ package whl.trending.chat.store
 
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -12,7 +11,8 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import whl.trending.chat.ChatContext
 import whl.trending.chat.db.ChatDatabase
-import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.ChatError
+import whl.trending.chat.model.ChatErrorCategory
 import whl.trending.chat.model.MessageKind
 import whl.trending.chat.model.Role
 import java.io.File
@@ -22,8 +22,8 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * 持久化层行为测试：懒建会话 / 入口恢复复用 / context 往返 / 标题策略 /
- * 图片迁移 filesDir / 终局一次写（空回复不落）/ 删除先删文件。
+ * Room 持久化层行为：建线与标题策略 / context 往返 / 图片迁移 filesDir /
+ * 错误行落库往返 / research 占位与 pendingResearch 哨兵 / 删除先删文件。
  * sdk 钉 35：同 ChatDatabaseTest（Robolectric 4.16.x + 测试 JVM 17 的上限）
  */
 @RunWith(RobolectricTestRunner::class)
@@ -34,7 +34,7 @@ class ChatStoreTest {
     private lateinit var imagesDir: File
     private lateinit var cacheDir: File
     private var now = 1000L
-    private lateinit var store: ChatStore
+    private lateinit var store: RoomChatStore
 
     private val repoContext = ChatContext(
         title = "octo/demo",
@@ -53,7 +53,7 @@ class ChatStoreTest {
         ).build()
         imagesDir = File.createTempFile("imgs", null).apply { delete(); mkdirs() }
         cacheDir = File.createTempFile("cache", null).apply { delete(); mkdirs() }
-        store = ChatStore(db, imagesDir.absolutePath, clock = { now })
+        store = RoomChatStore(db, imagesDir.absolutePath, clock = { now })
     }
 
     @After
@@ -63,40 +63,38 @@ class ChatStoreTest {
         cacheDir.deleteRecursively()
     }
 
-    private fun userMsg(text: String, images: List<String> = emptyList()) =
-        ChatMessage(id = 0, role = Role.USER, content = text, images = images)
-
     private fun cacheImage(name: String): String =
         File(cacheDir, name).apply { writeBytes(byteArrayOf(1, 2, 3)) }.absolutePath
 
-    // 懒建与入口恢复
+    // 建线与标题策略
 
     @Test
-    fun `repo 入口懒建：标题取 context 标题，entryKey 为 repo 前缀`() = runTest {
-        val id = store.ensureThread(repoContext, firstMessageText = "介绍一下")
+    fun `repo 入口建线：标题取 context 标题，entryKey 为 repo 前缀`() = runTest {
+        val id = store.createThread(repoContext, firstMessageText = "介绍一下")
         val thread = db.threadDao().getById(id)!!
         assertEquals("octo/demo", thread.title)
         assertEquals("repo:octo/demo", thread.entryKey)
     }
 
     @Test
-    fun `同入口再次 ensure 复用最近会话，不新建`() = runTest {
-        val first = store.ensureThread(repoContext, firstMessageText = "hi")
-        val second = store.ensureThread(repoContext, firstMessageText = "again")
-        assertEquals(first, second)
+    fun `通用入口标题取首条消息，超长截断`() = runTest {
+        val id = store.createThread(null, firstMessageText = "这是一条非常非常非常非常非常非常长的首条消息内容")
+        val title = db.threadDao().getById(id)!!.title
+        assertTrue(title.length <= ChatStore.MAX_TITLE_LENGTH)
+        assertTrue(title.startsWith("这是一条"))
     }
 
     @Test
-    fun `resolveLatestThread 无历史返回 null（进入即空态，不落库）`() = runTest {
-        assertNull(store.resolveLatestThread(null))
-        assertEquals(0, db.threadDao().observeAll().first().size)
+    fun `纯图消息无文本 → 默认标题`() = runTest {
+        val id = store.createThread(null, firstMessageText = "")
+        assertEquals(ChatStore.DEFAULT_TITLE, db.threadDao().getById(id)!!.title)
     }
 
     // context 往返
 
     @Test
     fun `contextJson 往返：恢复的会话还原 ChatContext 关键字段`() = runTest {
-        val id = store.ensureThread(repoContext, firstMessageText = "hi")
+        val id = store.createThread(repoContext, firstMessageText = "hi")
         val restored = store.contextOf(id)!!
         assertEquals("octo/demo", restored.title)
         assertEquals("github", restored.source)
@@ -106,29 +104,13 @@ class ChatStoreTest {
         assertFalse(restored.autoDetailSummary)
     }
 
-    // 标题策略
-
-    @Test
-    fun `通用入口标题取首条消息，超长截断`() = runTest {
-        val id = store.ensureThread(null, firstMessageText = "这是一条非常非常非常非常非常非常长的首条消息内容")
-        val title = db.threadDao().getById(id)!!.title
-        assertTrue(title.length <= ChatStore.MAX_TITLE_LENGTH)
-        assertTrue(title.startsWith("这是一条"))
-    }
-
-    @Test
-    fun `纯图消息无文本 → 默认标题`() = runTest {
-        val id = store.ensureThread(null, firstMessageText = "")
-        assertEquals(ChatStore.DEFAULT_TITLE, db.threadDao().getById(id)!!.title)
-    }
-
     // 消息落库
 
     @Test
-    fun `persistUserMessage 把图片从 cache 拷入 filesDir 并回写新路径`() = runTest {
+    fun `appendUserMessage 把图片从 cache 拷入 filesDir 并回写新路径，id 即行 id`() = runTest {
         val cachePath = cacheImage("a.jpg")
-        val id = store.ensureThread(null, firstMessageText = "看图")
-        val persisted = store.persistUserMessage(id, userMsg("看图", images = listOf(cachePath)))
+        val id = store.createThread(null, firstMessageText = "看图")
+        val persisted = store.appendUserMessage(id, "看图", images = listOf(cachePath))
 
         assertEquals(1, persisted.images.size)
         val newPath = persisted.images[0]
@@ -137,37 +119,92 @@ class ChatStoreTest {
 
         val rows = db.messageDao().messagesFor(id)
         assertEquals(1, rows.size)
+        assertEquals(rows[0].id, persisted.id)
         assertTrue(rows[0].imagesJson!!.contains(newPath))
     }
 
     @Test
-    fun `persistAssistantMessage 成功终局落一次，空内容不落`() = runTest {
-        val id = store.ensureThread(null, firstMessageText = "hi")
-        store.persistAssistantMessage(id, content = "回答", kind = MessageKind.CHAT, model = "gpt-5.4")
-        store.persistAssistantMessage(id, content = "", kind = MessageKind.CHAT, model = null)
-
-        val rows = db.messageDao().messagesFor(id)
-        assertEquals(1, rows.size)
-        assertEquals("assistant", rows[0].role)
-        assertEquals("gpt-5.4", rows[0].model)
-    }
-
-    @Test
-    fun `loadMessages 完整还原 model 层字段（kind与图片）`() = runTest {
-        val id = store.ensureThread(repoContext, firstMessageText = "解读")
-        store.persistUserMessage(
-            id,
-            ChatMessage(0, Role.USER, "解读", kind = MessageKind.DETAIL_SUMMARY),
-        )
-        store.persistAssistantMessage(id, "解读内容", MessageKind.DETAIL_SUMMARY, model = null)
+    fun `loadMessages 完整还原 model 层字段（kind、model 与图片）`() = runTest {
+        val id = store.createThread(repoContext, firstMessageText = "解读")
+        store.appendUserMessage(id, "解读", kind = MessageKind.DETAIL_SUMMARY)
+        store.appendAssistantMessage(id, "解读内容", MessageKind.DETAIL_SUMMARY, model = "gpt-5.5")
 
         val loaded = store.loadMessages(id)
         assertEquals(2, loaded.size)
         assertEquals(MessageKind.DETAIL_SUMMARY, loaded[0].kind)
         assertEquals(Role.ASSISTANT, loaded[1].role)
         assertEquals("解读内容", loaded[1].content)
-        // id 单调递增（VM 的 idSeq 从 max(id) 续）
+        assertEquals("gpt-5.5", loaded[1].model)
         assertTrue(loaded[1].id > loaded[0].id)
+    }
+
+    @Test
+    fun `错误行落库往返：分类、机器码、tier、authDegraded 全还原`() = runTest {
+        val id = store.createThread(null, firstMessageText = "hi")
+        store.appendUserMessage(id, "hi")
+        val error = ChatError(
+            ChatErrorCategory.QUOTA,
+            code = ChatError.CODE_QUOTA_DEVICE,
+            httpStatus = 429,
+            detail = "quota exceeded",
+            tier = ChatError.TIER_ANONYMOUS,
+            authDegraded = true,
+        )
+        store.appendErrorMessage(id, MessageKind.CHAT, error)
+
+        val loaded = store.loadMessages(id).last()
+        assertEquals("", loaded.content)
+        assertEquals(error, loaded.error)
+        assertEquals(MessageKind.CHAT, loaded.kind)
+    }
+
+    // research 占位与恢复哨兵
+
+    @Test
+    fun `research 占位进 pendingResearch，完成后退出`() = runTest {
+        val id = store.createThread(null, firstMessageText = "研究")
+        val placeholder = store.appendResearchPlaceholder(id, runId = "run-1")
+
+        assertEquals(
+            listOf(PendingResearch(id, placeholder.id, "run-1")),
+            store.pendingResearch(),
+        )
+
+        store.completeResearch(id, placeholder.id, "# 报告", "run-1", model = "gpt-5.5")
+        assertTrue(store.pendingResearch().isEmpty())
+        val loaded = store.loadMessages(id).last()
+        assertEquals("# 报告", loaded.content)
+        assertEquals("run-1", loaded.researchRunId)
+        assertEquals("gpt-5.5", loaded.model)
+    }
+
+    @Test
+    fun `markResearchError 后不再 pending；保留 runId 时 reset 可恢复占位形态`() = runTest {
+        val id = store.createThread(null, firstMessageText = "研究")
+        val placeholder = store.appendResearchPlaceholder(id, runId = "run-1")
+
+        // runId 保留（轮询永久错误）：错误行不触发恢复轮询，但重试可续
+        store.markResearchError(id, placeholder.id, ChatError(ChatErrorCategory.TIMEOUT), runId = "run-1")
+        assertTrue(store.pendingResearch().isEmpty())
+        val errored = store.loadMessages(id).last()
+        assertEquals(ChatErrorCategory.TIMEOUT, errored.error?.category)
+        assertEquals("run-1", errored.researchRunId)
+
+        store.resetResearchPlaceholder(id, placeholder.id, "run-1")
+        assertEquals(listOf(PendingResearch(id, placeholder.id, "run-1")), store.pendingResearch())
+        assertNull(store.loadMessages(id).last().error)
+    }
+
+    @Test
+    fun `markResearchError 判死（runId 置空）：错误行既不 pending 也无 runId`() = runTest {
+        val id = store.createThread(null, firstMessageText = "研究")
+        val placeholder = store.appendResearchPlaceholder(id, runId = "run-1")
+        store.markResearchError(id, placeholder.id, ChatError(ChatErrorCategory.SERVER), runId = null)
+
+        assertTrue(store.pendingResearch().isEmpty())
+        val loaded = store.loadMessages(id).last()
+        assertNull(loaded.researchRunId)
+        assertEquals(ChatErrorCategory.SERVER, loaded.error?.category)
     }
 
     // 删除
@@ -175,8 +212,8 @@ class ChatStoreTest {
     @Test
     fun `deleteThread 先删图片文件再删行`() = runTest {
         val cachePath = cacheImage("b.jpg")
-        val id = store.ensureThread(null, firstMessageText = "看图")
-        val persisted = store.persistUserMessage(id, userMsg("看图", images = listOf(cachePath)))
+        val id = store.createThread(null, firstMessageText = "看图")
+        val persisted = store.appendUserMessage(id, "看图", images = listOf(cachePath))
         val storedFile = File(persisted.images[0])
         assertTrue(storedFile.exists())
 
@@ -185,5 +222,16 @@ class ChatStoreTest {
         assertFalse(storedFile.exists())
         assertNull(db.threadDao().getById(id))
         assertTrue(db.messageDao().messagesFor(id).isEmpty())
+    }
+
+    @Test
+    fun `deleteMessage 只删目标行`() = runTest {
+        val id = store.createThread(null, firstMessageText = "hi")
+        store.appendUserMessage(id, "hi")
+        val error = store.appendErrorMessage(id, MessageKind.CHAT, ChatError(ChatErrorCategory.NETWORK))
+
+        store.deleteMessage(error.id)
+
+        assertEquals(listOf("hi"), store.loadMessages(id).map { it.content })
     }
 }

--- a/chat/src/androidMain/kotlin/whl/trending/chat/store/DefaultChatStore.android.kt
+++ b/chat/src/androidMain/kotlin/whl/trending/chat/store/DefaultChatStore.android.kt
@@ -10,6 +10,6 @@ import whl.trending.chat.db.chatDatabase
 internal actual fun rememberDefaultChatStore(): ChatStore {
     val appContext = LocalContext.current.applicationContext
     return remember {
-        ChatStore(chatDatabase(appContext), File(appContext.filesDir, "chat_images").absolutePath)
+        RoomChatStore(chatDatabase(appContext), File(appContext.filesDir, "chat_images").absolutePath)
     }
 }

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ChatAiEvents.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ChatAiEvents.kt
@@ -1,0 +1,34 @@
+package whl.trending.chat
+
+import whl.trending.chat.host.ChatAiEvent
+import whl.trending.chat.host.ChatAiKind
+import whl.trending.chat.host.ChatAiOutcome
+import whl.trending.chat.model.ChatError
+import whl.trending.chat.model.MessageKind
+
+internal fun MessageKind.toAiKind(): ChatAiKind = when (this) {
+    MessageKind.CHAT -> ChatAiKind.CHAT
+    MessageKind.DETAIL_SUMMARY -> ChatAiKind.DETAIL_SUMMARY
+    MessageKind.DEEP_RESEARCH -> ChatAiKind.RESEARCH
+}
+
+/**
+ * 失败终态事件：每次失败恰好一条 ai_completed，与 ai_requested 成对。配额触顶
+ * （付费意愿漏斗第一级）与匿名解读登录闸（登录转化信号）都靠 `reason` 区分。
+ */
+internal fun failureEvent(kind: MessageKind, error: ChatError, durationMs: Long? = null): ChatAiEvent.Completed =
+    ChatAiEvent.Completed(
+        kind = kind.toAiKind(),
+        outcome = if (error.code == ChatError.CODE_STREAM_INTERRUPTED) {
+            ChatAiOutcome.INTERRUPTED
+        } else {
+            ChatAiOutcome.ERROR
+        },
+        durationMs = durationMs,
+        reason = error.code ?: error.category.name.lowercase(),
+        tier = if (error.code == ChatError.CODE_QUOTA_DEVICE) {
+            error.tier ?: ChatError.TIER_ANONYMOUS
+        } else {
+            null
+        },
+    )

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -4,55 +4,63 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import whl.trending.chat.core.epochMillis
+import whl.trending.chat.engine.ChatEngine
+import whl.trending.chat.engine.ChatException
 import whl.trending.chat.host.ChatAiEvent
 import whl.trending.chat.host.ChatAiKind
 import whl.trending.chat.host.ChatAiOutcome
 import whl.trending.chat.host.chatHost
-import whl.trending.chat.model.ChatModelsResponse
-import whl.trending.chat.model.resolveDisplayedChatModel
-import whl.trending.chat.model.ChatModelsProvider
-import whl.trending.chat.engine.ChatEngine
-import whl.trending.chat.engine.ChatException
 import whl.trending.chat.model.ChatError
 import whl.trending.chat.model.ChatErrorCategory
 import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.ChatMode
+import whl.trending.chat.model.ChatModelsProvider
+import whl.trending.chat.model.ChatModelsResponse
 import whl.trending.chat.model.ChatUiState
 import whl.trending.chat.model.MessageKind
 import whl.trending.chat.model.Role
 import whl.trending.chat.model.SearchEvent
 import whl.trending.chat.model.SourceRef
+import whl.trending.chat.model.resolveDisplayedChatModel
 import whl.trending.chat.store.ChatStore
+import whl.trending.chat.store.InMemoryChatStore
 
 /** 抽屉里的一条会话概要 */
 data class ThreadSummary(val id: Long, val title: String, val updatedAt: Long)
 
 /**
- * 聊天 ViewModel：单实例 + currentThreadId 状态（P1 起，多会话由 [ChatStore] 支撑）。
- * 流式渲染不变（发送先追加空 assistant 占位，delta 到达增量更新）；落库为终局一次写。
+ * 聊天 ViewModel。并发模型是理解一切的钥匙：
  *
- * 会话切换语义：流按 threadId 分键（[streams]/[messagesByThread]）——切走后后台继续
- * 完成并落库（服务端已在计费，取消才是浪费），切回可见全文；uiState 只镜像当前线。
+ * - **所有状态变更串行化**：会改 [uiState]/[currentThreadId]/[activeContext] 的操作一律经
+ *   [locked] 排队，同一时刻只有一个在跑，挂起点之间不会被别的操作交错。
+ * - **单一真相源**：内存里只保留当前会话的消息（[uiState].messages 即真相），历史归 store；
+ *   消息 id 就是 store 行 id（全局唯一），唯一的例外是流式占位（固定 [PLACEHOLDER_ID]，
+ *   终局时被落库行替换）。
+ * - **切走即取消**：在途流只属于当前会话（切会话/新会话/换入口都会取消它，已渲染部分
+ *   落为可重试的中断错误行）。因此任何时刻至多一条在途流（[inFlight]）。
+ *   Deep Research 例外——任务是服务端资产，独立于会话切换（见 [ResearchRunner]）。
  *
- * @param store 持久化层；null = 纯内存模式（Demo/预览与旧行为完全一致）
+ * 会话语义：入口进入总是新会话（历史进抽屉），仅同入口的进程内再进入续接现场——
+ * 本 VM 挂 Activity 作用域（`viewModel(key="chat")`），返回首页再进来不该重置刚才的对话。
+ *
+ * @param store 持久化层；默认内存实现（Demo/预览），正式宿主注入 Room 实现
  * @param selectedModelId 应答模型记录用（展示「哪个模型答的」）；默认读全局设置的用户选择
  */
 class ChatViewModel(
     private val engine: ChatEngine,
     initialContext: ChatContext? = null,
     initialMessages: List<ChatMessage> = emptyList(),
-    private val store: ChatStore? = null,
+    private val store: ChatStore = InMemoryChatStore(),
     private val loadModels: suspend () -> ChatModelsResponse = { ChatModelsProvider.get() },
     private val track: (ChatAiEvent) -> Unit = { chatHost.onAiEvent(it) },
     private val selectedModelId: () -> String? = {
@@ -74,11 +82,9 @@ class ChatViewModel(
     private val _catalog = MutableStateFlow(ChatModelsResponse())
     val catalog: StateFlow<ChatModelsResponse> = _catalog.asStateFlow()
 
-    /** 会话列表（抽屉数据源）；纯内存模式恒为空 */
+    /** 会话列表（抽屉数据源） */
     val threads: StateFlow<List<ThreadSummary>> =
-        (store?.threads()?.map { list -> list.map { ThreadSummary(it.id, it.title, it.updatedAt) } }
-            ?: flowOf(emptyList()))
-            .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+        store.threads().stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private val _currentThreadId = MutableStateFlow<Long?>(null)
     val currentThreadId: StateFlow<Long?> = _currentThreadId.asStateFlow()
@@ -95,99 +101,45 @@ class ChatViewModel(
         _chatMode.value = if (_chatMode.value == mode) ChatMode.Normal else mode
     }
 
-    /** 当前会话的 ChatContext（解读 chip / 服务端 context 注入）；随切换/恢复而变 */
+    /** 当前会话的 ChatContext（解读 chip / 服务端 context 注入）；随切换/重置而变 */
     private var activeContext: ChatContext? = initialContext
 
-    // 每线消息缓冲（真相源，uiState.messages 只是当前线的镜像）；null 键 = 尚未落库的新会话
-    private val messagesByThread = mutableMapOf<Long?, List<ChatMessage>>(null to initialMessages)
+    private val stateLock = Mutex()
 
-    // 每线在途流（切走后后台继续）
-    private val streams = mutableMapOf<Long?, Job>()
+    private class InFlightSend(val threadId: Long, val kind: MessageKind, val startedAt: Long, val job: Job)
 
-    // research 轮询任务，按占位消息 id 分键——不与 streams（threadId 键）共用一张表：
-    // 两者都是从 1 起的自增序列，键空间重叠会互相顶掉 / 误取消 / 误判 isSending
-    private val researchJobs = mutableMapOf<Long, Job>()
+    private var inFlight: InFlightSend? = null
 
-    // research 占位行：缓冲内消息 id → Room 行 id。error 消息占内存 id 但不落库，两套自增
-    // 序列会错位；Room id 直接混进缓冲会与已有消息重号（LazyColumn 按 id 作 key 时崩溃）
-    private val researchRowIds = mutableMapOf<Long, Long>()
+    private val research = ResearchRunner(viewModelScope, engine, store, track, ::applyToVisible)
 
     init {
         viewModelScope.launch {
             _catalog.value = runCatching { loadModels() }.getOrDefault(ChatModelsResponse())
         }
-        viewModelScope.launch { resumeAllPendingResearch() }
+        // 落在 init 而非 enterEntry：Activity 被系统重建时 Screen 侧的 enteredKey
+        // （rememberSaveable）已恢复、enterEntry 不会再调，而那恰恰是最需要恢复的场景
+        locked { research.resumeAll() }
+    }
+
+    /** 状态变更的唯一入口：viewModelScope（主线程）+ [stateLock] 串行执行 */
+    private fun locked(block: suspend () -> Unit) {
+        viewModelScope.launch { stateLock.withLock { block() } }
     }
 
     /**
-     * 入口进入（Screen 每个新入口调用一次）。
-     *
-     * **通用入口默认新会话**（对齐 ChatGPT / Gemini / Grok）：对话是一次性任务单元，
-     * 历史进抽屉、不进现场。此前「永远续同一条 general 会话」的代价是——不相关的话题
-     * 堆进同一上下文窗口（最近 12 条 / 16k 字符会被上一话题连同 4000 字解读占满，答非
-     * 所问），抽屉里长期只有一条会话（多会话功能形同虚设），欢迎区与快捷问因 messages
-     * 非空而永久消失。线上 95% 的对话都走通用入口，这条路径的收益最大。
-     *
-     * 「新会话」的边界是**进程**，不是页面：本 VM 挂在 Activity 作用域（`viewModel(key="chat")`
-     * 的 owner 是 Activity，退出 chat 页不销毁），所以返回首页查个东西再进来，[_currentThreadId]
-     * 还指着刚才那条会话——此时保持现状即可，不必重新开一条。进程被杀后 VM 随之消失，
-     * 下次进来自然是新会话，无需任何额外标记或时间窗口。
-     *
-     * **条目入口（`repo:*`）仍恢复**：回到同一个项目继续追问是真实需求，且会话里已有的
-     * 解读全文可以复用，不必重新生成。
-     *
-     * 纯内存模式只切 context，不动 initialMessages（该模式下不建线，续接分支恒不触发）。
+     * 入口进入（Screen 每个新入口调用一次）。总是新会话（对齐 ChatGPT / Gemini / Grok：
+     * 对话是一次性任务单元，历史进抽屉、不进现场），唯一例外是**同入口的进程内续接**：
+     * VM 挂 Activity 作用域，返回首页查个东西再进来，现场还在就不重置。
      */
-    fun enterEntry(context: ChatContext?) {
-        viewModelScope.launch {
-            val isGeneralEntry = ChatStore.entryKeyOf(context) == ChatStore.ENTRY_GENERAL
-            // 进程内续接。两点讲究：
-            // 1. 判断必须在 activeContext 被覆盖之前——它此刻的值代表「上次停在哪」；
-            //    停在 repo 会话时走通用入口，应当开新会话而非把那条续过来。
-            // 2. 「上次是不是通用会话」与 isGeneralEntry 走同一个 entryKeyOf，避免两处口径不一：
-            //    entryKeyOf 把「有 title 但无 externalId」的 context（HN/PH 场景）也算 general，
-            //    裸写 activeContext == null 会把它判成非通用，将来给 HN/PH 加入口就会分歧。
-            val wasOnGeneralThread = ChatStore.entryKeyOf(activeContext) == ChatStore.ENTRY_GENERAL &&
-                _currentThreadId.value != null
-            if (isGeneralEntry && wasOnGeneralThread) return@launch
+    fun enterEntry(context: ChatContext?) = locked {
+        val sameEntry = ChatStore.entryKeyOf(context) == ChatStore.entryKeyOf(activeContext)
+        if (sameEntry && (_currentThreadId.value != null || _uiState.value.messages.isNotEmpty())) {
             activeContext = context
-            val s = store ?: return@launch
-            val id = if (isGeneralEntry) null else s.resolveLatestThread(context)
-            if (id != null) {
-                openThread(id, fallbackContext = context)
-            } else {
-                _currentThreadId.value = null
-                messagesByThread[null] = emptyList()
-                _uiState.update {
-                    it.copy(messages = emptyList(), isSending = false, pendingImages = emptyList())
-                }
-            }
+            return@locked
         }
+        cancelInFlight(persistInterrupted = true)
+        resetSession(context, clearInput = false)
     }
-
-    /**
-     * 跨进程恢复**所有**未完成的 research 轮询，不依赖「进入时恢复了哪个会话」。
-     *
-     * 通用入口不再恢复会话之后，那条挂着任务的会话不会被打开——恢复若仍挂在
-     * [openThread] 上，后台被杀再回来就没人接这个已扣费的任务了（服务端跑完也没人
-     * 写回）。轮询照常落库，用户从抽屉切过去就能看到完整报告。
-     *
-     * 落在 init 而非 [enterEntry]：Activity 被系统重建时 Screen 侧的 `enteredKey`
-     * （rememberSaveable）已恢复、`enterEntry` 不会再调，而那恰恰是最需要恢复的场景。
-     * 此刻尚无当前线，所以不区分——随后 [openThread] 对当前线补 searching 转圈标记，
-     * 它重复发起的轮询由 [researchJobs] 的在途判定拦下。
-     */
-    private suspend fun resumeAllPendingResearch() {
-        val s = store ?: return
-        s.threadsWithPendingResearch().forEach { threadId ->
-            val messages = messagesByThread[threadId]
-                ?: s.loadMessages(threadId).also { messagesByThread[threadId] = it }
-            resumeResearchIfAny(threadId, messages)
-        }
-    }
-
-    private var idSeq = initialMessages.maxOfOrNull { it.id } ?: 0L
-    private fun nextId(): Long = ++idSeq
 
     fun updateInput(text: String) {
         _uiState.update { it.copy(input = text) }
@@ -214,47 +166,47 @@ class ChatViewModel(
         if (_chatMode.value == ChatMode.DeepResearch) {
             if (text.isBlank()) return
             _uiState.update { it.copy(input = "") }
-            sendResearch(text)
+            queueResearch(text)
             return
         }
         val images = state.pendingImages
         _uiState.update { it.copy(input = "", pendingImages = emptyList()) }
-        sendMessage(text, images, from = "input")
+        queueChat(text, images, from = "input")
     }
 
     /** 发送一段指定文本（如快捷按钮的预设问题），不依赖输入框；发送中或空白则忽略。 */
-    fun sendText(text: String) = sendMessage(text, emptyList(), from = "quick_reply")
+    fun sendText(text: String) = queueChat(text, emptyList(), from = "quick_reply")
 
     /**
      * 「一键详细解读」：插入一条 user 消息（chip 文案），走 detail 管线流式生成解读。
      * 可见性由 [DetailSummaryPolicy] 保证（GitHub 条目 + README 达标 + 尚无成功解读）。
      */
     fun sendDetailSummary(promptText: String) {
-        val context = activeContext
-        if (_uiState.value.isSending || context?.externalId == null) return
-        track(ChatAiEvent.Requested(ChatAiKind.DETAIL_SUMMARY, from = "chat"))
-        _uiState.update { it.copy(isSending = true) }
-        viewModelScope.launch {
-            val threadId = ensureThreadForSend(promptText)
-            val userMessage = ChatMessage(nextId(), Role.USER, promptText, kind = MessageKind.DETAIL_SUMMARY)
-            appendAndPersistUser(threadId, userMessage)
-            launchRequest(threadId, MessageKind.DETAIL_SUMMARY, context)
+        if (_uiState.value.isSending || activeContext?.externalId == null) return
+        locked {
+            val context = activeContext
+            if (_uiState.value.isSending || context?.externalId == null) return@locked
+            track(ChatAiEvent.Requested(ChatAiKind.DETAIL_SUMMARY, from = "chat"))
+            _uiState.update { it.copy(isSending = true) }
+            val threadId = ensureThread(promptText)
+            appendVisible(store.appendUserMessage(threadId, promptText, kind = MessageKind.DETAIL_SUMMARY))
+            startStream(threadId, MessageKind.DETAIL_SUMMARY, context)
         }
     }
 
-    private fun sendMessage(text: String, images: List<String>, from: String) {
+    private fun queueChat(text: String, images: List<String>, from: String) {
         if (_uiState.value.isSending || (text.isBlank() && images.isEmpty())) return
         if (_chatMode.value == ChatMode.DeepResearch) {
-            sendResearch(text)
+            queueResearch(text, from)
             return
         }
-        trackChatSend(from, images.size)
-        _uiState.update { it.copy(isSending = true) }
-        viewModelScope.launch {
-            val threadId = ensureThreadForSend(text)
-            val userMessage = ChatMessage(nextId(), Role.USER, text, images = images)
-            appendAndPersistUser(threadId, userMessage)
-            launchRequest(threadId, MessageKind.CHAT, activeContext)
+        locked {
+            if (_uiState.value.isSending) return@locked
+            trackChatSend(from, images.size)
+            _uiState.update { it.copy(isSending = true) }
+            val threadId = ensureThread(text)
+            appendVisible(store.appendUserMessage(threadId, text, images))
+            startStream(threadId, MessageKind.CHAT, activeContext)
         }
     }
 
@@ -265,23 +217,27 @@ class ChatViewModel(
         val passthrough = error.code == ChatError.CODE_QUOTA_DEVICE ||
             error.code == ChatError.CODE_LOGIN_REQUIRED
         if (!error.category.retryable && !passthrough) return
-        if (message.kind == MessageKind.DEEP_RESEARCH) {
-            // research 不进流式管线（launchRequest 对该 kind 直接 error()），单独路由
-            retryResearch(message)
-            return
+        locked {
+            // 错误条仍须在场（防连点与过期引用）
+            if (_uiState.value.isSending || _uiState.value.messages.none { it.id == message.id }) return@locked
+            if (message.kind == MessageKind.DEEP_RESEARCH) {
+                retryResearch(message)
+                return@locked
+            }
+            val threadId = _currentThreadId.value ?: return@locked
+            store.deleteMessage(message.id)
+            removeVisible(message.id)
+            // 重试必然重打一次请求，两种 kind 都要补 ai_requested——不补则终局的
+            // ai_completed 落单，成对关系一破，「请求数」这个分母就再也不准
+            if (message.kind == MessageKind.CHAT) {
+                val resent = _uiState.value.messages.lastOrNull { it.role == Role.USER }
+                trackChatSend(from = "retry", imageCount = resent?.images?.size ?: 0)
+            } else {
+                track(ChatAiEvent.Requested(ChatAiKind.DETAIL_SUMMARY, from = "retry"))
+            }
+            _uiState.update { it.copy(isSending = true) }
+            startStream(threadId, message.kind, activeContext)
         }
-        val threadId = _currentThreadId.value
-        updateThreadMessages(threadId) { list -> list.filterNot { it.id == message.id } }
-        // 重试必然重打一次请求，两种 kind 都要补 ai_requested——不补则 launchRequest 的
-        // ai_completed 落单，成对关系一破，「请求数」这个分母就再也不准
-        if (message.kind == MessageKind.CHAT) {
-            val resent = messagesByThread[threadId]?.lastOrNull { it.role == Role.USER }
-            trackChatSend(from = "retry", imageCount = resent?.images?.size ?: 0)
-        } else {
-            track(ChatAiEvent.Requested(ChatAiKind.DETAIL_SUMMARY, from = "retry"))
-        }
-        _uiState.update { it.copy(isSending = true) }
-        launchRequest(threadId, message.kind, activeContext)
     }
 
     /**
@@ -305,159 +261,27 @@ class ChatViewModel(
 
     // 会话管理（抽屉）
 
-    fun switchThread(id: Long) {
-        if (id == _currentThreadId.value) return
-        viewModelScope.launch { openThread(id) }
+    fun switchThread(id: Long) = locked {
+        if (id == _currentThreadId.value) return@locked
+        cancelInFlight(persistInterrupted = true)
+        openThread(id)
     }
 
     /** 抽屉「新会话」：总是全新开始（通用入口），不复用任何历史 */
-    fun startNewThread() {
-        _currentThreadId.value = null
-        activeContext = null
-        messagesByThread[null] = emptyList()
-        _uiState.update {
-            it.copy(messages = emptyList(), isSending = false, input = "", pendingImages = emptyList())
-        }
+    fun startNewThread() = locked {
+        cancelInFlight(persistInterrupted = true)
+        resetSession(context = null, clearInput = true)
     }
 
-    fun renameThread(id: Long, title: String) {
-        viewModelScope.launch { store?.renameThread(id, title) }
+    fun renameThread(id: Long, title: String) = locked {
+        store.renameThread(id, title)
     }
 
-    fun deleteThread(id: Long) {
-        viewModelScope.launch {
-            // 在途流一并取消：线程行将消失，终局落库会撞外键；research 轮询同理
-            streams.remove(id)?.cancel()
-            messagesByThread[id]?.forEach { researchJobs.remove(it.id)?.cancel() }
-            messagesByThread.remove(id)
-            store?.deleteThread(id)
-            if (_currentThreadId.value == id) startNewThread()
-        }
-    }
-
-    // 内部
-
-    private suspend fun openThread(id: Long, fallbackContext: ChatContext? = null) {
-        val s = store ?: return
-        val messages = messagesByThread[id] ?: s.loadMessages(id).also { messagesByThread[id] = it }
-        idSeq = maxOf(idSeq, messages.maxOfOrNull { it.id } ?: 0L)
-        _currentThreadId.value = id
-        activeContext = s.contextOf(id) ?: fallbackContext
-        _uiState.update {
-            it.copy(
-                messages = messages,
-                isSending = streams[id]?.isActive == true,
-                pendingImages = emptyList(),
-            )
-        }
-        resumeResearchIfAny(id, messages)
-    }
-
-    /** 首条消息才建线（懒建）；当前线已存在则直接复用。内存模式恒为 null 键。 */
-    private suspend fun ensureThreadForSend(firstMessageText: String): Long? {
-        val s = store ?: return _currentThreadId.value
-        _currentThreadId.value?.let { return it }
-        val id = s.createThread(activeContext, firstMessageText)
-        // 未落库缓冲迁移到新线名下
-        messagesByThread[id] = messagesByThread.remove(null) ?: emptyList()
-        _currentThreadId.value = id
-        return id
-    }
-
-    private suspend fun appendAndPersistUser(threadId: Long?, message: ChatMessage) {
-        updateThreadMessages(threadId) { it + message }
-        if (store != null && threadId != null) {
-            val persisted = store.persistUserMessage(threadId, message)
-            if (persisted.images != message.images) {
-                // 图片已迁入 filesDir：回写新路径（cache 路径随时可能被系统清理）
-                updateThreadMessages(threadId) { list ->
-                    list.map { if (it.id == message.id) it.copy(images = persisted.images) else it }
-                }
-            }
-        }
-    }
-
-    /**
-     * 统一请求路径：先追加空 assistant 占位消息，delta 到达时增量更新其 content；
-     * 成功以全文定稿并终局落库，失败清空已渲染部分（整条重试）并挂上分类错误（不落库）。
-     */
-    private fun launchRequest(threadId: Long?, kind: MessageKind, context: ChatContext?) {
-        val startedAt = epochMillis()
-        var cacheHit = false
-        val placeholderId = nextId()
-        updateThreadMessages(threadId) { it + ChatMessage(placeholderId, Role.ASSISTANT, "", kind = kind) }
-        val job = viewModelScope.launch {
-            val result = runCatching {
-                when (kind) {
-                    MessageKind.CHAT -> {
-                        // 空 assistant 行（research 占位 / 错误条）不进 history：对模型无信息量，
-                        // 且上游可能拒空 content
-                        val history = (messagesByThread[threadId] ?: emptyList())
-                            .filterNot {
-                                it.id == placeholderId || (it.role == Role.ASSISTANT && it.content.isBlank())
-                            }
-                        val useSearch = _chatMode.value == ChatMode.WebSearch
-                        engine.send(
-                            history,
-                            context,
-                            onDelta = { delta -> appendDelta(threadId, placeholderId, delta) },
-                            search = useSearch,
-                            onSearch = { event -> applySearchEvent(threadId, placeholderId, event) },
-                        )
-                    }
-                    MessageKind.DETAIL_SUMMARY -> {
-                        val detail = engine.sendDetailSummary(requireNotNull(context)) { delta ->
-                            appendDelta(threadId, placeholderId, delta)
-                        }
-                        cacheHit = detail.cached
-                        detail.content
-                    }
-                    MessageKind.DEEP_RESEARCH -> error("research 走 launchResearch，不进流式管线")
-                }
-            }
-            result.fold(
-                onSuccess = { full ->
-                    var sources: List<SourceRef> = emptyList()
-                    updateThreadMessages(threadId) { list ->
-                        list.map {
-                            if (it.id == placeholderId) {
-                                sources = it.sources
-                                it.copy(content = full, searching = false)
-                            } else it
-                        }
-                    }
-                    if (store != null && threadId != null) {
-                        store.persistAssistantMessage(threadId, full, kind, selectedModelId(), sources)
-                    }
-                    track(
-                        ChatAiEvent.Completed(
-                            kind.toAiKind(),
-                            if (cacheHit) ChatAiOutcome.CACHE_HIT else ChatAiOutcome.OK,
-                            durationMs = epochMillis() - startedAt,
-                        )
-                    )
-                },
-                onFailure = { e ->
-                    // 取消不是失败。runCatching 连 CancellationException 一起吞，不排除的话
-                    // 「流还在跑时退出聊天页」与「删除会话」每次都会记一条 reason=unknown 的
-                    // 假失败终态，而它与真失败在数据里完全同形、事后分不开
-                    if (e !is CancellationException) {
-                        val error = (e as? ChatException)?.error
-                            ?: ChatError(ChatErrorCategory.UNKNOWN, detail = e.toString())
-                        trackFailure(kind, error, epochMillis() - startedAt)
-                        updateThreadMessages(threadId) { list ->
-                            // 已渲染部分丢弃，整条重试（中途断流语义）
-                            list.map { if (it.id == placeholderId) it.copy(content = "", error = error, searching = false) else it }
-                        }
-                    }
-                },
-            )
-            streams.remove(threadId)
-            if (threadId == _currentThreadId.value) {
-                _uiState.update { it.copy(isSending = false) }
-            }
-        }
-        streams[threadId] = job
+    fun deleteThread(id: Long) = locked {
+        if (inFlight?.threadId == id) cancelInFlight(persistInterrupted = false)
+        research.cancelForThread(id)
+        store.deleteThread(id)
+        if (_currentThreadId.value == id) resetSession(context = null, clearInput = true)
     }
 
     // Deep Research（P3）
@@ -465,236 +289,240 @@ class ChatViewModel(
     /** 解读卡尾部「深度调研此项目」升级入口：按 research 管线直发，不依赖模式开关 */
     fun sendRepoResearch(promptText: String) {
         if (_uiState.value.isSending || activeContext == null) return
-        sendResearch(promptText, from = "detail_summary_upsell")
+        queueResearch(promptText, from = "detail_summary_upsell")
     }
 
-    private fun sendResearch(topic: String, from: String = "chat") {
+    private fun queueResearch(topic: String, from: String = "chat") = locked {
+        if (_uiState.value.isSending) return@locked
         track(ChatAiEvent.Requested(ChatAiKind.RESEARCH, from = from))
         _uiState.update { it.copy(isSending = true) }
-        viewModelScope.launch {
-            val threadId = ensureThreadForSend(topic)
-            appendAndPersistUser(threadId, ChatMessage(nextId(), Role.USER, topic, kind = MessageKind.DEEP_RESEARCH))
-            startResearch(threadId, topic)
-        }
-    }
-
-    /** 提交 research 任务并启动轮询；提交失败挂错误条（重试经 [retryResearch] 重新提交） */
-    private suspend fun startResearch(threadId: Long?, topic: String) {
-        val runId = try {
-            // 条目会话附上标题/链接锚点（拼装收口在此：发送与重试都传原文，各自重拼保证同构）
-            engine.createResearch(ResearchTopics.compose(topic, activeContext))
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            // 不只 catch ChatException：Demo/预览引擎的默认实现抛 UnsupportedOperationException，逃逸即崩
-            val error = (e as? ChatException)?.error
-                ?: ChatError(ChatErrorCategory.UNKNOWN, detail = e.toString())
-            trackFailure(MessageKind.DEEP_RESEARCH, error)
-            updateThreadMessages(threadId) {
-                it + ChatMessage(nextId(), Role.ASSISTANT, "", error = error, kind = MessageKind.DEEP_RESEARCH)
-            }
-            if (threadId == _currentThreadId.value) _uiState.update { it.copy(isSending = false) }
-            return
-        }
-        // 占位行即恢复载体：提交成功立即落库。缓冲内一律用内存 id，Room 行 id 另记映射
-        // 供终局写库（见 researchRowIds 的重号说明）
-        val messageId = nextId()
-        if (store != null && threadId != null) {
-            researchRowIds[messageId] = store.persistResearchPlaceholder(threadId, runId)
-        }
-        updateThreadMessages(threadId) {
-            it + ChatMessage(messageId, Role.ASSISTANT, "", kind = MessageKind.DEEP_RESEARCH, searching = true, researchRunId = runId)
-        }
-        launchResearchPolling(threadId, messageId, runId)
+        val threadId = ensureThread(topic)
+        appendVisible(store.appendUserMessage(threadId, topic, kind = MessageKind.DEEP_RESEARCH))
+        // 条目会话附上标题/链接锚点（发送与重试都传原文、各自重拼，保证同构）
+        appendVisible(research.submit(threadId, ResearchTopics.compose(topic, activeContext)))
+        // 提交落定即解锁输入：轮询可能持续小时级，期间会话仍可正常对话
+        _uiState.update { it.copy(isSending = false) }
     }
 
     /** research 错误条的重试：任务已在服务端存在则恢复轮询同一 runId（绝不重复建任务——
-     *  会重复扣费）；任务未建立（提交失败 / 已判死删行）则取相邻提问重新提交 */
-    private fun retryResearch(message: ChatMessage) {
-        val threadId = _currentThreadId.value
+     *  会重复扣费）；任务未建立（提交失败 / 空报告判死）则取相邻提问重新提交 */
+    private suspend fun retryResearch(message: ChatMessage) {
+        val threadId = _currentThreadId.value ?: return
         val runId = message.researchRunId
-        // 两条路都会走到一个终态 ai_completed（恢复轮询也一样），不补就落单
-        track(ChatAiEvent.Requested(ChatAiKind.RESEARCH, from = "retry"))
         if (runId != null) {
-            updateThreadMessages(threadId) { list ->
-                list.map { if (it.id == message.id) it.copy(error = null, searching = true) else it }
-            }
-            _uiState.update { it.copy(isSending = true) }
-            launchResearchPolling(threadId, message.id, runId)
+            track(ChatAiEvent.Requested(ChatAiKind.RESEARCH, from = "retry"))
+            store.resetResearchPlaceholder(threadId, message.id, runId)
+            applyToVisible(message.id) { it.copy(error = null, searching = true) }
+            research.startPolling(threadId, message.id, runId)
             return
         }
-        val messages = messagesByThread[threadId] ?: emptyList()
+        val messages = _uiState.value.messages
         val index = messages.indexOfFirst { it.id == message.id }
         val topic = messages.take(index.coerceAtLeast(0))
             .lastOrNull { it.role == Role.USER && it.kind == MessageKind.DEEP_RESEARCH }
             ?.content ?: return
-        updateThreadMessages(threadId) { list -> list.filterNot { it.id == message.id } }
+        track(ChatAiEvent.Requested(ChatAiKind.RESEARCH, from = "retry"))
+        store.deleteMessage(message.id)
+        removeVisible(message.id)
         _uiState.update { it.copy(isSending = true) }
-        viewModelScope.launch { startResearch(threadId, topic) }
+        appendVisible(research.submit(threadId, ResearchTopics.compose(topic, activeContext)))
+        _uiState.update { it.copy(isSending = false) }
     }
 
+    // 流式管线
+
     /**
-     * 轮询任务：快轮 8s 覆盖正常时长，转慢轮 60s 直到盖过服务端 2h 超龄判死闸——服务端
-     * 保证死任务终会转 failed，客户端跟到那个终态为止，不留「静默停轮永远转圈」的僵尸态。
-     * 绝对上限仍无终态（异常情况）→ 呈现可重试错误，runId 保留（重试恢复轮询，不重复扣费）。
+     * 统一请求路径：先追加流式占位（[PLACEHOLDER_ID]），delta 到达时增量更新其 content；
+     * 终局在 [stateLock] 内收口——成功以全文落库并替换占位，失败落错误行（整条重试）。
+     * 流协程只在占位上做原子更新，不碰其他状态，取消它无需回滚。
      */
-    private fun launchResearchPolling(threadId: Long?, messageId: Long, runId: String) {
-        if (researchJobs[messageId]?.isActive == true) return
+    private fun startStream(threadId: Long, kind: MessageKind, context: ChatContext?) {
+        val startedAt = epochMillis()
+        _uiState.update {
+            it.copy(messages = it.messages + ChatMessage(PLACEHOLDER_ID, Role.ASSISTANT, "", kind = kind))
+        }
         val job = viewModelScope.launch {
-            repeat(MAX_RESEARCH_POLLS + MAX_RESEARCH_SLOW_POLLS) { attempt ->
-                delay(if (attempt < MAX_RESEARCH_POLLS) RESEARCH_POLL_MS else RESEARCH_SLOW_POLL_MS)
-                val run = try {
-                    engine.pollResearch(runId)
-                } catch (e: ChatException) {
-                    // 瞬态（网络/超时/5xx）继续轮；永久错误（鉴权/配额/非法请求）终局呈现——
-                    // 否则用户只看到转圈直到静默停轮（Sourcery 审查确认的 bug）。
-                    // 占位行不删：任务可能仍在服务端跑完，重登后重试/重开会话可恢复
-                    if (e.error.category.retryable) return@repeat
-                    trackFailure(MessageKind.DEEP_RESEARCH, e.error)
-                    updateThreadMessages(threadId) { list ->
-                        list.map { if (it.id == messageId) it.copy(searching = false, error = e.error) else it }
-                    }
-                    finishResearch(threadId, messageId)
-                    return@launch
-                }
-                when (run.status) {
-                    "completed" -> {
-                        val report = run.report.orEmpty()
-                        if (report.isBlank()) {
-                            // 空报告视同失败（服务端已按失败退款）：直接写回空串会留下一个
-                            // 永远满足恢复哨兵的空占位——每次开会话闪一次、清不掉
-                            store?.deleteMessage(researchRowId(messageId))
-                            val error = ChatError(ChatErrorCategory.SERVER, detail = "empty report")
-                            track(ChatAiEvent.Completed(ChatAiKind.RESEARCH, ChatAiOutcome.ERROR, reason = "empty_report"))
-                            updateThreadMessages(threadId) { list ->
-                                list.map { if (it.id == messageId) it.copy(searching = false, error = error, researchRunId = null) else it }
-                            }
-                        } else {
-                            if (store != null && threadId != null) {
-                                store.completeResearchMessage(threadId, researchRowId(messageId), report, runId, run.model)
-                            }
-                            updateThreadMessages(threadId) { list ->
-                                list.map { if (it.id == messageId) it.copy(content = report, searching = false, model = run.model) else it }
-                            }
-                            track(ChatAiEvent.Completed(ChatAiKind.RESEARCH, ChatAiOutcome.OK))
+            var cacheHit = false
+            val result = runCatching {
+                when (kind) {
+                    MessageKind.CHAT -> {
+                        // 空 assistant 行（错误条 / research 占位）不进 history：对模型无信息量，
+                        // 且上游可能拒空 content
+                        val history = _uiState.value.messages.filterNot {
+                            it.id == PLACEHOLDER_ID || (it.role == Role.ASSISTANT && it.content.isBlank())
                         }
-                        finishResearch(threadId, messageId)
-                        return@launch
+                        engine.send(
+                            history,
+                            context,
+                            onDelta = { appendDelta(it) },
+                            search = _chatMode.value == ChatMode.WebSearch,
+                            onSearch = { applySearchEvent(it) },
+                        )
                     }
-                    "failed" -> {
-                        store?.deleteMessage(researchRowId(messageId))
-                        val error = ChatError(ChatErrorCategory.SERVER, detail = run.error ?: "research failed")
-                        track(ChatAiEvent.Completed(ChatAiKind.RESEARCH, ChatAiOutcome.ERROR, reason = run.error ?: "unknown"))
-                        updateThreadMessages(threadId) { list ->
-                            list.map { if (it.id == messageId) it.copy(searching = false, error = error, researchRunId = null) else it }
-                        }
-                        finishResearch(threadId, messageId)
-                        return@launch
+                    MessageKind.DETAIL_SUMMARY -> {
+                        val detail = engine.sendDetailSummary(requireNotNull(context)) { appendDelta(it) }
+                        cacheHit = detail.cached
+                        detail.content
                     }
-                    else -> Unit // running：继续
+                    MessageKind.DEEP_RESEARCH -> error("research 走 ResearchRunner，不进流式管线")
                 }
             }
-            // 绝对上限：已超过服务端判死闸仍无终态，属异常。呈现可重试错误（runId 保留 →
-            // 重试恢复轮询同一任务；库中占位行保留 → 跨进程仍可恢复），不再无限转圈
-            val error = ChatError(ChatErrorCategory.TIMEOUT, detail = "research polling exhausted")
-            trackFailure(MessageKind.DEEP_RESEARCH, error)
-            updateThreadMessages(threadId) { list ->
-                list.map { if (it.id == messageId) it.copy(searching = false, error = error) else it }
-            }
-            finishResearch(threadId, messageId)
+            // 取消不是失败：runCatching 连 CancellationException 一起吞，必须重抛——
+            // 终局收口交给取消方（cancelInFlight），这里再进锁会与它互等
+            result.exceptionOrNull()?.let { if (it is CancellationException) throw it }
+            stateLock.withLock { finishStream(threadId, kind, result, startedAt, cacheHit) }
         }
-        researchJobs[messageId] = job
+        inFlight = InFlightSend(threadId, kind, startedAt, job)
     }
 
-    /** 占位行的 Room 行 id：同会话建的走映射，重启后从库载入的消息 id 本身就是行 id */
-    private fun researchRowId(messageId: Long): Long = researchRowIds[messageId] ?: messageId
-
-    private fun finishResearch(threadId: Long?, messageId: Long) {
-        researchJobs.remove(messageId)
-        if (threadId == _currentThreadId.value) _uiState.update { it.copy(isSending = false) }
-    }
-
-    /** 恢复：打开会话时发现「空内容 + runId」的 research 占位 → 续轮询 */
-    private fun resumeResearchIfAny(threadId: Long?, messages: List<ChatMessage>) {
-        messages.filter { it.kind == MessageKind.DEEP_RESEARCH && it.content.isBlank() && it.researchRunId != null && it.error == null }
-            .forEach { placeholder ->
-                updateThreadMessages(threadId) { list ->
-                    list.map { if (it.id == placeholder.id) it.copy(searching = true) else it }
+    private suspend fun finishStream(
+        threadId: Long,
+        kind: MessageKind,
+        result: Result<String>,
+        startedAt: Long,
+        cacheHit: Boolean,
+    ) {
+        inFlight = null
+        result.fold(
+            onSuccess = { full ->
+                if (full.isBlank()) {
+                    // 空回复（如内容过滤拒答）：不落库也不留幽灵气泡
+                    removeVisible(PLACEHOLDER_ID)
+                } else {
+                    val sources = _uiState.value.messages
+                        .firstOrNull { it.id == PLACEHOLDER_ID }?.sources.orEmpty()
+                    replaceVisible(
+                        PLACEHOLDER_ID,
+                        store.appendAssistantMessage(threadId, full, kind, selectedModelId(), sources),
+                    )
                 }
-                launchResearchPolling(threadId, placeholder.id, placeholder.researchRunId!!)
-            }
-    }
-
-    /** 搜索事件落到占位消息：searching 瞬态 + sources 累积（服务端已按 url 去重，客户端再防御一层） */
-    private fun applySearchEvent(threadId: Long?, messageId: Long, event: SearchEvent) {
-        updateThreadMessages(threadId) { list ->
-            list.map { m ->
-                if (m.id != messageId) m
-                else when (event) {
-                    is SearchEvent.Started -> m.copy(searching = true)
-                    is SearchEvent.Done -> m.copy(searching = false)
-                    is SearchEvent.Source ->
-                        m.copy(sources = (m.sources + SourceRef(event.title, event.url)).distinctBy { it.url })
-                }
-            }
-        }
-    }
-
-    private fun appendDelta(threadId: Long?, messageId: Long, delta: String) {
-        updateThreadMessages(threadId) { list ->
-            list.map { if (it.id == messageId) it.copy(content = it.content + delta) else it }
-        }
-    }
-
-    /** 所有消息变更的唯一入口：写缓冲，且仅当该线是当前线时镜像进 uiState */
-    private fun updateThreadMessages(threadId: Long?, transform: (List<ChatMessage>) -> List<ChatMessage>) {
-        val updated = transform(messagesByThread[threadId] ?: emptyList())
-        messagesByThread[threadId] = updated
-        if (threadId == _currentThreadId.value) {
-            _uiState.update { it.copy(messages = updated) }
-        }
+                track(
+                    ChatAiEvent.Completed(
+                        kind.toAiKind(),
+                        if (cacheHit) ChatAiOutcome.CACHE_HIT else ChatAiOutcome.OK,
+                        durationMs = epochMillis() - startedAt,
+                    ),
+                )
+            },
+            onFailure = { e ->
+                val error = (e as? ChatException)?.error
+                    ?: ChatError(ChatErrorCategory.UNKNOWN, detail = e.toString())
+                track(failureEvent(kind, error, epochMillis() - startedAt))
+                // 已渲染部分丢弃，整条重试（中途断流语义）
+                replaceVisible(PLACEHOLDER_ID, store.appendErrorMessage(threadId, kind, error))
+            },
+        )
+        _uiState.update { it.copy(isSending = false) }
     }
 
     /**
-     * 每次失败恰好一条 ai_completed，与 ai_requested 成对。配额触顶（付费意愿漏斗第一级）
-     * 与匿名解读登录闸（登录转化信号）都靠 `reason` 区分，不再各开一个事件。
-     * 在 VM 记而不是 UI 记：重组会重复上报。
+     * 取消在途流（持锁调用）。[persistInterrupted]：会话还在（切换/重置）时落一条可重试的
+     * 中断错误行，用户切回能看到「回复被打断」而非凭空少一条；线程将删时不落。
+     * 无论哪种都补 ai_completed(interrupted)——取消也是终态，不补则与 ai_requested 失配。
      */
-    private fun trackFailure(kind: MessageKind, error: ChatError, durationMs: Long? = null) {
+    private suspend fun cancelInFlight(persistInterrupted: Boolean) {
+        val flight = inFlight ?: return
+        inFlight = null
+        // 流协程若正等本锁，cancel 会把它从锁等待中打断，不会互等
+        flight.job.cancel()
+        flight.job.join()
+        removeVisible(PLACEHOLDER_ID)
+        _uiState.update { it.copy(isSending = false) }
         track(
             ChatAiEvent.Completed(
-                kind = kind.toAiKind(),
-                outcome = if (error.code == ChatError.CODE_STREAM_INTERRUPTED) {
-                    ChatAiOutcome.INTERRUPTED
-                } else {
-                    ChatAiOutcome.ERROR
-                },
-                durationMs = durationMs,
-                reason = error.code ?: error.category.name.lowercase(),
-                tier = if (error.code == ChatError.CODE_QUOTA_DEVICE) {
-                    error.tier ?: ChatError.TIER_ANONYMOUS
-                } else {
-                    null
-                },
-            )
+                flight.kind.toAiKind(),
+                ChatAiOutcome.INTERRUPTED,
+                durationMs = epochMillis() - flight.startedAt,
+                reason = "canceled",
+            ),
         )
+        if (persistInterrupted) {
+            val error = ChatError(
+                ChatErrorCategory.SERVER,
+                code = ChatError.CODE_STREAM_INTERRUPTED,
+                detail = "canceled: session switched away",
+            )
+            store.appendErrorMessage(flight.threadId, flight.kind, error)
+        }
     }
 
-    private fun MessageKind.toAiKind(): ChatAiKind = when (this) {
-        MessageKind.CHAT -> ChatAiKind.CHAT
-        MessageKind.DETAIL_SUMMARY -> ChatAiKind.DETAIL_SUMMARY
-        MessageKind.DEEP_RESEARCH -> ChatAiKind.RESEARCH
+    // 会话状态（持锁调用）
+
+    private suspend fun openThread(id: Long) {
+        val messages = store.loadMessages(id).map {
+            if (it.kind == MessageKind.DEEP_RESEARCH && it.content.isBlank() &&
+                it.researchRunId != null && it.error == null
+            ) it.copy(searching = true) else it
+        }
+        _currentThreadId.value = id
+        activeContext = store.contextOf(id)
+        _uiState.update {
+            it.copy(messages = messages, isSending = false, pendingImages = emptyList())
+        }
+        messages.filter { it.searching }.forEach { research.startPolling(id, it.id, it.researchRunId!!) }
+    }
+
+    private fun resetSession(context: ChatContext?, clearInput: Boolean) {
+        activeContext = context
+        _currentThreadId.value = null
+        _uiState.update {
+            it.copy(
+                messages = emptyList(),
+                isSending = false,
+                input = if (clearInput) "" else it.input,
+                pendingImages = emptyList(),
+            )
+        }
+    }
+
+    /** 首条消息才建线（懒建）；当前线已存在则直接复用 */
+    private suspend fun ensureThread(firstMessageText: String): Long {
+        _currentThreadId.value?.let { return it }
+        val id = store.createThread(activeContext, firstMessageText)
+        _currentThreadId.value = id
+        return id
+    }
+
+    // 可见列表的原子更新（消息 id 全局唯一，按 id 定位即可，无需 threadId）
+
+    private fun appendVisible(message: ChatMessage) {
+        _uiState.update { it.copy(messages = it.messages + message) }
+    }
+
+    private fun removeVisible(messageId: Long) {
+        _uiState.update { s -> s.copy(messages = s.messages.filterNot { it.id == messageId }) }
+    }
+
+    private fun replaceVisible(messageId: Long, replacement: ChatMessage) {
+        _uiState.update { s ->
+            s.copy(messages = s.messages.map { if (it.id == messageId) replacement else it })
+        }
+    }
+
+    private fun applyToVisible(messageId: Long, transform: (ChatMessage) -> ChatMessage) {
+        _uiState.update { s ->
+            s.copy(messages = s.messages.map { if (it.id == messageId) transform(it) else it })
+        }
+    }
+
+    /** 流式增量与搜索事件只落在占位上：单次原子更新，无锁也不会与串行操作交错出错态 */
+    private fun appendDelta(delta: String) =
+        applyToVisible(PLACEHOLDER_ID) { it.copy(content = it.content + delta) }
+
+    private fun applySearchEvent(event: SearchEvent) = applyToVisible(PLACEHOLDER_ID) { m ->
+        when (event) {
+            is SearchEvent.Started -> m.copy(searching = true)
+            is SearchEvent.Done -> m.copy(searching = false)
+            is SearchEvent.Source ->
+                m.copy(sources = (m.sources + SourceRef(event.title, event.url)).distinctBy { it.url })
+        }
     }
 
     companion object {
         /** 单条消息图片数上限：服务端 app-config 下发（KV 单源），未拉到用与服务端一致的默认 */
         fun maxImagesPerMessage(): Int = chatHost.imagesMaxCount()
 
-        /** research 轮询节奏：快轮 8s×90（≈12 分钟）覆盖正常任务时长，慢轮 60s×110（≈110 分钟）
-         *  盖过服务端 2h 超龄判死闸——每个任务都能等到服务端终态，不留僵尸占位 */
-        private const val RESEARCH_POLL_MS = 8_000L
-        private const val MAX_RESEARCH_POLLS = 90
-        private const val RESEARCH_SLOW_POLL_MS = 60_000L
-        private const val MAX_RESEARCH_SLOW_POLLS = 110
+        /** 流式占位的保留 id：store 行 id 恒为正，负值永不与真实消息撞号 */
+        private const val PLACEHOLDER_ID = -1L
     }
 }

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ResearchRunner.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ResearchRunner.kt
@@ -1,0 +1,148 @@
+package whl.trending.chat
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import whl.trending.chat.engine.ChatEngine
+import whl.trending.chat.engine.ChatException
+import whl.trending.chat.host.ChatAiEvent
+import whl.trending.chat.host.ChatAiKind
+import whl.trending.chat.host.ChatAiOutcome
+import whl.trending.chat.model.ChatError
+import whl.trending.chat.model.ChatErrorCategory
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.MessageKind
+import whl.trending.chat.store.ChatStore
+
+/**
+ * Deep Research 的提交与轮询。任务是服务端资产（已扣费），生命周期独立于会话切换：
+ * 轮询终局先写库，再经 [applyToVisible] 按消息 id 更新可见列表（不在当前会话就只落库，
+ * 用户切过去即见终局）。消息 id 即 store 行 id，全局唯一，可见性判定不需要 threadId。
+ *
+ * @param applyToVisible (messageId, transform)：该消息在当前可见列表中则应用变换，否则忽略
+ */
+internal class ResearchRunner(
+    private val scope: CoroutineScope,
+    private val engine: ChatEngine,
+    private val store: ChatStore,
+    private val track: (ChatAiEvent) -> Unit,
+    private val applyToVisible: (Long, (ChatMessage) -> ChatMessage) -> Unit,
+) {
+
+    private class Polling(val threadId: Long, val job: Job)
+
+    private val jobs = mutableMapOf<Long, Polling>()
+
+    /**
+     * 提交任务。成功：占位行落库、启动轮询，返回占位消息（searching=true）；
+     * 失败：错误行落库并记终态埋点，返回错误消息。两种返回调用方直接追加即可。
+     */
+    suspend fun submit(threadId: Long, topic: String): ChatMessage {
+        val runId = try {
+            engine.createResearch(topic)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            // 不只 catch ChatException：Demo/预览引擎的默认实现抛 UnsupportedOperationException，逃逸即崩
+            val error = (e as? ChatException)?.error
+                ?: ChatError(ChatErrorCategory.UNKNOWN, detail = e.toString())
+            track(failureEvent(MessageKind.DEEP_RESEARCH, error))
+            return store.appendErrorMessage(threadId, MessageKind.DEEP_RESEARCH, error)
+        }
+        val placeholder = store.appendResearchPlaceholder(threadId, runId)
+        startPolling(threadId, placeholder.id, runId)
+        return placeholder.copy(searching = true)
+    }
+
+    /** 幂等：同一占位行已有在途轮询则不重复发起 */
+    fun startPolling(threadId: Long, messageId: Long, runId: String) {
+        if (jobs[messageId]?.job?.isActive == true) return
+        val job = scope.launch {
+            try {
+                poll(threadId, messageId, runId)
+            } finally {
+                jobs.remove(messageId)
+            }
+        }
+        jobs[messageId] = Polling(threadId, job)
+    }
+
+    /**
+     * 跨进程恢复**所有**未完成轮询，与「当前打开哪个会话」无关——挂着任务的会话
+     * 可能永远不被打开，但任务已扣费，轮询照常落库，用户从抽屉切过去就能看到报告。
+     */
+    suspend fun resumeAll() {
+        store.pendingResearch().forEach { pending ->
+            startPolling(pending.threadId, pending.messageId, pending.runId)
+            applyToVisible(pending.messageId) { it.copy(searching = true) }
+        }
+    }
+
+    /** 线程行将消失，终局写库会撞外键，轮询一并取消 */
+    fun cancelForThread(threadId: Long) {
+        jobs.filterValues { it.threadId == threadId }.forEach { (messageId, polling) ->
+            polling.job.cancel()
+            jobs.remove(messageId)
+        }
+    }
+
+    /**
+     * 快轮 8s 覆盖正常时长，转慢轮 60s 直到盖过服务端 2h 超龄判死闸——服务端保证死任务
+     * 终会转 failed，客户端跟到那个终态为止。绝对上限仍无终态（异常）→ 可重试错误，
+     * runId 保留（重试恢复轮询，不重复扣费）。
+     */
+    private suspend fun poll(threadId: Long, messageId: Long, runId: String) {
+        repeat(MAX_FAST_POLLS + MAX_SLOW_POLLS) { attempt ->
+            delay(if (attempt < MAX_FAST_POLLS) FAST_POLL_MS else SLOW_POLL_MS)
+            val run = try {
+                engine.pollResearch(runId)
+            } catch (e: ChatException) {
+                // 瞬态（网络/超时/5xx）继续轮；永久错误（鉴权/配额/非法请求）终局呈现。
+                // runId 保留：任务可能仍在服务端跑完，重试可恢复轮询
+                if (e.error.category.retryable) return@repeat
+                track(failureEvent(MessageKind.DEEP_RESEARCH, e.error))
+                store.markResearchError(threadId, messageId, e.error, runId = runId)
+                applyToVisible(messageId) { it.copy(searching = false, error = e.error) }
+                return
+            }
+            when (run.status) {
+                "completed" -> {
+                    val report = run.report.orEmpty()
+                    if (report.isBlank()) {
+                        // 空报告视同失败（服务端已按失败退款）；runId 置空防止重启误续死任务
+                        val error = ChatError(ChatErrorCategory.SERVER, detail = "empty report")
+                        track(ChatAiEvent.Completed(ChatAiKind.RESEARCH, ChatAiOutcome.ERROR, reason = "empty_report"))
+                        store.markResearchError(threadId, messageId, error, runId = null)
+                        applyToVisible(messageId) { it.copy(searching = false, error = error, researchRunId = null) }
+                    } else {
+                        store.completeResearch(threadId, messageId, report, runId, run.model)
+                        applyToVisible(messageId) { it.copy(content = report, searching = false, model = run.model) }
+                        track(ChatAiEvent.Completed(ChatAiKind.RESEARCH, ChatAiOutcome.OK))
+                    }
+                    return
+                }
+                "failed" -> {
+                    val error = ChatError(ChatErrorCategory.SERVER, detail = run.error ?: "research failed")
+                    track(ChatAiEvent.Completed(ChatAiKind.RESEARCH, ChatAiOutcome.ERROR, reason = run.error ?: "unknown"))
+                    store.markResearchError(threadId, messageId, error, runId = null)
+                    applyToVisible(messageId) { it.copy(searching = false, error = error, researchRunId = null) }
+                    return
+                }
+                else -> Unit // running：继续
+            }
+        }
+        val error = ChatError(ChatErrorCategory.TIMEOUT, detail = "research polling exhausted")
+        track(failureEvent(MessageKind.DEEP_RESEARCH, error))
+        store.markResearchError(threadId, messageId, error, runId = runId)
+        applyToVisible(messageId) { it.copy(searching = false, error = error) }
+    }
+
+    private companion object {
+        const val FAST_POLL_MS = 8_000L
+        const val MAX_FAST_POLLS = 90
+        const val SLOW_POLL_MS = 60_000L
+        const val MAX_SLOW_POLLS = 110
+    }
+}

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ResearchRunner.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ResearchRunner.kt
@@ -98,13 +98,19 @@ internal class ResearchRunner(
             delay(if (attempt < MAX_FAST_POLLS) FAST_POLL_MS else SLOW_POLL_MS)
             val run = try {
                 engine.pollResearch(runId)
-            } catch (e: ChatException) {
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
                 // 瞬态（网络/超时/5xx）继续轮；永久错误（鉴权/配额/非法请求）终局呈现。
-                // runId 保留：任务可能仍在服务端跑完，重试可恢复轮询
-                if (e.error.category.retryable) return@repeat
-                track(failureEvent(MessageKind.DEEP_RESEARCH, e.error))
-                store.markResearchError(threadId, messageId, e.error, runId = runId)
-                applyToVisible(messageId) { it.copy(searching = false, error = e.error) }
+                // 非 ChatException（如不支持 research 的引擎抛 UnsupportedOperationException）
+                // 一律按永久错误收口——逃逸出 launch 就是崩溃。runId 保留：任务可能仍在
+                // 服务端跑完，重试可恢复轮询
+                if (e is ChatException && e.error.category.retryable) return@repeat
+                val error = (e as? ChatException)?.error
+                    ?: ChatError(ChatErrorCategory.UNKNOWN, detail = e.toString())
+                track(failureEvent(MessageKind.DEEP_RESEARCH, error))
+                store.markResearchError(threadId, messageId, error, runId = runId)
+                applyToVisible(messageId) { it.copy(searching = false, error = error) }
                 return
             }
             when (run.status) {

--- a/chat/src/commonMain/kotlin/whl/trending/chat/db/ChatDatabase.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/db/ChatDatabase.kt
@@ -16,8 +16,7 @@ import kotlinx.coroutines.flow.Flow
 /**
  * 会话线：一次对话的容器。
  *
- * @param entryKey 入口键（`repo:{externalId}` / `general`）——「同一入口再次进入恢复最近会话」
- *   按此列查询（延续原 sessionKey 的体验，但跨进程存活）
+ * @param entryKey 入口键（`repo:{externalId}` / `general`），留痕会话来自哪个入口
  * @param contextJson 进入时的 [whl.trending.chat.ChatContext] 序列化（通用入口为 null）；
  *   恢复历史会话后「一键解读」chip 与服务端 context 注入都依赖它——不存等于恢复的会话丢了灵魂
  * @param updatedAt 排序键：列表按最近活跃倒序
@@ -33,13 +32,13 @@ data class ThreadEntity(
 )
 
 /**
- * 持久化消息。error 消息不落库（失败是瞬态 UI 状态，可重试；重启后无意义），
- * 流式过程零写库——user 消息即发即落，assistant 仅在成功终局落一次。
+ * 持久化消息。流式过程零写库——user 消息即发即落，assistant 在终局落一次
+ * （成功为全文，失败为错误行：content 空、错误详情进 segmentsJson）。
  *
  * @param imagesJson 用户附图的本地路径列表（JSON）；持久化文件在 filesDir/chat_images，
  *   删线程时先删文件再删行（CASCADE 之后路径就找不回了）
  * @param model 应答模型 id（用户在选择器里选的；展示「哪个模型答的」用）
- * @param segmentsJson P2 预留：富内容时间线信封（JSON，含 v 版本字段），本期恒 null
+ * @param segmentsJson 富内容信封（JSON，含 v 版本字段）：搜索来源 / research runId / 错误终局
  */
 @Entity(
     tableName = "chat_messages",
@@ -76,10 +75,6 @@ interface ThreadDao {
     @Query("SELECT * FROM chat_threads WHERE id = :id")
     suspend fun getById(id: Long): ThreadEntity?
 
-    /** 入口恢复语义：该入口最近活跃的会话线 */
-    @Query("SELECT * FROM chat_threads WHERE entryKey = :entryKey ORDER BY updatedAt DESC LIMIT 1")
-    suspend fun latestByEntry(entryKey: String): ThreadEntity?
-
     @Query("UPDATE chat_threads SET title = :title WHERE id = :id")
     suspend fun rename(id: Long, title: String)
 
@@ -111,14 +106,11 @@ interface MessageDao {
     suspend fun deleteById(id: Long)
 
     /**
-     * 仍有未完成 research 占位（空内容）的会话 id。
-     *
-     * 恢复轮询不能只覆盖「当前打开的会话」：通用入口进入即新会话，之前那条挂着任务的
-     * 会话不会被打开，任务就没人接了。runId 存在 segmentsJson 里，SQL 侧只筛到「空内容
-     * 的 research 行」，由 [whl.trending.chat.ChatViewModel] 再按 runId 过滤。
+     * 空内容的 research 行（占位或错误终局，runId/error 在 segmentsJson 里，
+     * 由 [RoomChatStore.pendingResearch] 解码后过滤出真正待恢复的占位）。
      */
-    @Query("SELECT DISTINCT threadId FROM chat_messages WHERE kind = :kind AND content = ''")
-    suspend fun threadsWithPendingResearch(kind: String): List<Long>
+    @Query("SELECT * FROM chat_messages WHERE kind = :kind AND content = ''")
+    suspend fun pendingResearchRows(kind: String): List<MessageEntity>
 }
 
 @Database(entities = [ThreadEntity::class, MessageEntity::class], version = 1, exportSchema = true)

--- a/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatMessage.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatMessage.kt
@@ -5,8 +5,7 @@ enum class Role { USER, ASSISTANT }
 
 /**
  * 消息由哪条管线生成：驱动 chip 可见性与 retry 路由（解读失败重试回 detail 管线），渲染无差别。
- * 若未来新增 kind 需要消息级再生成参数或差异化渲染，届时再升级为 sealed interface——
- * 会话仅内存存储，重构无兼容成本。
+ * 随消息持久化（kind 列存枚举名），新增值向后兼容、改名不兼容。
  */
 enum class MessageKind { CHAT, DETAIL_SUMMARY, DEEP_RESEARCH }
 

--- a/chat/src/commonMain/kotlin/whl/trending/chat/store/ChatStore.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/store/ChatStore.kt
@@ -1,252 +1,96 @@
 package whl.trending.chat.store
 
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
+import kotlinx.coroutines.flow.Flow
 import whl.trending.chat.ChatContext
-import whl.trending.chat.db.ChatDatabase
-import whl.trending.chat.db.MessageEntity
-import whl.trending.chat.db.ThreadEntity
+import whl.trending.chat.ThreadSummary
+import whl.trending.chat.model.ChatError
 import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.MessageKind
-import whl.trending.chat.model.Role
 import whl.trending.chat.model.SourceRef
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
-import okio.FileSystem
-import okio.Path.Companion.toPath
-import okio.SYSTEM
-import whl.trending.chat.core.epochMillis
+
+/** 跨进程恢复轮询的载体：库里「空内容 + runId + 无 error」的 research 占位行 */
+data class PendingResearch(val threadId: Long, val messageId: Long, val runId: String)
 
 /**
- * 会话持久化层。落库策略（EchoFlow 经验的裁剪版，见 ai-chat/chat-改造评估方案-v2.md P1）：
- * - 懒建：进入 chat 不落库，首条消息发出时才建 thread；
- * - 终局一次写：流式过程零写库，user 消息即发即落，assistant 仅成功终局落一次，
- *   error 消息不落（瞬态可重试，重启后无意义）；
- * - 图片落库时从 cacheDir 拷入 [imagesDir]（filesDir 下，系统不清理），删线程先删文件再删行。
+ * 会话持久化契约。消息 id 全局唯一且由 store 分配（Room 实现即行 id）——
+ * VM 侧不再维护第二套 id 序列，所有 append* 方法返回带最终 id 的消息。
  *
- * @param clock 时间注入点（测试替身）；updatedAt 排序与懒建时间戳共用
+ * 落库策略（EchoFlow 经验的裁剪版，见 ai-chat/chat-改造评估方案-v2.md P1）：
+ * - 懒建：进入 chat 不落库，首条消息发出时才建 thread；
+ * - user 消息即发即落；assistant 成功终局落一次（流式过程零写库）；
+ * - error 也落库（重启后错误条仍可见可重试，且 id 空间保持单一）；
+ * - research 占位行提交成功即落（跨进程恢复轮询的载体）。
  */
-class ChatStore(
-    private val db: ChatDatabase,
-    private val imagesDir: String,
-    private val clock: () -> Long = { epochMillis() },
-) {
+interface ChatStore {
 
-    /** 入口恢复语义：该入口最近活跃的会话 id；无历史返回 null（UI 呈现空态，不落库） */
-    suspend fun resolveLatestThread(context: ChatContext?): Long? =
-        db.threadDao().latestByEntry(entryKeyOf(context))?.id
+    fun threads(): Flow<List<ThreadSummary>>
 
-    /**
-     * 懒建或复用：同入口已有会话直接复用最近的，否则以首条消息建线。
-     * 标题优先取 context 标题（repo 名可读性最好），通用入口取首条消息截断。
-     */
-    suspend fun ensureThread(context: ChatContext?, firstMessageText: String): Long {
-        db.threadDao().latestByEntry(entryKeyOf(context))?.let { return it.id }
-        return createThread(context, firstMessageText)
-    }
+    /** 总是新建（入口进入与抽屉「新会话」同语义：不复用历史） */
+    suspend fun createThread(context: ChatContext?, firstMessageText: String): Long
 
-    /** 总是新建（抽屉「新会话」语义）——入口复用由 [resolveLatestThread] 在进入时单独承担 */
-    suspend fun createThread(context: ChatContext?, firstMessageText: String): Long {
-        val now = clock()
-        return db.threadDao().insert(
-            ThreadEntity(
-                title = context?.title ?: titleFrom(firstMessageText),
-                entryKey = entryKeyOf(context),
-                contextJson = context?.let { json.encodeToString(StoredContext.from(it)) },
-                createdAt = now,
-                updatedAt = now,
-            ),
-        )
-    }
+    /** 会话的 ChatContext（解读 chip 与服务端 context 注入依赖）；通用入口/解析失败为 null */
+    suspend fun contextOf(threadId: Long): ChatContext?
 
-    /** 恢复会话的 ChatContext（解读 chip 与服务端 context 注入依赖）；通用入口/解析失败为 null */
-    suspend fun contextOf(threadId: Long): ChatContext? =
-        db.threadDao().getById(threadId)?.contextJson?.let { raw ->
-            runCatching { json.decodeFromString<StoredContext>(raw).toContext() }.getOrNull()
-        }
+    suspend fun loadMessages(threadId: Long): List<ChatMessage>
 
-    /** user 消息即发即落；图片从 cacheDir 拷入 filesDir 并回写新路径（cache 可被系统清理） */
-    suspend fun persistUserMessage(threadId: Long, message: ChatMessage): ChatMessage {
-        val persistedImages = message.images.map { copyIntoStore(it) }
-        val stored = message.copy(images = persistedImages)
-        db.messageDao().insert(stored.toEntity(threadId, clock()))
-        db.threadDao().touch(threadId, clock())
-        return stored
-    }
+    suspend fun renameThread(threadId: Long, title: String)
 
-    /** assistant 仅成功终局落一次；空内容（如内容过滤拒答）不落空行 */
-    suspend fun persistAssistantMessage(
+    suspend fun deleteThread(threadId: Long)
+
+    /** user 消息落库；图片迁入持久目录后路径可能改写，以返回值为准 */
+    suspend fun appendUserMessage(
+        threadId: Long,
+        text: String,
+        images: List<String> = emptyList(),
+        kind: MessageKind = MessageKind.CHAT,
+    ): ChatMessage
+
+    suspend fun appendAssistantMessage(
         threadId: Long,
         content: String,
         kind: MessageKind,
         model: String?,
         sources: List<SourceRef> = emptyList(),
-    ) {
-        if (content.isBlank()) return
-        db.messageDao().insert(
-            MessageEntity(
-                threadId = threadId,
-                role = ROLE_ASSISTANT,
-                content = content,
-                imagesJson = null,
-                kind = kind.name,
-                model = model,
-                segmentsJson = sources.takeIf { it.isNotEmpty() }
-                    ?.let { json.encodeToString(StoredSegments(sources = it.map { s -> StoredSource(s.title, s.url) })) },
-                createdAt = clock(),
-            ),
-        )
-        db.threadDao().touch(threadId, clock())
-    }
+    ): ChatMessage
 
-    suspend fun loadMessages(threadId: Long): List<ChatMessage> =
-        db.messageDao().messagesFor(threadId).map { it.toModel() }
+    /** 失败终局落一条错误行；research 提交失败时无 runId */
+    suspend fun appendErrorMessage(
+        threadId: Long,
+        kind: MessageKind,
+        error: ChatError,
+        researchRunId: String? = null,
+    ): ChatMessage
 
-    /**
-     * Deep Research 占位行：提交成功即落库（content 空 + runId），是跨进程恢复轮询的
-     * 载体——进程死亡后重进，「空内容 + runId」的行触发续轮询，5 credits 不白花。
-     */
-    suspend fun persistResearchPlaceholder(threadId: Long, runId: String): Long {
-        val id = db.messageDao().insert(
-            MessageEntity(
-                threadId = threadId, role = ROLE_ASSISTANT, content = "",
-                imagesJson = null, kind = MessageKind.DEEP_RESEARCH.name, model = null,
-                segmentsJson = json.encodeToString(StoredSegments(researchRunId = runId)),
-                createdAt = clock(),
-            ),
-        )
-        db.threadDao().touch(threadId, clock())
-        return id
-    }
+    /** research 占位（空内容 + runId） */
+    suspend fun appendResearchPlaceholder(threadId: Long, runId: String): ChatMessage
 
     /** research 终局：占位行升级为报告全文（保留 runId 供追溯；model 为生成模型留痕） */
-    suspend fun completeResearchMessage(threadId: Long, messageId: Long, report: String, runId: String, model: String? = null) {
-        db.messageDao().updateContent(
-            messageId, report,
-            json.encodeToString(StoredSegments(researchRunId = runId)),
-            model,
-        )
-        db.threadDao().touch(threadId, clock())
-    }
-
-    /** research 失败：删占位行（服务端已退款；留着会让重启误续轮询死任务） */
-    suspend fun deleteMessage(messageId: Long) = db.messageDao().deleteById(messageId)
-
-    /** 仍挂着未完成 research 的会话 id（跨进程恢复轮询用，与「当前打开哪个会话」无关） */
-    suspend fun threadsWithPendingResearch(): List<Long> =
-        db.messageDao().threadsWithPendingResearch(MessageKind.DEEP_RESEARCH.name)
-
-    suspend fun renameThread(threadId: Long, title: String) =
-        db.threadDao().rename(threadId, title.trim().take(MAX_TITLE_LENGTH))
-
-    /** 删线程：先删图片文件（CASCADE 之后路径就找不回了），再删行 */
-    suspend fun deleteThread(threadId: Long) {
-        db.messageDao().imagesJsonFor(threadId).forEach { raw ->
-            runCatching { json.decodeFromString<List<String>>(raw) }.getOrNull()
-                ?.forEach { path -> runCatching { FileSystem.SYSTEM.delete(path.toPath()) } }
-        }
-        db.threadDao().delete(threadId)
-    }
-
-    fun threads() = db.threadDao().observeAll()
-
-    // 内部
-
-    @OptIn(ExperimentalUuidApi::class)
-    private fun copyIntoStore(sourcePath: String): String {
-        val fs = FileSystem.SYSTEM
-        val source = sourcePath.toPath()
-        val dir = imagesDir.toPath()
-        if (!fs.exists(source) || source.parent == dir) return sourcePath
-        // 保留源扩展名（当前附件层恒产 JPEG，此处是对未来透传原图的加固；无扩展名回退 jpg）
-        val extension = source.name.substringAfterLast('.', "").takeIf { it.isNotBlank() } ?: "jpg"
-        val target = dir / "${Uuid.random()}.$extension"
-        return runCatching {
-            fs.createDirectories(dir)
-            fs.copy(source, target)
-            target.toString()
-        }.getOrDefault(sourcePath) // 拷贝失败退回原路径：宁可将来图裂，不阻塞发送
-    }
-
-    private fun titleFrom(text: String): String =
-        text.trim().take(MAX_TITLE_LENGTH).ifBlank { DEFAULT_TITLE }
-
-    private fun MessageEntity.toModel(): ChatMessage {
-        // segments 信封热路径只解码一次（Sourcery 建议）
-        val segments = segmentsJson?.let { raw ->
-            runCatching { json.decodeFromString<StoredSegments>(raw) }.getOrNull()
-        }
-        return ChatMessage(
-            id = id,
-            role = if (role == ROLE_USER) Role.USER else Role.ASSISTANT,
-            content = content,
-            images = imagesJson?.let { runCatching { json.decodeFromString<List<String>>(it) }.getOrNull() }
-                ?: emptyList(),
-            kind = runCatching { MessageKind.valueOf(kind) }.getOrDefault(MessageKind.CHAT),
-            sources = segments?.sources?.map { SourceRef(it.title, it.url) } ?: emptyList(),
-            researchRunId = segments?.researchRunId,
-            model = model,
-        )
-    }
-
-    private fun ChatMessage.toEntity(threadId: Long, now: Long) = MessageEntity(
-        threadId = threadId,
-        role = if (role == Role.USER) ROLE_USER else ROLE_ASSISTANT,
-        content = content,
-        imagesJson = images.takeIf { it.isNotEmpty() }?.let { json.encodeToString(it) },
-        kind = kind.name,
-        model = null,
-        segmentsJson = null,
-        createdAt = now,
-    )
+    suspend fun completeResearch(threadId: Long, messageId: Long, report: String, runId: String, model: String?)
 
     /**
-     * segmentsJson 信封 v1（P2）：目前只承载搜索来源；v 字段为演进留位，
-     * 反序列化 ignoreUnknownKeys 保证老版本读新数据不崩（EchoFlow 教训的版本化版）
+     * research 失败写回占位行。[runId] 非空表示任务在服务端仍可续（重试恢复轮询、
+     * 不重复扣费）；null 表示终局死亡（服务端已退款），行不再触发恢复轮询。
      */
-    @Serializable
-    private data class StoredSegments(val v: Int = 1, val sources: List<StoredSource> = emptyList(), val researchRunId: String? = null)
+    suspend fun markResearchError(threadId: Long, messageId: Long, error: ChatError, runId: String?)
 
-    @Serializable
-    private data class StoredSource(val title: String, val url: String)
+    /** 重试续轮前清掉错误标记，行回到占位形态 */
+    suspend fun resetResearchPlaceholder(threadId: Long, messageId: Long, runId: String)
 
-    /**
-     * ChatContext 的持久化镜像（原类未标 @Serializable，此处 DTO 隔离序列化关注点）。
-     * autoDetailSummary 是一次性触发标记，不持久化。
-     */
-    @Serializable
-    private data class StoredContext(
-        val title: String,
-        val summary: String? = null,
-        val sourceUrl: String? = null,
-        val source: String? = null,
-        val externalId: String? = null,
-        val readmeLength: Int? = null,
-    ) {
-        fun toContext() = ChatContext(
-            title = title, summary = summary, sourceUrl = sourceUrl,
-            source = source, externalId = externalId, readmeLength = readmeLength,
-        )
+    /** 重试重新提交前移除错误行 */
+    suspend fun deleteMessage(messageId: Long)
 
-        companion object {
-            fun from(c: ChatContext) = StoredContext(
-                title = c.title, summary = c.summary, sourceUrl = c.sourceUrl,
-                source = c.source, externalId = c.externalId, readmeLength = c.readmeLength,
-            )
-        }
-    }
+    suspend fun pendingResearch(): List<PendingResearch>
 
     companion object {
         const val MAX_TITLE_LENGTH = 20
         const val DEFAULT_TITLE = "新对话"
         const val ENTRY_GENERAL = "general"
-        private const val ROLE_USER = "user"
-        private const val ROLE_ASSISTANT = "assistant"
-
-        private val json = Json { ignoreUnknownKeys = true }
 
         /** 入口键：repo 条目按 externalId 隔离，其余（含 HN/PH 无 externalId 的场景）归通用 */
         fun entryKeyOf(context: ChatContext?): String =
             context?.externalId?.let { "repo:$it" } ?: ENTRY_GENERAL
+
+        internal fun titleFrom(text: String): String =
+            text.trim().take(MAX_TITLE_LENGTH).ifBlank { DEFAULT_TITLE }
     }
 }

--- a/chat/src/commonMain/kotlin/whl/trending/chat/store/InMemoryChatStore.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/store/InMemoryChatStore.kt
@@ -1,0 +1,124 @@
+package whl.trending.chat.store
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import whl.trending.chat.ChatContext
+import whl.trending.chat.ThreadSummary
+import whl.trending.chat.model.ChatError
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.MessageKind
+import whl.trending.chat.model.Role
+import whl.trending.chat.model.SourceRef
+
+/**
+ * 纯内存实现：Demo / 预览 / 无持久化诉求的宿主用。语义与 Room 实现一致
+ * （id 全局唯一、错误行保留），进程结束即消失。
+ */
+class InMemoryChatStore : ChatStore {
+
+    private class Thread(
+        val id: Long,
+        var title: String,
+        val context: ChatContext?,
+        var updatedAt: Long,
+    )
+
+    private var nextThreadId = 0L
+    private var nextMessageId = 0L
+    private var tick = 0L
+    private val threads = LinkedHashMap<Long, Thread>()
+    private val messagesByThread = LinkedHashMap<Long, MutableList<ChatMessage>>()
+    private val threadsFlow = MutableStateFlow<List<ThreadSummary>>(emptyList())
+
+    override fun threads(): Flow<List<ThreadSummary>> = threadsFlow
+
+    override suspend fun createThread(context: ChatContext?, firstMessageText: String): Long {
+        val id = ++nextThreadId
+        threads[id] = Thread(id, context?.title ?: ChatStore.titleFrom(firstMessageText), context, ++tick)
+        messagesByThread[id] = mutableListOf()
+        publish()
+        return id
+    }
+
+    override suspend fun contextOf(threadId: Long): ChatContext? = threads[threadId]?.context
+
+    override suspend fun loadMessages(threadId: Long): List<ChatMessage> =
+        messagesByThread[threadId]?.toList() ?: emptyList()
+
+    override suspend fun renameThread(threadId: Long, title: String) {
+        threads[threadId]?.title = title.trim().take(ChatStore.MAX_TITLE_LENGTH)
+        publish()
+    }
+
+    override suspend fun deleteThread(threadId: Long) {
+        threads.remove(threadId)
+        messagesByThread.remove(threadId)
+        publish()
+    }
+
+    override suspend fun appendUserMessage(
+        threadId: Long,
+        text: String,
+        images: List<String>,
+        kind: MessageKind,
+    ): ChatMessage = append(threadId, ChatMessage(0, Role.USER, text, images = images, kind = kind))
+
+    override suspend fun appendAssistantMessage(
+        threadId: Long,
+        content: String,
+        kind: MessageKind,
+        model: String?,
+        sources: List<SourceRef>,
+    ): ChatMessage = append(threadId, ChatMessage(0, Role.ASSISTANT, content, kind = kind, sources = sources, model = model))
+
+    override suspend fun appendErrorMessage(
+        threadId: Long,
+        kind: MessageKind,
+        error: ChatError,
+        researchRunId: String?,
+    ): ChatMessage = append(threadId, ChatMessage(0, Role.ASSISTANT, "", error = error, kind = kind, researchRunId = researchRunId))
+
+    override suspend fun appendResearchPlaceholder(threadId: Long, runId: String): ChatMessage =
+        append(threadId, ChatMessage(0, Role.ASSISTANT, "", kind = MessageKind.DEEP_RESEARCH, researchRunId = runId))
+
+    override suspend fun completeResearch(threadId: Long, messageId: Long, report: String, runId: String, model: String?) =
+        update(threadId, messageId) { it.copy(content = report, error = null, researchRunId = runId, model = model) }
+
+    override suspend fun markResearchError(threadId: Long, messageId: Long, error: ChatError, runId: String?) =
+        update(threadId, messageId) { it.copy(content = "", error = error, researchRunId = runId) }
+
+    override suspend fun resetResearchPlaceholder(threadId: Long, messageId: Long, runId: String) =
+        update(threadId, messageId) { it.copy(content = "", error = null, researchRunId = runId) }
+
+    override suspend fun deleteMessage(messageId: Long) {
+        messagesByThread.values.forEach { list -> list.removeAll { it.id == messageId } }
+    }
+
+    override suspend fun pendingResearch(): List<PendingResearch> =
+        messagesByThread.flatMap { (threadId, list) ->
+            list.filter { it.kind == MessageKind.DEEP_RESEARCH && it.content.isBlank() && it.error == null }
+                .mapNotNull { m -> m.researchRunId?.let { PendingResearch(threadId, m.id, it) } }
+        }
+
+    private fun append(threadId: Long, message: ChatMessage): ChatMessage {
+        val stored = message.copy(id = ++nextMessageId, searching = false)
+        messagesByThread.getOrPut(threadId) { mutableListOf() }.add(stored)
+        threads[threadId]?.updatedAt = ++tick
+        publish()
+        return stored
+    }
+
+    private fun update(threadId: Long, messageId: Long, transform: (ChatMessage) -> ChatMessage) {
+        val list = messagesByThread[threadId] ?: return
+        val index = list.indexOfFirst { it.id == messageId }
+        if (index >= 0) list[index] = transform(list[index])
+        threads[threadId]?.updatedAt = ++tick
+        publish()
+    }
+
+    private fun publish() {
+        threadsFlow.value = threads.values
+            .sortedByDescending { it.updatedAt }
+            .map { ThreadSummary(it.id, it.title, it.updatedAt) }
+    }
+}

--- a/chat/src/commonMain/kotlin/whl/trending/chat/store/RoomChatStore.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/store/RoomChatStore.kt
@@ -61,11 +61,17 @@ class RoomChatStore(
     override suspend fun renameThread(threadId: Long, title: String) =
         db.threadDao().rename(threadId, title.trim().take(ChatStore.MAX_TITLE_LENGTH))
 
-    /** 删线程：先删图片文件（CASCADE 之后路径就找不回了），再删行 */
+    /** 删线程：先删图片文件（CASCADE 之后路径就找不回了），再删行。
+     *  只删 [imagesDir] 名下的文件——迁移失败的行留着源路径（copyIntoStore 的回退），
+     *  顺着删会伤及 store 之外的文件 */
     override suspend fun deleteThread(threadId: Long) {
+        val dir = imagesDir.toPath()
         db.messageDao().imagesJsonFor(threadId).forEach { raw ->
             runCatching { json.decodeFromString<List<String>>(raw) }.getOrNull()
-                ?.forEach { path -> runCatching { FileSystem.SYSTEM.delete(path.toPath()) } }
+                ?.forEach { path ->
+                    val p = path.toPath()
+                    if (p.parent == dir) runCatching { FileSystem.SYSTEM.delete(p) }
+                }
         }
         db.threadDao().delete(threadId)
     }
@@ -170,6 +176,7 @@ class RoomChatStore(
             json.encodeToString(StoredSegments(researchRunId = runId)),
             null,
         )
+        db.threadDao().touch(threadId, clock())
     }
 
     override suspend fun deleteMessage(messageId: Long) = db.messageDao().deleteById(messageId)

--- a/chat/src/commonMain/kotlin/whl/trending/chat/store/RoomChatStore.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/store/RoomChatStore.kt
@@ -1,0 +1,289 @@
+package whl.trending.chat.store
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import okio.SYSTEM
+import whl.trending.chat.ChatContext
+import whl.trending.chat.ThreadSummary
+import whl.trending.chat.core.epochMillis
+import whl.trending.chat.db.ChatDatabase
+import whl.trending.chat.db.MessageEntity
+import whl.trending.chat.db.ThreadEntity
+import whl.trending.chat.model.ChatError
+import whl.trending.chat.model.ChatErrorCategory
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.MessageKind
+import whl.trending.chat.model.Role
+import whl.trending.chat.model.SourceRef
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Room 实现。图片落库时从 cacheDir 拷入 [imagesDir]（filesDir 下，系统不清理），
+ * 删线程先删文件再删行。error 与 research 状态存 segmentsJson 信封，不改表结构。
+ *
+ * @param clock 时间注入点（测试替身）；updatedAt 排序与懒建时间戳共用
+ */
+class RoomChatStore(
+    private val db: ChatDatabase,
+    private val imagesDir: String,
+    private val clock: () -> Long = { epochMillis() },
+) : ChatStore {
+
+    override fun threads(): Flow<List<ThreadSummary>> =
+        db.threadDao().observeAll().map { list -> list.map { ThreadSummary(it.id, it.title, it.updatedAt) } }
+
+    override suspend fun createThread(context: ChatContext?, firstMessageText: String): Long {
+        val now = clock()
+        return db.threadDao().insert(
+            ThreadEntity(
+                title = context?.title ?: ChatStore.titleFrom(firstMessageText),
+                entryKey = ChatStore.entryKeyOf(context),
+                contextJson = context?.let { json.encodeToString(StoredContext.from(it)) },
+                createdAt = now,
+                updatedAt = now,
+            ),
+        )
+    }
+
+    override suspend fun contextOf(threadId: Long): ChatContext? =
+        db.threadDao().getById(threadId)?.contextJson?.let { raw ->
+            runCatching { json.decodeFromString<StoredContext>(raw).toContext() }.getOrNull()
+        }
+
+    override suspend fun loadMessages(threadId: Long): List<ChatMessage> =
+        db.messageDao().messagesFor(threadId).map { it.toModel() }
+
+    override suspend fun renameThread(threadId: Long, title: String) =
+        db.threadDao().rename(threadId, title.trim().take(ChatStore.MAX_TITLE_LENGTH))
+
+    /** 删线程：先删图片文件（CASCADE 之后路径就找不回了），再删行 */
+    override suspend fun deleteThread(threadId: Long) {
+        db.messageDao().imagesJsonFor(threadId).forEach { raw ->
+            runCatching { json.decodeFromString<List<String>>(raw) }.getOrNull()
+                ?.forEach { path -> runCatching { FileSystem.SYSTEM.delete(path.toPath()) } }
+        }
+        db.threadDao().delete(threadId)
+    }
+
+    override suspend fun appendUserMessage(
+        threadId: Long,
+        text: String,
+        images: List<String>,
+        kind: MessageKind,
+    ): ChatMessage {
+        val persistedImages = images.map { copyIntoStore(it) }
+        val id = db.messageDao().insert(
+            MessageEntity(
+                threadId = threadId,
+                role = ROLE_USER,
+                content = text,
+                imagesJson = persistedImages.takeIf { it.isNotEmpty() }?.let { json.encodeToString(it) },
+                kind = kind.name,
+                model = null,
+                segmentsJson = null,
+                createdAt = clock(),
+            ),
+        )
+        db.threadDao().touch(threadId, clock())
+        return ChatMessage(id = id, role = Role.USER, content = text, images = persistedImages, kind = kind)
+    }
+
+    override suspend fun appendAssistantMessage(
+        threadId: Long,
+        content: String,
+        kind: MessageKind,
+        model: String?,
+        sources: List<SourceRef>,
+    ): ChatMessage {
+        val segments = sources.takeIf { it.isNotEmpty() }
+            ?.let { json.encodeToString(StoredSegments(sources = it.map { s -> StoredSource(s.title, s.url) })) }
+        val id = db.messageDao().insert(
+            MessageEntity(
+                threadId = threadId, role = ROLE_ASSISTANT, content = content,
+                imagesJson = null, kind = kind.name, model = model,
+                segmentsJson = segments, createdAt = clock(),
+            ),
+        )
+        db.threadDao().touch(threadId, clock())
+        return ChatMessage(id = id, role = Role.ASSISTANT, content = content, kind = kind, sources = sources, model = model)
+    }
+
+    override suspend fun appendErrorMessage(
+        threadId: Long,
+        kind: MessageKind,
+        error: ChatError,
+        researchRunId: String?,
+    ): ChatMessage {
+        val id = db.messageDao().insert(
+            MessageEntity(
+                threadId = threadId, role = ROLE_ASSISTANT, content = "",
+                imagesJson = null, kind = kind.name, model = null,
+                segmentsJson = json.encodeToString(
+                    StoredSegments(researchRunId = researchRunId, error = StoredError.from(error)),
+                ),
+                createdAt = clock(),
+            ),
+        )
+        db.threadDao().touch(threadId, clock())
+        return ChatMessage(id = id, role = Role.ASSISTANT, content = "", error = error, kind = kind, researchRunId = researchRunId)
+    }
+
+    override suspend fun appendResearchPlaceholder(threadId: Long, runId: String): ChatMessage {
+        val id = db.messageDao().insert(
+            MessageEntity(
+                threadId = threadId, role = ROLE_ASSISTANT, content = "",
+                imagesJson = null, kind = MessageKind.DEEP_RESEARCH.name, model = null,
+                segmentsJson = json.encodeToString(StoredSegments(researchRunId = runId)),
+                createdAt = clock(),
+            ),
+        )
+        db.threadDao().touch(threadId, clock())
+        return ChatMessage(id = id, role = Role.ASSISTANT, content = "", kind = MessageKind.DEEP_RESEARCH, researchRunId = runId)
+    }
+
+    override suspend fun completeResearch(threadId: Long, messageId: Long, report: String, runId: String, model: String?) {
+        db.messageDao().updateContent(
+            messageId, report,
+            json.encodeToString(StoredSegments(researchRunId = runId)),
+            model,
+        )
+        db.threadDao().touch(threadId, clock())
+    }
+
+    override suspend fun markResearchError(threadId: Long, messageId: Long, error: ChatError, runId: String?) {
+        db.messageDao().updateContent(
+            messageId, "",
+            json.encodeToString(StoredSegments(researchRunId = runId, error = StoredError.from(error))),
+            null,
+        )
+        db.threadDao().touch(threadId, clock())
+    }
+
+    override suspend fun resetResearchPlaceholder(threadId: Long, messageId: Long, runId: String) {
+        db.messageDao().updateContent(
+            messageId, "",
+            json.encodeToString(StoredSegments(researchRunId = runId)),
+            null,
+        )
+    }
+
+    override suspend fun deleteMessage(messageId: Long) = db.messageDao().deleteById(messageId)
+
+    override suspend fun pendingResearch(): List<PendingResearch> =
+        db.messageDao().pendingResearchRows(MessageKind.DEEP_RESEARCH.name).mapNotNull { row ->
+            val segments = row.segmentsJson?.let { decodeSegments(it) } ?: return@mapNotNull null
+            if (segments.error != null) return@mapNotNull null
+            segments.researchRunId?.let { PendingResearch(row.threadId, row.id, it) }
+        }
+
+    // 内部
+
+    @OptIn(ExperimentalUuidApi::class)
+    private fun copyIntoStore(sourcePath: String): String {
+        val fs = FileSystem.SYSTEM
+        val source = sourcePath.toPath()
+        val dir = imagesDir.toPath()
+        if (!fs.exists(source) || source.parent == dir) return sourcePath
+        // 保留源扩展名（当前附件层恒产 JPEG，此处是对未来透传原图的加固；无扩展名回退 jpg）
+        val extension = source.name.substringAfterLast('.', "").takeIf { it.isNotBlank() } ?: "jpg"
+        val target = dir / "${Uuid.random()}.$extension"
+        return runCatching {
+            fs.createDirectories(dir)
+            fs.copy(source, target)
+            target.toString()
+        }.getOrDefault(sourcePath) // 拷贝失败退回原路径：宁可将来图裂，不阻塞发送
+    }
+
+    private fun decodeSegments(raw: String): StoredSegments? =
+        runCatching { json.decodeFromString<StoredSegments>(raw) }.getOrNull()
+
+    private fun MessageEntity.toModel(): ChatMessage {
+        val segments = segmentsJson?.let { decodeSegments(it) }
+        return ChatMessage(
+            id = id,
+            role = if (role == ROLE_USER) Role.USER else Role.ASSISTANT,
+            content = content,
+            images = imagesJson?.let { runCatching { json.decodeFromString<List<String>>(it) }.getOrNull() }
+                ?: emptyList(),
+            error = segments?.error?.toError(),
+            kind = runCatching { MessageKind.valueOf(kind) }.getOrDefault(MessageKind.CHAT),
+            sources = segments?.sources?.map { SourceRef(it.title, it.url) } ?: emptyList(),
+            researchRunId = segments?.researchRunId,
+            model = model,
+        )
+    }
+
+    /**
+     * segmentsJson 信封 v1：搜索来源 / research runId / 错误终局共用；v 字段为演进留位，
+     * 反序列化 ignoreUnknownKeys 保证老版本读新数据不崩（EchoFlow 教训的版本化版）
+     */
+    @Serializable
+    private data class StoredSegments(
+        val v: Int = 1,
+        val sources: List<StoredSource> = emptyList(),
+        val researchRunId: String? = null,
+        val error: StoredError? = null,
+    )
+
+    @Serializable
+    private data class StoredSource(val title: String, val url: String)
+
+    @Serializable
+    private data class StoredError(
+        val category: String,
+        val code: String? = null,
+        val httpStatus: Int? = null,
+        val detail: String? = null,
+        val tier: String? = null,
+        val authDegraded: Boolean = false,
+    ) {
+        fun toError() = ChatError(
+            category = runCatching { ChatErrorCategory.valueOf(category) }.getOrDefault(ChatErrorCategory.UNKNOWN),
+            code = code, httpStatus = httpStatus, detail = detail, tier = tier, authDegraded = authDegraded,
+        )
+
+        companion object {
+            fun from(e: ChatError) = StoredError(
+                category = e.category.name, code = e.code, httpStatus = e.httpStatus,
+                detail = e.detail, tier = e.tier, authDegraded = e.authDegraded,
+            )
+        }
+    }
+
+    /**
+     * ChatContext 的持久化镜像（原类未标 @Serializable，此处 DTO 隔离序列化关注点）。
+     * autoDetailSummary 是一次性触发标记，不持久化。
+     */
+    @Serializable
+    private data class StoredContext(
+        val title: String,
+        val summary: String? = null,
+        val sourceUrl: String? = null,
+        val source: String? = null,
+        val externalId: String? = null,
+        val readmeLength: Int? = null,
+    ) {
+        fun toContext() = ChatContext(
+            title = title, summary = summary, sourceUrl = sourceUrl,
+            source = source, externalId = externalId, readmeLength = readmeLength,
+        )
+
+        companion object {
+            fun from(c: ChatContext) = StoredContext(
+                title = c.title, summary = c.summary, sourceUrl = c.sourceUrl,
+                source = c.source, externalId = c.externalId, readmeLength = c.readmeLength,
+            )
+        }
+    }
+
+    private companion object {
+        const val ROLE_USER = "user"
+        const val ROLE_ASSISTANT = "assistant"
+        val json = Json { ignoreUnknownKeys = true }
+    }
+}

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -55,6 +55,7 @@ import trendingai.chat.generated.resources.chat_research_repo_prefill
 import whl.trending.chat.engine.ChatApi
 import whl.trending.chat.engine.ChatEngine
 import whl.trending.chat.store.ChatStore
+import whl.trending.chat.store.InMemoryChatStore
 import whl.trending.chat.store.rememberDefaultChatStore
 
 /** 入口键，驱动「同一入口只 enterEntry 一次」 */
@@ -76,7 +77,7 @@ fun ChatScreen(
     initialMessages: List<whl.trending.chat.model.ChatMessage> = emptyList(),
     persistent: Boolean = true,
 ) {
-    val store = if (persistent) rememberDefaultChatStore() else null
+    val store = if (persistent) rememberDefaultChatStore() else remember { InMemoryChatStore() }
     val viewModel: ChatViewModel = viewModel(key = "chat") {
         ChatViewModel(engine, initialContext, initialMessages, store)
     }
@@ -162,7 +163,7 @@ fun ChatScreen(
                     },
                     actions = {
                         // 会话抽屉入口（纯内存模式无历史可言，隐藏）
-                        if (store != null) {
+                        if (persistent) {
                             IconButton(onClick = { scope.launch { drawerState.open() } }) {
                                 Icon(
                                     imageVector = Icons.Filled.Menu,

--- a/chat/src/iosMain/kotlin/whl/trending/chat/store/DefaultChatStore.ios.kt
+++ b/chat/src/iosMain/kotlin/whl/trending/chat/store/DefaultChatStore.ios.kt
@@ -10,7 +10,7 @@ import whl.trending.chat.db.chatDatabase
 
 @Composable
 internal actual fun rememberDefaultChatStore(): ChatStore =
-    remember { ChatStore(chatDatabase(), documentsPath() + "/chat_images") }
+    remember { RoomChatStore(chatDatabase(), documentsPath() + "/chat_images") }
 
 @OptIn(ExperimentalForeignApi::class)
 private fun documentsPath(): String {


### PR DESCRIPTION
## 背景

ChatViewModel 此前十几条路径各自起协程，在挂起点之间交错读写消息缓冲 / 当前线 / 在途表（#112），消息身份靠内存 `idSeq` + Room 行 id 双序列加映射表对齐，`store` 可空又让每条路径都要维护「内存模式 / 持久化模式」两个世界。本次按「健壮、简单、好维护」目标重构 VM + Store 层，三个功能取舍已事前对齐。

## 改动

**并发模型**
- 所有状态变更收进 `Mutex` 串行入口（`locked{}`），同一时刻只有一个操作在跑，挂起点交错类 bug 失去土壤
- 流协程只在流式占位上做原子更新，取消无需回滚

**单一真相源**
- 内存只保留当前会话消息，`uiState.messages` 即真相；`messagesByThread` 镜像、null 键缓冲、建线迁移删除
- 消息 id 统一为 store 行 id（流式占位固定 `-1`）；`idSeq` 与 `researchRowIds` 映射表删除

**功能取舍（已对齐）**
1. 切会话 / 换入口即取消在途流（放弃后台续流）：原会话落 `stream_interrupted` 可重试错误行，补 `ai_completed(interrupted, reason=canceled)` 保持埋点成对（`interrupted` 是词汇表既有 outcome，无词汇变更）
2. 所有入口总是新会话，仅同入口进程内续接；repo 入口跨进程恢复删除（`enterEntry` 50 行判断 → 6 行）
3. 错误终局落库（`segmentsJson` 信封存 ChatError，**无 schema 迁移**），重启后可见可重试

**结构**
- `ChatStore` 接口化：`RoomChatStore` + `InMemoryChatStore`（Demo / 预览 / 测试），可空 store 出局
- research 抽 `ResearchRunner`：提交 / 双速轮询 / 跨进程恢复自包含；轮询不再锁发送（顺带修掉「重启后不锁、当场锁」的不一致）
- 埋点失败终态收口 `ChatAiEvents.failureEvent`，Requested/Completed 成对由结构保证

## 验证

- 宿主测试 143 全绿，含新增用例：切走中断落库、进程死亡后 `resumeAll` 接手、取消埋点配对、轮询不阻塞发送
- `androidApp` githubDebug 与 `chat` iosSimulatorArm64 编译通过（AGP 9.3.2）
- Pixel_9_2 实机走查：发送 → 流式 → 终局渲染、抽屉新建 / 切回、存量数据库直接兼容（旧会话完整读出）、退出重进续接，无崩溃

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZ8x7UgXkjUzXLKtesWsJW

## Sourcery 总结

围绕序列化操作、统一的消息标识空间、持久化终止错误以及可独立恢复的研究任务，重构聊天状态管理和持久化机制。

Bug 修复：
- 持久化聊天和研究任务的终止错误，使失败的响应在重启后仍然可见并可重试。
- 在切换会话或条目时取消正在进行的聊天流，并以一致的方式记录中断结果。
- 在进程重启后恢复待处理的研究任务，无需打开受影响的会话。

改进：
- 通过互斥锁串行处理 ViewModel 状态变更，并使当前 UI 消息列表成为唯一的内存数据源。
- 统一使用存储分配的行 ID 作为消息标识，并将流式传输占位符 ID 与持久化消息分离。
- 使聊天存储采用接口设计，并提供 Room 和内存实现；同时将研究任务提交和轮询提取到专用运行器中。
- 在长时间运行的研究任务轮询于后台继续进行时，允许发送普通聊天消息。
- 将条目导航改为创建新会话，同时保留同一条目的进程内继续功能。

测试：
- 扩展持久化和存储测试范围，覆盖错误往返、中断的流式传输、分析事件配对、跨进程研究任务恢复、非阻塞轮询以及统一的消息 ID。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

围绕序列化操作、统一的消息标识空间、持久化终止错误以及可独立恢复的研究任务，重构聊天状态和持久化机制。

Bug 修复：
- 持久化聊天和研究任务的终止错误，使失败的响应在重启后仍然可见并可重试。
- 在切换会话或条目时取消正在进行的聊天流，记录可重试的中断结果，并匹配完成遥测数据。
- 进程重启后，独立于当前打开的会话恢复待处理的研究任务。
- 防止研究轮询阻塞普通聊天消息。

增强功能：
- 序列化 ViewModel 状态变更，并将可见的当前会话消息列表作为内存中唯一的事实来源。
- 全程使用存储分配的消息行 ID，并为临时流式占位消息使用专用的负 ID。
- 将具体的可空聊天存储替换为 ChatStore 接口，支持 Room 和内存实现。
- 将研究任务提交和轮询提取为独立的运行器，并使条目导航创建新会话，同时保留进程内的任务继续执行能力。

测试：
- 扩展持久化、存储和数据库测试范围，覆盖错误往返、中断的流、遥测配对、研究任务恢复、非阻塞轮询以及统一的消息 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor chat state and persistence around serialized operations, a single message identity space, durable terminal errors, and independently recoverable research tasks.

Bug Fixes:
- Persist chat and research terminal errors so failed responses remain visible and retryable after restart.
- Cancel in-flight chat streams when switching sessions or entries, recording an interrupted retryable result and matching completion telemetry.
- Resume pending research tasks independently of the currently opened session after process restart.
- Prevent research polling from blocking ordinary chat messages.

Enhancements:
- Serialize ViewModel state changes and make the visible current-session message list the single in-memory source of truth.
- Use store-assigned message row IDs throughout, with a dedicated negative ID for transient streaming placeholders.
- Replace the concrete nullable chat store with a ChatStore interface supporting Room and in-memory implementations.
- Extract research submission and polling into a standalone runner and make entry navigation create new sessions while preserving in-process continuation.

Tests:
- Expand persistence, store, and database coverage for error round trips, interrupted streams, telemetry pairing, research recovery, non-blocking polling, and unified message IDs.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat history now persists across sessions and process restarts.
  * New sessions start fresh, while previous conversations remain available through history.
  * Deep Research tasks can resume after interruption without blocking new messages.
  * Chat previews and non-persistent modes support in-memory history.

* **Bug Fixes**
  * Failed and interrupted replies remain visible as error messages.
  * Switching or deleting conversations cancels active responses.
  * Research failures now support clearer recovery, retry, and unsupported-engine handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->