### PR TITLE
fix(profile): 已关联但无 token 时引导重新关联 GitHub

### DIFF
--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -156,6 +156,7 @@
     <string name="unstar_success">已取消 Star</string>
     <string name="star_failed">操作失败，请重试</string>
     <string name="star_need_login">登录后即可 Star 该仓库</string>
+    <string name="star_need_github_link">关联 GitHub 后即可 Star，请到「我的」页操作</string>
     <string name="favorites_delete_confirm">确定从收藏中移除？</string>
     <string name="theme_color">主题色</string>
     <string name="app_icon">应用图标</string>
@@ -237,6 +238,8 @@
     <string name="account_upgrade_hint">解锁更高额度与全部高阶模型</string>
     <string name="account_link_github">关联 GitHub</string>
     <string name="account_link_github_desc">解锁 star、关注等 GitHub 功能</string>
+    <string name="account_relink_github">重新关联 GitHub</string>
+    <string name="account_relink_github_desc">GitHub 授权已失效，重新关联后恢复主页、动态与 Star</string>
     <string name="account_link_required_title">需要先关联 GitHub</string>
     <string name="account_link_required_message">Pro 权益通过 GitHub Sponsors 发放，需要你的账户关联 GitHub。你当前用邮箱登录，直接赞助不会自动生效。</string>
     <string name="account_link_sponsor_anyway">仍要前往赞助</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -156,6 +156,7 @@
     <string name="unstar_success">Unstarred</string>
     <string name="star_failed">Operation failed, please try again</string>
     <string name="star_need_login">Sign in to star this repository</string>
+    <string name="star_need_github_link">Link GitHub in the Me tab to star repositories</string>
     <string name="favorites_delete_confirm">Remove this item from favorites?</string>
     <string name="theme_color">Accent Color</string>
     <string name="app_icon">App icon</string>
@@ -237,6 +238,8 @@
     <string name="account_upgrade_hint">Higher allowance and all advanced models</string>
     <string name="account_link_github">Link GitHub</string>
     <string name="account_link_github_desc">Unlocks starring, following and other GitHub features</string>
+    <string name="account_relink_github">Reconnect GitHub</string>
+    <string name="account_relink_github_desc">GitHub authorization is no longer valid. Reconnect to restore your profile, activity and starring</string>
     <string name="account_link_required_title">Link GitHub first</string>
     <string name="account_link_required_message">Pro perks are granted through GitHub Sponsors and need a GitHub account linked to yours. You signed in with email, so sponsoring now would not take effect automatically.</string>
     <string name="account_link_sponsor_anyway">Sponsor anyway</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/auth/GithubTokenProvider.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/auth/GithubTokenProvider.kt
@@ -2,6 +2,17 @@ package whl.trending.ai.auth
 
 import whl.trending.ai.data.remote.GithubTokenApi
 
+/** 一次 GitHub token 取回的结果。区分「服务端明确没存」与「没问到」，两者的 UI 归宿不同。 */
+sealed interface GithubTokenLookup {
+    data class Available(val token: String) : GithubTokenLookup
+
+    /** 服务端 404：纯邮箱账号，或已关联但 vault 为空（被清空过）。恢复手段只有再走一次 GitHub OAuth。 */
+    data object Missing : GithubTokenLookup
+
+    /** 网络或其他错误，有没有 token 未知，不应据此引导用户做任何事。 */
+    data object Failed : GithubTokenLookup
+}
+
 /**
  * GitHub token 会话级缓存。GitHub OAuth App 的 access token 永不过期
  * （用户主动撤销授权才失效），进程内取一次即可；不落盘，避免明文持久化第三方凭据。
@@ -11,15 +22,20 @@ open class GithubTokenProvider(
 ) {
     private var cached: String? = null
 
-    open suspend fun get(): String? {
-        cached?.let { return it }
+    open suspend fun lookup(): GithubTokenLookup {
+        cached?.let { return GithubTokenLookup.Available(it) }
         return try {
-            accountApi.fetchGithubToken()?.also { cached = it }
+            val token = accountApi.fetchGithubToken() ?: return GithubTokenLookup.Missing
+            cached = token
+            GithubTokenLookup.Available(token)
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
-            null
+            GithubTokenLookup.Failed
         }
     }
+
+    /** 只关心「能不能拿到」的调用方用这个；要区分没存与没问到的走 [lookup]。 */
+    open suspend fun get(): String? = (lookup() as? GithubTokenLookup.Available)?.token
 
     fun clear() {
         cached = null

--- a/shared/src/commonMain/kotlin/whl/trending/ai/auth/RepoStarService.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/auth/RepoStarService.kt
@@ -13,7 +13,7 @@ class RepoStarService(
     private val tokenProvider: GithubTokenProvider = GithubTokenProvider.shared,
     private val authManager: () -> AuthManager = { globalAuthManager },
 ) {
-    enum class Result { STARRED, UNSTARRED, NEED_LOGIN, FAILED }
+    enum class Result { STARRED, UNSTARRED, NEED_LOGIN, NEED_GITHUB_LINK, FAILED }
 
     /** 查询是否已 star；无 token（未登录/取不到）或查询失败时返回 null，UI 据此显示未点亮且不报错。 */
     suspend fun isStarred(owner: String, repo: String): Boolean? {
@@ -31,11 +31,12 @@ class RepoStarService(
     suspend fun unstar(owner: String, repo: String): Result = run(owner, repo, star = false)
 
     private suspend fun run(owner: String, repo: String, star: Boolean): Result {
-        val token = tokenProvider.get()
-        if (token == null) {
-            // 未登录 → 引导登录；已登录却取不到 token（Vault/网络问题）→ 普通失败
-            return if (authManager().authState.value is AuthState.LoggedIn) Result.FAILED
-            else Result.NEED_LOGIN
+        val loggedIn = authManager().authState.value is AuthState.LoggedIn
+        val token = when (val lookup = tokenProvider.lookup()) {
+            is GithubTokenLookup.Available -> lookup.token
+            // 已登录但服务端明确没存 token（纯邮箱账号 / vault 被清空）→ 引导去关联；网络问题 → 普通失败
+            GithubTokenLookup.Missing -> return if (loggedIn) Result.NEED_GITHUB_LINK else Result.NEED_LOGIN
+            GithubTokenLookup.Failed -> return if (loggedIn) Result.FAILED else Result.NEED_LOGIN
         }
         return try {
             if (star) githubApi.starRepo(token, owner, repo)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeScreen.kt
@@ -47,6 +47,7 @@ import trendingai.shared.generated.resources.retry
 import trendingai.shared.generated.resources.share_to_ai
 import trendingai.shared.generated.resources.sign_in
 import trendingai.shared.generated.resources.star_failed
+import trendingai.shared.generated.resources.star_need_github_link
 import trendingai.shared.generated.resources.star_need_login
 import trendingai.shared.generated.resources.star_success
 import trendingai.shared.generated.resources.unstar_success
@@ -91,6 +92,7 @@ fun ReadmeScreen(
     val msgUnstarred = stringResource(Res.string.unstar_success)
     val msgFailed = stringResource(Res.string.star_failed)
     val msgNeedLogin = stringResource(Res.string.star_need_login)
+    val msgNeedGithubLink = stringResource(Res.string.star_need_github_link)
     val actionLogin = stringResource(Res.string.sign_in)
     LaunchedEffect(Unit) {
         viewModel.starEvents.collect { result ->
@@ -98,6 +100,7 @@ fun ReadmeScreen(
                 RepoStarService.Result.STARRED -> snackbarHostState.showSnackbar(msgStarred)
                 RepoStarService.Result.UNSTARRED -> snackbarHostState.showSnackbar(msgUnstarred)
                 RepoStarService.Result.FAILED -> snackbarHostState.showSnackbar(msgFailed)
+                RepoStarService.Result.NEED_GITHUB_LINK -> snackbarHostState.showSnackbar(msgNeedGithubLink)
                 RepoStarService.Result.NEED_LOGIN -> {
                     val action = snackbarHostState.showSnackbar(
                         message = msgNeedLogin,

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/detail/ReadmeViewModel.kt
@@ -74,6 +74,7 @@ class ReadmeViewModel(
                 RepoStarService.Result.UNSTARRED ->
                     _uiState.update { it.copy(isStarred = false, isStarLoading = false) }
                 RepoStarService.Result.NEED_LOGIN,
+                RepoStarService.Result.NEED_GITHUB_LINK,
                 RepoStarService.Result.FAILED ->
                     _uiState.update { it.copy(isStarLoading = false) }
             }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -65,6 +65,8 @@ import trendingai.shared.generated.resources.Res
 import trendingai.shared.generated.resources.account_github_entry
 import trendingai.shared.generated.resources.account_github_entry_desc
 import trendingai.shared.generated.resources.account_link_github
+import trendingai.shared.generated.resources.account_relink_github
+import trendingai.shared.generated.resources.account_relink_github_desc
 import trendingai.shared.generated.resources.account_link_github_desc
 import trendingai.shared.generated.resources.account_plan_title
 import trendingai.shared.generated.resources.account_pro_active
@@ -224,16 +226,30 @@ fun ProfileScreen(
                 }
 
                 // 两处条件刻意不对称：githubUserId 是「是否已关联」的权威，githubLogin 才是能展示的名字；
-                // 中间态（有 id 无 login）两块都不显示，好过显示「关联 GitHub」或 @null
+                // 中间态（有 id 无 login）两块都不显示，好过显示「关联 GitHub」或 @null。
+                // 已关联但服务端没存 token 时入口卡换成重新关联：主页/动态/star 全会失败，
+                // 而恢复 token 的唯一手段就是再走一次关联
                 if (uiState.user?.githubLogin != null) {
-                    item(key = "github_entry") {
-                        GithubEntryCard(uiState = uiState, onClick = onNavigateToGithubProfile)
+                    if (uiState.githubTokenMissing && isGithubOAuthSupported) {
+                        item(key = "relink_github") {
+                            LinkGithubCard(
+                                title = stringResource(Res.string.account_relink_github),
+                                description = stringResource(Res.string.account_relink_github_desc),
+                                onClick = { AccountLink.openLinkGithubPage(AccountLink.SOURCE_ACCOUNT) },
+                            )
+                        }
+                    } else {
+                        item(key = "github_entry") {
+                            GithubEntryCard(uiState = uiState, onClick = onNavigateToGithubProfile)
+                        }
                     }
                 } else if (uiState.loggedIn && uiState.user?.githubUserId == null && isGithubOAuthSupported) {
                     item(key = "link_github") {
-                        LinkGithubCard(onClick = {
-                            AccountLink.openLinkGithubPage(AccountLink.SOURCE_ACCOUNT)
-                        })
+                        LinkGithubCard(
+                            title = stringResource(Res.string.account_link_github),
+                            description = stringResource(Res.string.account_link_github_desc),
+                            onClick = { AccountLink.openLinkGithubPage(AccountLink.SOURCE_ACCOUNT) },
+                        )
                     }
                 }
             }
@@ -544,16 +560,16 @@ private fun TierPillFree() {
  * 占据它的位置——一个账户在这里要么是「已连接的 GitHub」，要么是「去连接」。
  */
 @Composable
-private fun LinkGithubCard(onClick: () -> Unit) {
+private fun LinkGithubCard(title: String, description: String, onClick: () -> Unit) {
     SettingsGroup(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
         settingsItem(
             leading = {
                 Icon(Icons.Default.AccountCircle, null, modifier = Modifier.size(40.dp))
             },
-            title = { Text(stringResource(Res.string.account_link_github)) },
+            title = { Text(title) },
             description = {
                 Text(
-                    stringResource(Res.string.account_link_github_desc),
+                    description,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -14,6 +14,7 @@ import whl.trending.ai.auth.AuthManager
 import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.FollowingInfo
 import whl.trending.ai.auth.FollowingProvider
+import whl.trending.ai.auth.GithubTokenLookup
 import whl.trending.ai.auth.GithubTokenProvider
 import whl.trending.ai.auth.OwnRepoEventsProvider
 import whl.trending.ai.auth.globalAuthManager
@@ -61,6 +62,8 @@ data class ProfileUiState(
     val feedEndReached: Boolean = false,
     /** feed 不可用（无 GitHub token / 请求失败），与整页 isError 区分 */
     val feedUnavailable: Boolean = false,
+    /** 账号已关联 GitHub 但服务端明确没存 token（vault 被清空过）：入口卡换成重新关联引导 */
+    val githubTokenMissing: Boolean = false,
     /** true = 精选档（默认），false = 全部档 */
     val highlightsOnly: Boolean = true,
 ) {
@@ -249,12 +252,23 @@ class ProfileViewModel(
     }
 
     private suspend fun loadGithubData(user: MeUser) {
-        val githubToken = tokenProvider.get()
         val login = user.githubLogin
-        if (githubToken == null || login == null) {
+        val githubToken = when (val lookup = tokenProvider.lookup()) {
+            is GithubTokenLookup.Available -> lookup.token
+            GithubTokenLookup.Missing -> {
+                _uiState.value = _uiState.value.copy(feedUnavailable = true, githubTokenMissing = login != null)
+                return
+            }
+            GithubTokenLookup.Failed -> {
+                _uiState.value = _uiState.value.copy(feedUnavailable = true)
+                return
+            }
+        }
+        if (login == null) {
             _uiState.value = _uiState.value.copy(feedUnavailable = true)
             return
         }
+        _uiState.value = _uiState.value.copy(githubTokenMissing = false)
         try {
             val githubUser = githubApi.fetchUser(githubToken)
             _uiState.value = _uiState.value.copy(githubUser = githubUser)
@@ -429,6 +443,7 @@ class ProfileViewModel(
             feedItems = emptyList(),
             feedEndReached = false,
             feedUnavailable = false,
+            githubTokenMissing = false,
             contributions = null,
         )
         persistSnapshot()

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
@@ -96,6 +96,7 @@ import trendingai.shared.generated.resources.retry
 import trendingai.shared.generated.resources.select_date
 import trendingai.shared.generated.resources.sign_in
 import trendingai.shared.generated.resources.star_failed
+import trendingai.shared.generated.resources.star_need_github_link
 import trendingai.shared.generated.resources.star_need_login
 import trendingai.shared.generated.resources.star_success
 import trendingai.shared.generated.resources.stars_period
@@ -141,12 +142,14 @@ fun TrendingScreen(
     val msgStarred = stringResource(Res.string.star_success)
     val msgFailed = stringResource(Res.string.star_failed)
     val msgNeedLogin = stringResource(Res.string.star_need_login)
+    val msgNeedGithubLink = stringResource(Res.string.star_need_github_link)
     val actionLogin = stringResource(Res.string.sign_in)
     LaunchedEffect(Unit) {
         viewModel.starEvents.collect { result ->
             when (result) {
                 RepoStarService.Result.STARRED -> snackbarHostState.showSnackbar(msgStarred)
                 RepoStarService.Result.FAILED -> snackbarHostState.showSnackbar(msgFailed)
+                RepoStarService.Result.NEED_GITHUB_LINK -> snackbarHostState.showSnackbar(msgNeedGithubLink)
                 RepoStarService.Result.NEED_LOGIN -> {
                     val action = snackbarHostState.showSnackbar(
                         message = msgNeedLogin,

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
@@ -25,6 +25,7 @@ import kotlin.test.assertTrue
 import whl.trending.ai.auth.AuthManager
 import whl.trending.ai.auth.AuthState
 import whl.trending.ai.auth.FollowingProvider
+import whl.trending.ai.auth.GithubTokenLookup
 import whl.trending.ai.auth.GithubTokenProvider
 import whl.trending.ai.auth.OwnRepoEventsProvider
 import whl.trending.ai.data.local.FakeCacheFileStore
@@ -77,7 +78,17 @@ class ProfileViewModelTest {
     }
 
     private class FakeTokenProvider : GithubTokenProvider() {
-        override suspend fun get(): String? = "gh-token"
+        override suspend fun lookup(): GithubTokenLookup = GithubTokenLookup.Available("gh-token")
+    }
+
+    /** 服务端明确 404：已关联但 vault 为空 */
+    private class MissingTokenProvider : GithubTokenProvider() {
+        override suspend fun lookup(): GithubTokenLookup = GithubTokenLookup.Missing
+    }
+
+    /** 请求失败：有没有 token 未知 */
+    private class FailedTokenProvider : GithubTokenProvider() {
+        override suspend fun lookup(): GithubTokenLookup = GithubTokenLookup.Failed
     }
 
     private class FakeFollowingProvider : FollowingProvider() {
@@ -99,10 +110,11 @@ class ProfileViewModelTest {
         auth: FakeAuthManager = FakeAuthManager(),
         repository: UserRepository = FakeUserRepository(),
         settingsManager: SettingsManager = settings(),
+        tokenProvider: GithubTokenProvider = FakeTokenProvider(),
     ) = ProfileViewModel(
         repository = repository,
         githubApi = FakeGithubApi(),
-        tokenProvider = FakeTokenProvider(),
+        tokenProvider = tokenProvider,
         followingProvider = FakeFollowingProvider(),
         ownRepoEventsProvider = FakeOwnRepoEventsProvider(),
         authManager = { auth },
@@ -122,6 +134,33 @@ class ProfileViewModelTest {
     @AfterTest
     fun tearDown() {
         Dispatchers.resetMain()
+    }
+
+    @Test
+    fun serverSaysNoTokenFlagsRelink() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val vm = viewModel(cache(), tokenProvider = MissingTokenProvider())
+        vm.load()
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state.loggedIn)
+        assertTrue(state.githubTokenMissing)
+        assertTrue(state.feedUnavailable)
+        assertNull(state.githubUser)
+    }
+
+    @Test
+    fun tokenLookupFailureDoesNotFlagRelink() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val vm = viewModel(cache(), tokenProvider = FailedTokenProvider())
+        vm.load()
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state.loggedIn)
+        assertFalse(state.githubTokenMissing)
+        assertTrue(state.feedUnavailable)
     }
 
     @Test


### PR DESCRIPTION
## 背景

串号事故止血时清空了 14 个账户的 GitHub token（vault），留下一个客户端从未处理过的中间态：`github_user_id` / `github_login` 在、`gh_token_enc` 空。此时「我的」页照常显示「GitHub 主页」卡片，主页、动态、star 全部静默失败，且没有任何入口指向唯一的恢复手段（再走一次 GitHub OAuth）。

## 改动

- `GithubTokenProvider` 增加三态 `lookup()`：区分服务端明确 404（没存 token）与请求失败（有没有未知），后者不能据此引导用户
- `ProfileViewModel` 在 404 且已关联时置 `githubTokenMissing`；`ProfileScreen` 把入口卡换成「重新关联 GitHub」，点击复用现有关联流程（同一 GitHub 重绑幂等成功，后端 `saveGithubToken` 会回填）
- `RepoStarService` 新增 `NEED_GITHUB_LINK`，Trending / README 的 star 提示改为指向「我的」页，不再归入通用失败
- 双语文案 3 条；`ProfileViewModelTest` 补 404 与请求失败两个用例

不动后端。用户在 GitHub 侧撤销授权导致的「死 token」不在本次范围。

## 验证

iOS 模拟器（iPhone 17）用测试小号实测：
1. 清空其 `gh_token_enc` 后重启 → 「我的」页出现「重新关联 GitHub」卡片
2. Trending 列表 Star → 提示「关联 GitHub 后即可 Star，请到「我的」页操作」
3. 点卡片走关联 → 服务端 `oauth_callback linked`、token 同秒回填、卡片复原为「GitHub 主页」并拉到实时计数

`:shared:testAndroidHostTest` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118bXtGDTDheYiAHL45izJQ

## Summary by Sourcery

在客户端识别已关联但缺少 GitHub token 的账户，并引导用户重新关联以恢复 GitHub 功能。

New Features:
- 引导已关联但缺少 GitHub token 的用户重新完成 GitHub 关联，以恢复 GitHub 主页、动态和 Star 功能。

Bug Fixes:
- 区分服务端明确缺少 token 与 token 查询失败，避免在网络或其他请求错误时错误地引导用户重新关联。
- 将缺少 GitHub token 时的 Star 操作从通用失败提示调整为明确的关联引导。

Enhancements:
- 为 GitHub token 查询增加 Available、Missing 和 Failed 三态结果，并在个人资料页展示对应状态。

Tests:
- 为个人资料页补充服务端缺少 token 和 token 查询失败时的状态测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在客户端识别已关联但缺少 GitHub token 的账户，并引导用户重新关联以恢复 GitHub 功能。

New Features:
- 引导已关联但缺少 GitHub token 的用户重新完成 GitHub 关联，以恢复 GitHub 主页、动态和 Star 功能。

Bug Fixes:
- 区分服务端明确缺少 token 与 token 查询失败，避免在网络或其他请求错误时错误地引导用户重新关联。
- 将缺少 GitHub token 时的 Star 操作从通用失败提示调整为明确的关联引导。

Enhancements:
- 为 GitHub token 查询增加 Available、Missing 和 Failed 三态结果，并在个人资料页展示对应状态。

Tests:
- 为个人资料页补充服务端缺少 token 和 token 查询失败时的状态测试。

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer GitHub account status handling, including prompts to link or reconnect GitHub.
  - Users can reconnect expired GitHub authorization to restore profile, activity, and repository starring features.
  - Repository starring now explains when GitHub linking is required.

- **Bug Fixes**
  - Improved distinction between missing GitHub authorization and temporary lookup failures.
  - Added corresponding messaging in profile, repository detail, and trending screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->