### PR TITLE
feat(chat): 语音录入（按住说话、松手即发）Android 实现

### DIFF
--- a/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelVoiceTest.kt
+++ b/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelVoiceTest.kt
@@ -1,0 +1,152 @@
+package whl.trending.chat
+
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import whl.trending.chat.attach.VoiceRecording
+import whl.trending.chat.engine.ChatEngine
+import whl.trending.chat.engine.ChatException
+import whl.trending.chat.engine.Transcription
+import whl.trending.chat.engine.VoiceTranscriber
+import whl.trending.chat.host.ChatAiEvent
+import whl.trending.chat.host.ChatVoiceOutcome
+import whl.trending.chat.model.ChatError
+import whl.trending.chat.model.ChatErrorCategory
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.ChatModelsResponse
+import whl.trending.chat.model.Role
+
+/** 语音录入：转写后直接发送、空文本与失败的就地反馈、音频用后即删、埋点成对。 */
+class ChatViewModelVoiceTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @AfterTest
+    fun tearDown() = Dispatchers.resetMain()
+
+    private class EchoEngine : ChatEngine {
+        val sent = mutableListOf<String>()
+        override suspend fun send(
+            history: List<ChatMessage>,
+            onDelta: (String) -> Unit,
+            search: Boolean,
+            onSearch: (whl.trending.chat.model.SearchEvent) -> Unit,
+        ): String {
+            sent += history.last { it.role == Role.USER }.content
+            onDelta("ok")
+            return "ok"
+        }
+    }
+
+    private class ScriptedTranscriber(var text: String = "你好", var failWith: ChatError? = null) : VoiceTranscriber {
+        val calls = mutableListOf<Pair<String, Long>>()
+        override suspend fun transcribe(path: String, durationMs: Long): Transcription {
+            calls += path to durationMs
+            failWith?.let { throw ChatException(it) }
+            return Transcription(text)
+        }
+    }
+
+    private fun tempAudio(): File = File.createTempFile("voice", ".m4a").apply { writeBytes(ByteArray(16)) }
+
+    private fun vm(engine: ChatEngine, transcriber: VoiceTranscriber?, events: MutableList<ChatAiEvent> = mutableListOf()) =
+        ChatViewModel(engine, loadModels = { ChatModelsResponse() }, track = { events += it }, transcriber = transcriber)
+
+    @Test
+    fun `转写成功：文本直接发送，音频删除，voice_input sent 与 ai_requested from=voice 各一条`() = runTest(dispatcher) {
+        val engine = EchoEngine()
+        val events = mutableListOf<ChatAiEvent>()
+        val viewModel = vm(engine, ScriptedTranscriber(" 帮我看看 Kubernetes "), events)
+        val audio = tempAudio()
+        viewModel.sendVoice(VoiceRecording(audio.absolutePath, 4200))
+        advanceUntilIdle()
+
+        assertEquals(listOf("帮我看看 Kubernetes"), engine.sent)
+        assertFalse(audio.exists())
+        assertFalse(viewModel.uiState.value.isTranscribing)
+        assertEquals(
+            listOf(ChatAiEvent.Requested(from = "voice", imageCount = 0)),
+            events.filterIsInstance<ChatAiEvent.Requested>(),
+        )
+        assertEquals(
+            listOf(ChatAiEvent.VoiceInput(ChatVoiceOutcome.SENT, 4200)),
+            events.filterIsInstance<ChatAiEvent.VoiceInput>(),
+        )
+    }
+
+    @Test
+    fun `转写为空：不发送，提示 EMPTY，音频仍删除`() = runTest(dispatcher) {
+        val engine = EchoEngine()
+        val events = mutableListOf<ChatAiEvent>()
+        val viewModel = vm(engine, ScriptedTranscriber("   "), events)
+        val notices = mutableListOf<VoiceNotice>()
+        val collector = launch { viewModel.voiceNotices.collect { notices += it } }
+        val audio = tempAudio()
+        viewModel.sendVoice(VoiceRecording(audio.absolutePath, 1500))
+        advanceUntilIdle()
+        collector.cancel()
+
+        assertTrue(engine.sent.isEmpty())
+        assertEquals(listOf(VoiceNotice.EMPTY), notices)
+        assertFalse(audio.exists())
+        assertTrue(viewModel.uiState.value.messages.isEmpty())
+        assertEquals(listOf<ChatAiEvent>(ChatAiEvent.VoiceInput(ChatVoiceOutcome.EMPTY, 1500)), events)
+    }
+
+    @Test
+    fun `转写失败：提示 FAILED，isTranscribing 复位；403 Pro 闸提示 PRO_REQUIRED`() = runTest(dispatcher) {
+        val transcriber = ScriptedTranscriber(failWith = ChatError(ChatErrorCategory.SERVER, code = "upstream_error"))
+        val viewModel = vm(EchoEngine(), transcriber)
+        val notices = mutableListOf<VoiceNotice>()
+        val collector = launch { viewModel.voiceNotices.collect { notices += it } }
+
+        viewModel.sendVoice(VoiceRecording(tempAudio().absolutePath, 2000))
+        advanceUntilIdle()
+        transcriber.failWith = ChatError(ChatErrorCategory.BAD_REQUEST, code = ChatError.CODE_VOICE_REQUIRES_PRO, httpStatus = 403)
+        viewModel.sendVoice(VoiceRecording(tempAudio().absolutePath, 2000))
+        advanceUntilIdle()
+        collector.cancel()
+
+        assertEquals(listOf(VoiceNotice.FAILED, VoiceNotice.PRO_REQUIRED), notices)
+        assertFalse(viewModel.uiState.value.isTranscribing)
+    }
+
+    @Test
+    fun `转写在途禁发：isTranscribing 为真时 canSend 为假，第二次 sendVoice 被忽略`() = runTest(dispatcher) {
+        val transcriber = ScriptedTranscriber()
+        val viewModel = vm(EchoEngine(), transcriber)
+        viewModel.sendVoice(VoiceRecording(tempAudio().absolutePath, 2000))
+        viewModel.updateInput("typed")
+        assertTrue(viewModel.uiState.value.isTranscribing)
+        assertFalse(viewModel.uiState.value.canSend)
+        viewModel.sendVoice(VoiceRecording(tempAudio().absolutePath, 2000))
+        advanceUntilIdle()
+        assertEquals(1, transcriber.calls.size)
+    }
+
+    @Test
+    fun `未注入转写器：voiceAvailable 为假，sendVoice 无副作用`() = runTest(dispatcher) {
+        val engine = EchoEngine()
+        val viewModel = vm(engine, transcriber = null)
+        assertFalse(viewModel.voiceAvailable)
+        viewModel.sendVoice(VoiceRecording(tempAudio().absolutePath, 2000))
+        advanceUntilIdle()
+        assertTrue(engine.sent.isEmpty())
+        assertFalse(viewModel.uiState.value.isTranscribing)
+    }
+}

--- a/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelVoiceTest.kt
+++ b/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelVoiceTest.kt
@@ -111,7 +111,8 @@ class ChatViewModelVoiceTest {
     @Test
     fun `转写失败：提示 FAILED，isTranscribing 复位；403 Pro 闸提示 PRO_REQUIRED`() = runTest(dispatcher) {
         val transcriber = ScriptedTranscriber(failWith = ChatError(ChatErrorCategory.SERVER, code = "upstream_error"))
-        val viewModel = vm(EchoEngine(), transcriber)
+        val events = mutableListOf<ChatAiEvent>()
+        val viewModel = vm(EchoEngine(), transcriber, events)
         val notices = mutableListOf<VoiceNotice>()
         val collector = launch { viewModel.voiceNotices.collect { notices += it } }
 
@@ -124,6 +125,10 @@ class ChatViewModelVoiceTest {
 
         assertEquals(listOf(VoiceNotice.FAILED, VoiceNotice.PRO_REQUIRED), notices)
         assertFalse(viewModel.uiState.value.isTranscribing)
+        assertEquals(
+            listOf(ChatVoiceOutcome.ERROR, ChatVoiceOutcome.PRO_GATE),
+            events.filterIsInstance<ChatAiEvent.VoiceInput>().map { it.outcome },
+        )
     }
 
     @Test

--- a/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelVoiceTest.kt
+++ b/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelVoiceTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -142,6 +143,36 @@ class ChatViewModelVoiceTest {
         viewModel.sendVoice(VoiceRecording(tempAudio().absolutePath, 2000))
         advanceUntilIdle()
         assertEquals(1, transcriber.calls.size)
+    }
+
+    @Test
+    fun `转写在途：建议动作与重试的发送被门禁拒绝，转写文本随后照常发出`() = runTest(dispatcher) {
+        val gate = CompletableDeferred<Unit>()
+        val transcriber = object : VoiceTranscriber {
+            override suspend fun transcribe(path: String, durationMs: Long): Transcription {
+                gate.await()
+                return Transcription("语音内容")
+            }
+        }
+        val engine = EchoEngine()
+        val events = mutableListOf<ChatAiEvent>()
+        val viewModel = vm(engine, transcriber, events)
+        viewModel.sendVoice(VoiceRecording(tempAudio().absolutePath, 3000))
+        advanceUntilIdle()
+        assertTrue(viewModel.uiState.value.isBusy)
+
+        viewModel.sendText("chip")
+        advanceUntilIdle()
+        assertTrue(engine.sent.isEmpty())
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(listOf("语音内容"), engine.sent)
+        assertEquals(listOf("voice"), events.filterIsInstance<ChatAiEvent.Requested>().map { it.from })
+        assertEquals(
+            listOf(ChatVoiceOutcome.SENT),
+            events.filterIsInstance<ChatAiEvent.VoiceInput>().map { it.outcome },
+        )
     }
 
     @Test

--- a/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelVoiceTest.kt
+++ b/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelVoiceTest.kt
@@ -176,6 +176,36 @@ class ChatViewModelVoiceTest {
     }
 
     @Test
+    fun `转写在途切走会话：转写被取消，不发送、删音频、记 CANCELLED`() = runTest(dispatcher) {
+        val gate = CompletableDeferred<Unit>()
+        val transcriber = object : VoiceTranscriber {
+            override suspend fun transcribe(path: String, durationMs: Long): Transcription {
+                gate.await()
+                return Transcription("语音内容")
+            }
+        }
+        val engine = EchoEngine()
+        val events = mutableListOf<ChatAiEvent>()
+        val viewModel = vm(engine, transcriber, events)
+        val audio = tempAudio()
+        viewModel.sendVoice(VoiceRecording(audio.absolutePath, 3000))
+        advanceUntilIdle()
+
+        viewModel.startNewThread()
+        advanceUntilIdle()
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        assertTrue(engine.sent.isEmpty())
+        assertFalse(audio.exists())
+        assertFalse(viewModel.uiState.value.isTranscribing)
+        assertEquals(
+            listOf(ChatVoiceOutcome.CANCELLED),
+            events.filterIsInstance<ChatAiEvent.VoiceInput>().map { it.outcome },
+        )
+    }
+
+    @Test
     fun `未注入转写器：voiceAvailable 为假，sendVoice 无副作用`() = runTest(dispatcher) {
         val engine = EchoEngine()
         val viewModel = vm(engine, transcriber = null)

--- a/chat/src/androidMain/AndroidManifest.xml
+++ b/chat/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- 语音录入（按住说话）；权限跟着功能走，宿主 manifest 经 merger 自动合入 -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
     <application>
         <!--
             离线 Demo 入口。不带 LAUNCHER intent-filter（避免给正式包多一个图标），

--- a/chat/src/androidMain/kotlin/whl/trending/chat/ChatDemoActivity.kt
+++ b/chat/src/androidMain/kotlin/whl/trending/chat/ChatDemoActivity.kt
@@ -54,6 +54,7 @@ private fun DemoContent(real: Boolean, onBack: () -> Unit) {
             initialMessages = SampleData.messages,
             // 纯内存：假引擎的样例会话不落真库
             persistent = false,
+            transcriber = null,
         )
     }
 }

--- a/chat/src/androidMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.android.kt
+++ b/chat/src/androidMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.android.kt
@@ -68,13 +68,13 @@ private class AndroidVoiceRecorder(
     override val isAvailable: Boolean =
         context.packageManager.hasSystemFeature(PackageManager.FEATURE_MICROPHONE)
 
-    override fun start(): Boolean {
-        if (recorder != null) return false
+    override fun start(): VoiceStart {
+        if (recorder != null) return VoiceStart.FAILED
         val granted = ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
             PackageManager.PERMISSION_GRANTED
         if (!granted) {
             requestPermission()
-            return false
+            return VoiceStart.PERMISSION_PENDING
         }
         val target = File(File(context.cacheDir, DIR).apply { mkdirs() }, "${UUID.randomUUID()}.m4a")
         @Suppress("DEPRECATION")
@@ -99,12 +99,12 @@ private class AndroidVoiceRecorder(
             logWarn(TAG, "start failed", e)
             mr.release()
             target.delete()
-            return false
+            return VoiceStart.FAILED
         }
         recorder = mr
         file = target
         startedAt = SystemClock.elapsedRealtime()
-        return true
+        return VoiceStart.STARTED
     }
 
     override fun stop(): VoiceRecording? {

--- a/chat/src/androidMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.android.kt
+++ b/chat/src/androidMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.android.kt
@@ -1,0 +1,140 @@
+package whl.trending.chat.attach
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.media.MediaRecorder
+import android.net.Uri
+import android.os.Build
+import android.os.SystemClock
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import java.io.File
+import java.util.UUID
+import whl.trending.chat.core.logWarn
+
+private const val TAG = "ChatVoiceRecorder"
+private const val DIR = "chat_voice"
+
+/**
+ * Android 实现：MediaRecorder 直出 AAC m4a（单声道 16kHz 32kbps，60s 约 240KB）。
+ * 权限走运行时申请；被拒后由 UI 引导去系统设置。
+ */
+@Composable
+actual fun rememberChatVoiceRecorder(
+    maxDurationMs: Int,
+    minDurationMs: Int,
+    onAutoStop: (VoiceRecording) -> Unit,
+    onPermissionDenied: () -> Unit,
+): ChatVoiceRecorder {
+    val context = LocalContext.current
+    val currentAutoStop by rememberUpdatedState(onAutoStop)
+    val currentDenied by rememberUpdatedState(onPermissionDenied)
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted -> if (!granted) currentDenied() }
+
+    return remember(context, maxDurationMs, minDurationMs) {
+        AndroidVoiceRecorder(
+            context = context,
+            maxDurationMs = maxDurationMs,
+            minDurationMs = minDurationMs,
+            requestPermission = { permissionLauncher.launch(Manifest.permission.RECORD_AUDIO) },
+            onAutoStop = { currentAutoStop(it) },
+        )
+    }
+}
+
+private class AndroidVoiceRecorder(
+    private val context: Context,
+    private val maxDurationMs: Int,
+    private val minDurationMs: Int,
+    private val requestPermission: () -> Unit,
+    private val onAutoStop: (VoiceRecording) -> Unit,
+) : ChatVoiceRecorder {
+
+    private var recorder: MediaRecorder? = null
+    private var file: File? = null
+    private var startedAt = 0L
+
+    override val isAvailable: Boolean =
+        context.packageManager.hasSystemFeature(PackageManager.FEATURE_MICROPHONE)
+
+    override fun start(): Boolean {
+        if (recorder != null) return false
+        val granted = ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+            PackageManager.PERMISSION_GRANTED
+        if (!granted) {
+            requestPermission()
+            return false
+        }
+        val target = File(File(context.cacheDir, DIR).apply { mkdirs() }, "${UUID.randomUUID()}.m4a")
+        @Suppress("DEPRECATION")
+        val mr = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) MediaRecorder(context) else MediaRecorder()
+        try {
+            mr.setAudioSource(MediaRecorder.AudioSource.MIC)
+            mr.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+            mr.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+            mr.setAudioChannels(1)
+            mr.setAudioSamplingRate(16_000)
+            mr.setAudioEncodingBitRate(32_000)
+            mr.setMaxDuration(maxDurationMs)
+            mr.setOutputFile(target.absolutePath)
+            mr.setOnInfoListener { _, what, _ ->
+                if (what == MediaRecorder.MEDIA_RECORDER_INFO_MAX_DURATION_REACHED) {
+                    stop()?.let(onAutoStop)
+                }
+            }
+            mr.prepare()
+            mr.start()
+        } catch (e: Exception) {
+            logWarn(TAG, "start failed", e)
+            mr.release()
+            target.delete()
+            return false
+        }
+        recorder = mr
+        file = target
+        startedAt = SystemClock.elapsedRealtime()
+        return true
+    }
+
+    override fun stop(): VoiceRecording? {
+        val mr = recorder ?: return null
+        val target = file
+        val durationMs = SystemClock.elapsedRealtime() - startedAt
+        recorder = null
+        file = null
+        // 过短时 stop() 会因无有效数据抛 RuntimeException，与误触同一处理
+        val ok = runCatching { mr.stop() }.isSuccess
+        mr.release()
+        if (!ok || target == null || durationMs < minDurationMs || target.length() == 0L) {
+            target?.delete()
+            return null
+        }
+        return VoiceRecording(target.absolutePath, durationMs)
+    }
+
+    override fun cancel() {
+        val mr = recorder ?: return
+        recorder = null
+        runCatching { mr.stop() }
+        mr.release()
+        file?.delete()
+        file = null
+    }
+
+    override fun openPermissionSettings() {
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.fromParts("package", context.packageName, null))
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        runCatching { context.startActivity(intent) }.onFailure { logWarn(TAG, "open settings failed", it) }
+    }
+}

--- a/chat/src/androidMain/kotlin/whl/trending/chat/ui/ShowNotice.android.kt
+++ b/chat/src/androidMain/kotlin/whl/trending/chat/ui/ShowNotice.android.kt
@@ -1,0 +1,11 @@
+package whl.trending.chat.ui
+
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+internal actual fun rememberShowNotice(): (String) -> Unit {
+    val context = LocalContext.current
+    return { text -> Toast.makeText(context, text, Toast.LENGTH_SHORT).show() }
+}

--- a/chat/src/commonMain/composeResources/values-zh/strings.xml
+++ b/chat/src/commonMain/composeResources/values-zh/strings.xml
@@ -56,4 +56,15 @@
     <!-- P2 联网搜索 -->
     <string name="chat_web_search">联网搜索</string>
     <string name="chat_searching">正在搜索网络…</string>
+    <string name="chat_voice_mic">语音输入</string>
+    <string name="chat_voice_release_send">松开发送 · 上滑取消</string>
+    <string name="chat_voice_release_cancel">松开取消</string>
+    <string name="chat_voice_transcribing">正在识别…</string>
+    <string name="chat_voice_empty">没有听清，请重试</string>
+    <string name="chat_voice_failed">语音识别失败，请重试</string>
+    <string name="chat_voice_pro_title">Pro 专属功能</string>
+    <string name="chat_voice_pro_message">语音输入目前仅对 Pro 开放，可继续使用文字输入。</string>
+    <string name="chat_voice_permission_title">需要麦克风权限</string>
+    <string name="chat_voice_permission_message">请在系统设置中允许使用麦克风，以使用语音输入。</string>
+    <string name="chat_voice_permission_settings">去设置</string>
 </resources>

--- a/chat/src/commonMain/composeResources/values/strings.xml
+++ b/chat/src/commonMain/composeResources/values/strings.xml
@@ -59,4 +59,15 @@
     <!-- P2 联网搜索 -->
     <string name="chat_web_search">Web search</string>
     <string name="chat_searching">Searching the web…</string>
+    <string name="chat_voice_mic">Voice input</string>
+    <string name="chat_voice_release_send">Release to send · Slide up to cancel</string>
+    <string name="chat_voice_release_cancel">Release to cancel</string>
+    <string name="chat_voice_transcribing">Transcribing…</string>
+    <string name="chat_voice_empty">Didn&apos;t catch that. Please try again.</string>
+    <string name="chat_voice_failed">Voice recognition failed. Please try again.</string>
+    <string name="chat_voice_pro_title">Pro feature</string>
+    <string name="chat_voice_pro_message">Voice input is currently available to Pro only. Typing works as usual.</string>
+    <string name="chat_voice_permission_title">Microphone access needed</string>
+    <string name="chat_voice_permission_message">Allow microphone access in system settings to use voice input.</string>
+    <string name="chat_voice_permission_settings">Open settings</string>
 </resources>

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -157,37 +157,46 @@ class ChatViewModel(
 
     /**
      * 语音录入：转写成文本后直接发送（听写不进输入框）。音频用完即删，失败也删。
-     * 转写在途期间 [ChatUiState.isTranscribing] 为真，输入区据此禁发与显示等待态。
+     * 转写在途期间 [ChatUiState.isTranscribing] 为真：所有其他发送入口在 [enqueueChat] 里被拒，
+     * 转写文本因此不会撞上别的发送而丢失；UI 的禁用只是观感层。
      */
     fun sendVoice(recording: whl.trending.chat.attach.VoiceRecording) {
         val transcriber = transcriber ?: return
         if (_uiState.value.isSending || _uiState.value.isTranscribing) return
         _uiState.update { it.copy(isTranscribing = true) }
         viewModelScope.launch {
-            val outcome = try {
-                val text = transcriber.transcribe(recording.path, recording.durationMs).text.trim()
-                if (text.isEmpty()) {
-                    _voiceNotices.tryEmit(VoiceNotice.EMPTY)
-                    ChatVoiceOutcome.EMPTY
-                } else {
-                    _uiState.update { it.copy(isTranscribing = false) }
-                    queueChat(text, emptyList(), from = "voice")
-                    ChatVoiceOutcome.SENT
-                }
+            val text = try {
+                transcriber.transcribe(recording.path, recording.durationMs).text.trim()
             } catch (e: ChatException) {
+                runCatching { FileSystem.SYSTEM.delete(recording.path.toPath()) }
                 // 服务端 Pro 闸（本地 Pro 态过期未同步时才会到这）与转写故障在漏斗里要分得开
-                if (e.error.code == ChatError.CODE_VOICE_REQUIRES_PRO) {
+                val outcome = if (e.error.code == ChatError.CODE_VOICE_REQUIRES_PRO) {
                     _voiceNotices.tryEmit(VoiceNotice.PRO_REQUIRED)
                     ChatVoiceOutcome.PRO_GATE
                 } else {
                     _voiceNotices.tryEmit(VoiceNotice.FAILED)
                     ChatVoiceOutcome.ERROR
                 }
-            } finally {
                 _uiState.update { it.copy(isTranscribing = false) }
-                runCatching { FileSystem.SYSTEM.delete(recording.path.toPath()) }
+                reportVoiceOutcome(outcome, recording.durationMs)
+                return@launch
             }
-            reportVoiceOutcome(outcome, recording.durationMs)
+            runCatching { FileSystem.SYSTEM.delete(recording.path.toPath()) }
+            stateLock.withLock {
+                val outcome = when {
+                    text.isEmpty() -> {
+                        _voiceNotices.tryEmit(VoiceNotice.EMPTY)
+                        ChatVoiceOutcome.EMPTY
+                    }
+                    enqueueChat(text, emptyList(), from = "voice", fromVoice = true) -> ChatVoiceOutcome.SENT
+                    else -> {
+                        _voiceNotices.tryEmit(VoiceNotice.FAILED)
+                        ChatVoiceOutcome.ERROR
+                    }
+                }
+                _uiState.update { it.copy(isTranscribing = false) }
+                reportVoiceOutcome(outcome, recording.durationMs)
+            }
         }
     }
 
@@ -197,17 +206,26 @@ class ChatViewModel(
     }
 
     private fun queueChat(text: String, images: List<String>, from: String) {
-        if (_uiState.value.isSending || (text.isBlank() && images.isEmpty())) return
+        if (_uiState.value.isBusy || (text.isBlank() && images.isEmpty())) return
+        locked { enqueueChat(text, images, from) }
+    }
+
+    /**
+     * 发送的唯一门禁，须在 [stateLock] 内调用；返回是否接受。
+     * 转写在途拒绝一切非语音发送（[fromVoice]），否则转写文本会在这里被 isSending 挡掉而丢失。
+     */
+    private suspend fun enqueueChat(text: String, images: List<String>, from: String, fromVoice: Boolean = false): Boolean {
+        val state = _uiState.value
+        if (state.isSending || (state.isTranscribing && !fromVoice)) return false
+        if (text.isBlank() && images.isEmpty()) return false
         // 发送被接受那一刻捕获搜索开关：排队与流启动之间用户再切开关不影响本条
         val search = _searchEnabled.value
-        locked {
-            if (_uiState.value.isSending) return@locked
-            trackChatSend(from, images.size)
-            _uiState.update { it.copy(isSending = true) }
-            val threadId = ensureThread(text)
-            appendVisible(store.appendUserMessage(threadId, text, images))
-            startStream(threadId, search)
-        }
+        trackChatSend(from, images.size)
+        _uiState.update { it.copy(isSending = true) }
+        val threadId = ensureThread(text)
+        appendVisible(store.appendUserMessage(threadId, text, images))
+        startStream(threadId, search)
+        return true
     }
 
     /** 对可重试的失败消息重试：移除该错误条，重打一次请求。
@@ -216,8 +234,8 @@ class ChatViewModel(
         val error = message.error ?: return
         if (!error.category.retryable && error.code != ChatError.CODE_QUOTA_DEVICE) return
         locked {
-            // 错误条仍须在场（防连点与过期引用）
-            if (_uiState.value.isSending || _uiState.value.messages.none { it.id == message.id }) return@locked
+            // 错误条仍须在场（防连点与过期引用）；转写在途同样不放行，理由见 enqueueChat
+            if (_uiState.value.isBusy || _uiState.value.messages.none { it.id == message.id }) return@locked
             val threadId = _currentThreadId.value ?: return@locked
             store.deleteMessage(message.id)
             removeVisible(message.id)

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -175,10 +175,14 @@ class ChatViewModel(
                     ChatVoiceOutcome.SENT
                 }
             } catch (e: ChatException) {
-                _voiceNotices.tryEmit(
-                    if (e.error.code == ChatError.CODE_VOICE_REQUIRES_PRO) VoiceNotice.PRO_REQUIRED else VoiceNotice.FAILED,
-                )
-                ChatVoiceOutcome.ERROR
+                // 服务端 Pro 闸（本地 Pro 态过期未同步时才会到这）与转写故障在漏斗里要分得开
+                if (e.error.code == ChatError.CODE_VOICE_REQUIRES_PRO) {
+                    _voiceNotices.tryEmit(VoiceNotice.PRO_REQUIRED)
+                    ChatVoiceOutcome.PRO_GATE
+                } else {
+                    _voiceNotices.tryEmit(VoiceNotice.FAILED)
+                    ChatVoiceOutcome.ERROR
+                }
             } finally {
                 _uiState.update { it.copy(isTranscribing = false) }
                 runCatching { FileSystem.SYSTEM.delete(recording.path.toPath()) }

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -164,40 +164,55 @@ class ChatViewModel(
         val transcriber = transcriber ?: return
         if (_uiState.value.isSending || _uiState.value.isTranscribing) return
         _uiState.update { it.copy(isTranscribing = true) }
-        viewModelScope.launch {
-            val text = try {
-                transcriber.transcribe(recording.path, recording.durationMs).text.trim()
-            } catch (e: ChatException) {
-                runCatching { FileSystem.SYSTEM.delete(recording.path.toPath()) }
-                // 服务端 Pro 闸（本地 Pro 态过期未同步时才会到这）与转写故障在漏斗里要分得开
-                val outcome = if (e.error.code == ChatError.CODE_VOICE_REQUIRES_PRO) {
-                    _voiceNotices.tryEmit(VoiceNotice.PRO_REQUIRED)
-                    ChatVoiceOutcome.PRO_GATE
-                } else {
-                    _voiceNotices.tryEmit(VoiceNotice.FAILED)
-                    ChatVoiceOutcome.ERROR
-                }
-                _uiState.update { it.copy(isTranscribing = false) }
-                reportVoiceOutcome(outcome, recording.durationMs)
-                return@launch
-            }
-            runCatching { FileSystem.SYSTEM.delete(recording.path.toPath()) }
-            stateLock.withLock {
-                val outcome = when {
-                    text.isEmpty() -> {
-                        _voiceNotices.tryEmit(VoiceNotice.EMPTY)
-                        ChatVoiceOutcome.EMPTY
-                    }
-                    enqueueChat(text, emptyList(), from = "voice", fromVoice = true) -> ChatVoiceOutcome.SENT
-                    else -> {
+        transcribeJob = viewModelScope.launch {
+            var outcome: ChatVoiceOutcome? = null
+            try {
+                val text = try {
+                    transcriber.transcribe(recording.path, recording.durationMs).text.trim()
+                } catch (e: ChatException) {
+                    // 服务端 Pro 闸（本地 Pro 态过期未同步时才会到这）与转写故障在漏斗里要分得开
+                    outcome = if (e.error.code == ChatError.CODE_VOICE_REQUIRES_PRO) {
+                        _voiceNotices.tryEmit(VoiceNotice.PRO_REQUIRED)
+                        ChatVoiceOutcome.PRO_GATE
+                    } else {
                         _voiceNotices.tryEmit(VoiceNotice.FAILED)
                         ChatVoiceOutcome.ERROR
                     }
+                    return@launch
                 }
+                stateLock.withLock {
+                    outcome = when {
+                        text.isEmpty() -> {
+                            _voiceNotices.tryEmit(VoiceNotice.EMPTY)
+                            ChatVoiceOutcome.EMPTY
+                        }
+                        enqueueChat(text, emptyList(), from = "voice", fromVoice = true) -> ChatVoiceOutcome.SENT
+                        else -> {
+                            _voiceNotices.tryEmit(VoiceNotice.FAILED)
+                            ChatVoiceOutcome.ERROR
+                        }
+                    }
+                }
+            } catch (e: CancellationException) {
+                outcome = ChatVoiceOutcome.CANCELLED
+                throw e
+            } finally {
+                runCatching { FileSystem.SYSTEM.delete(recording.path.toPath()) }
                 _uiState.update { it.copy(isTranscribing = false) }
-                reportVoiceOutcome(outcome, recording.durationMs)
+                transcribeJob = null
+                outcome?.let { reportVoiceOutcome(it, recording.durationMs) }
             }
         }
+    }
+
+    private var transcribeJob: Job? = null
+
+    /** 切走即取消：转写属于发起它的会话，切换/重置/删除当前会话时与在途流同一处理（持锁调用）。 */
+    private suspend fun cancelTranscription() {
+        val job = transcribeJob ?: return
+        transcribeJob = null
+        job.cancel()
+        job.join()
     }
 
     /** 转写前就结束的语音结果（取消 / 太短 / 权限 / Pro 闸）由 UI 上报；转写后的由 [sendVoice] 上报。 */
@@ -264,12 +279,14 @@ class ChatViewModel(
     fun switchThread(id: Long) = locked {
         if (id == _currentThreadId.value) return@locked
         cancelInFlight(persistInterrupted = true)
+        cancelTranscription()
         openThread(id)
     }
 
     /** 抽屉「新会话」：总是全新开始，不复用任何历史 */
     fun startNewThread() = locked {
         cancelInFlight(persistInterrupted = true)
+        cancelTranscription()
         resetSession()
     }
 
@@ -279,6 +296,7 @@ class ChatViewModel(
 
     fun deleteThread(id: Long) = locked {
         if (inFlight?.threadId == id) cancelInFlight(persistInterrupted = false)
+        if (_currentThreadId.value == id) cancelTranscription()
         store.deleteThread(id)
         if (_currentThreadId.value == id) resetSession()
     }

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -4,9 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -16,8 +19,10 @@ import kotlinx.coroutines.sync.withLock
 import whl.trending.chat.core.epochMillis
 import whl.trending.chat.engine.ChatEngine
 import whl.trending.chat.engine.ChatException
+import whl.trending.chat.engine.VoiceTranscriber
 import whl.trending.chat.host.ChatAiEvent
 import whl.trending.chat.host.ChatAiOutcome
+import whl.trending.chat.host.ChatVoiceOutcome
 import whl.trending.chat.host.chatHost
 import whl.trending.chat.model.ChatError
 import whl.trending.chat.model.ChatErrorCategory
@@ -31,9 +36,15 @@ import whl.trending.chat.model.SourceRef
 import whl.trending.chat.model.resolveDisplayedChatModel
 import whl.trending.chat.store.ChatStore
 import whl.trending.chat.store.InMemoryChatStore
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import okio.SYSTEM
 
 /** 抽屉里的一条会话概要 */
 data class ThreadSummary(val id: Long, val title: String, val updatedAt: Long)
+
+/** 语音录入需要就地反馈的结果（成功即发送，无需通知）。 */
+enum class VoiceNotice { EMPTY, FAILED, PRO_REQUIRED }
 
 /**
  * 聊天 ViewModel。并发模型是理解一切的钥匙：
@@ -51,11 +62,13 @@ data class ThreadSummary(val id: Long, val title: String, val updatedAt: Long)
  *
  * @param store 持久化层；默认内存实现（Demo/预览），正式宿主注入 Room 实现
  * @param selectedModelId 应答模型记录用（展示「哪个模型答的」）；默认读全局设置的用户选择
+ * @param transcriber 语音转写；null 时语音入口不可用（Demo）
  */
 class ChatViewModel(
     private val engine: ChatEngine,
     initialMessages: List<ChatMessage> = emptyList(),
     private val store: ChatStore = InMemoryChatStore(),
+    private val transcriber: VoiceTranscriber? = null,
     private val loadModels: suspend () -> ChatModelsResponse = { ChatModelsProvider.get() },
     private val track: (ChatAiEvent) -> Unit = { chatHost.onAiEvent(it) },
     private val selectedModelId: () -> String? = {
@@ -91,6 +104,11 @@ class ChatViewModel(
     fun toggleWebSearch() {
         _searchEnabled.value = !_searchEnabled.value
     }
+
+    val voiceAvailable: Boolean get() = transcriber != null
+
+    private val _voiceNotices = MutableSharedFlow<VoiceNotice>(extraBufferCapacity = 1)
+    val voiceNotices: SharedFlow<VoiceNotice> = _voiceNotices.asSharedFlow()
 
     private val stateLock = Mutex()
 
@@ -137,6 +155,43 @@ class ChatViewModel(
     /** 发送一段指定文本（如建议动作的预设问题），不依赖输入框；发送中或空白则忽略。 */
     fun sendText(text: String) = queueChat(text, emptyList(), from = "quick_reply")
 
+    /**
+     * 语音录入：转写成文本后直接发送（听写不进输入框）。音频用完即删，失败也删。
+     * 转写在途期间 [ChatUiState.isTranscribing] 为真，输入区据此禁发与显示等待态。
+     */
+    fun sendVoice(recording: whl.trending.chat.attach.VoiceRecording) {
+        val transcriber = transcriber ?: return
+        if (_uiState.value.isSending || _uiState.value.isTranscribing) return
+        _uiState.update { it.copy(isTranscribing = true) }
+        viewModelScope.launch {
+            val outcome = try {
+                val text = transcriber.transcribe(recording.path, recording.durationMs).text.trim()
+                if (text.isEmpty()) {
+                    _voiceNotices.tryEmit(VoiceNotice.EMPTY)
+                    ChatVoiceOutcome.EMPTY
+                } else {
+                    _uiState.update { it.copy(isTranscribing = false) }
+                    queueChat(text, emptyList(), from = "voice")
+                    ChatVoiceOutcome.SENT
+                }
+            } catch (e: ChatException) {
+                _voiceNotices.tryEmit(
+                    if (e.error.code == ChatError.CODE_VOICE_REQUIRES_PRO) VoiceNotice.PRO_REQUIRED else VoiceNotice.FAILED,
+                )
+                ChatVoiceOutcome.ERROR
+            } finally {
+                _uiState.update { it.copy(isTranscribing = false) }
+                runCatching { FileSystem.SYSTEM.delete(recording.path.toPath()) }
+            }
+            reportVoiceOutcome(outcome, recording.durationMs)
+        }
+    }
+
+    /** 转写前就结束的语音结果（取消 / 太短 / 权限 / Pro 闸）由 UI 上报；转写后的由 [sendVoice] 上报。 */
+    fun reportVoiceOutcome(outcome: ChatVoiceOutcome, durationMs: Long? = null) {
+        track(ChatAiEvent.VoiceInput(outcome = outcome, durationMs = durationMs))
+    }
+
     private fun queueChat(text: String, images: List<String>, from: String) {
         if (_uiState.value.isSending || (text.isBlank() && images.isEmpty())) return
         // 发送被接受那一刻捕获搜索开关：排队与流启动之间用户再切开关不影响本条
@@ -176,7 +231,7 @@ class ChatViewModel(
      * 被限流 / 上游报错的请求同样留痕，所以这里也在发出前记，两侧行数可直接对账，
      * 残差只剩上报丢失一项。
      *
-     * [from]：`input`（输入框）/ `quick_reply`（建议动作）/ `retry`（重试）。
+     * [from]：`input`（输入框）/ `quick_reply`（建议动作）/ `retry`（重试）/ `voice`（语音转写）。
      */
     private fun trackChatSend(from: String, imageCount: Int) {
         track(ChatAiEvent.Requested(from = from, imageCount = imageCount))

--- a/chat/src/commonMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.kt
@@ -1,0 +1,41 @@
+package whl.trending.chat.attach
+
+import androidx.compose.runtime.Composable
+
+/** 一段录好的语音：本地 m4a 路径 + 时长。 */
+data class VoiceRecording(val path: String, val durationMs: Long)
+
+/**
+ * 语音录入的平台缝：按住录音、松手取件。产出为 AAC m4a（单声道 16kHz 低码率），
+ * 权限申请与被拒反馈由各平台在 [start] 内自行处理。
+ */
+interface ChatVoiceRecorder {
+    /** 平台是否有录音能力；false 时 UI 不渲染麦克风。 */
+    val isAvailable: Boolean
+
+    /** 开始录音；返回 false 表示本次未开始（权限未授予时会发起申请，用户需再按一次）。 */
+    fun start(): Boolean
+
+    /** 结束并取件；不足最短时长或写文件失败返回 null（文件已清理）。 */
+    fun stop(): VoiceRecording?
+
+    /** 放弃本次录音并清理文件。 */
+    fun cancel()
+
+    /** 打开系统的应用权限设置页（权限被永久拒绝后的出口）。 */
+    fun openPermissionSettings()
+}
+
+/**
+ * @param maxDurationMs 触顶自动停止的上限
+ * @param minDurationMs 短于此视为误触，[ChatVoiceRecorder.stop] 返回 null
+ * @param onAutoStop 触顶自动停止时的取件回调（此时手指仍按着，UI 据此结束本次手势）
+ * @param onPermissionDenied 权限申请被拒
+ */
+@Composable
+expect fun rememberChatVoiceRecorder(
+    maxDurationMs: Int,
+    minDurationMs: Int,
+    onAutoStop: (VoiceRecording) -> Unit,
+    onPermissionDenied: () -> Unit,
+): ChatVoiceRecorder

--- a/chat/src/commonMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.kt
@@ -5,6 +5,9 @@ import androidx.compose.runtime.Composable
 /** 一段录好的语音：本地 m4a 路径 + 时长。 */
 data class VoiceRecording(val path: String, val durationMs: Long)
 
+/** [ChatVoiceRecorder.start] 的结果：权限未授予时已发起申请（用户需再按一次）；FAILED 是录音器本身起不来。 */
+enum class VoiceStart { STARTED, PERMISSION_PENDING, FAILED }
+
 /**
  * 语音录入的平台缝：按住录音、松手取件。产出为 AAC m4a（单声道 16kHz 低码率），
  * 权限申请与被拒反馈由各平台在 [start] 内自行处理。
@@ -13,8 +16,7 @@ interface ChatVoiceRecorder {
     /** 平台是否有录音能力；false 时 UI 不渲染麦克风。 */
     val isAvailable: Boolean
 
-    /** 开始录音；返回 false 表示本次未开始（权限未授予时会发起申请，用户需再按一次）。 */
-    fun start(): Boolean
+    fun start(): VoiceStart
 
     /** 结束并取件；不足最短时长或写文件失败返回 null（文件已清理）。 */
     fun stop(): VoiceRecording?

--- a/chat/src/commonMain/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -164,9 +164,9 @@ class ChatApi(
      * 流在 done 之前结束视为中途断流 → SERVER 可重试，已渲染部分由调用方丢弃。
      */
     override suspend fun transcribe(path: String, durationMs: Long): Transcription {
-        val bytes = FileSystem.SYSTEM.read(path.toPath()) { readByteArray() }
         val lang = resolveLang()
         try {
+            val bytes = FileSystem.SYSTEM.read(path.toPath()) { readByteArray() }
             val sentAsLoggedIn = chatHost.isLoggedInNow()
             val response = client.post("$baseUrl/chat/transcribe") {
                 header("X-Install-Id", chatHost.installId())

--- a/chat/src/commonMain/kotlin/whl/trending/chat/engine/ChatApi.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/engine/ChatApi.kt
@@ -5,13 +5,18 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.timeout
 import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
 import io.ktor.client.request.header
+import io.ktor.client.request.post
 import io.ktor.client.request.preparePost
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
@@ -45,14 +50,16 @@ private const val TAG = "ChatApi"
  */
 class ChatApi(
     private val baseUrl: String = "https://api.trendingai.cn/api",
-) : ChatEngine {
+) : ChatEngine, VoiceTranscriber {
 
     companion object {
         /**
          * App 级共享实例：全进程仅一个 HttpClient，常驻至进程结束，无需 close。
          * 各会话线（keyed ChatViewModel）共用同一 engine，避免反复新建且从不关闭的泄漏。
          */
-        val shared: ChatEngine by lazy { ChatApi() }
+        private val sharedApi: ChatApi by lazy { ChatApi() }
+        val shared: ChatEngine get() = sharedApi
+        val sharedTranscriber: VoiceTranscriber get() = sharedApi
 
         /** 流式请求总时长上限：生成 2500~4000 字解读可能远超普通请求，放到 5 分钟 */
         private const val STREAM_REQUEST_TIMEOUT_MS = 300_000L
@@ -83,6 +90,9 @@ class ChatApi(
 
     @Serializable
     private data class ChatResponse(val content: String)
+
+    @Serializable
+    private data class TranscribeResponse(val text: String, val languages: List<String> = emptyList())
 
     @Serializable
     private data class ErrorResponse(
@@ -153,6 +163,44 @@ class ChatApi(
      * 2xx 非 SSE（服务端降级非流式）整段作为一个 delta 兜底。
      * 流在 done 之前结束视为中途断流 → SERVER 可重试，已渲染部分由调用方丢弃。
      */
+    override suspend fun transcribe(path: String, durationMs: Long): Transcription {
+        val bytes = FileSystem.SYSTEM.read(path.toPath()) { readByteArray() }
+        val lang = resolveLang()
+        try {
+            val sentAsLoggedIn = chatHost.isLoggedInNow()
+            val response = client.post("$baseUrl/chat/transcribe") {
+                header("X-Install-Id", chatHost.installId())
+                setBody(
+                    MultiPartFormDataContent(
+                        formData {
+                            append("lang", lang)
+                            append("duration_ms", durationMs.toString())
+                            append(
+                                "file", bytes,
+                                Headers.build {
+                                    append(HttpHeaders.ContentType, "audio/mp4")
+                                    append(HttpHeaders.ContentDisposition, "filename=\"voice.m4a\"")
+                                },
+                            )
+                        },
+                    ),
+                )
+            }
+            if (response.status != HttpStatusCode.OK) throw toChatException(response, sentAsLoggedIn)
+            val parsed = json.decodeFromString<TranscribeResponse>(response.bodyAsText())
+            return Transcription(parsed.text, parsed.languages)
+        } catch (e: ChatException) {
+            logFailure("chat/transcribe", e.error)
+            throw e
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            val error = ChatErrors.forThrowable(e)
+            logFailure("chat/transcribe", error)
+            throw ChatException(error)
+        }
+    }
+
     private suspend fun executeStreaming(
         path: String,
         onDelta: (String) -> Unit,

--- a/chat/src/commonMain/kotlin/whl/trending/chat/engine/VoiceTranscriber.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/engine/VoiceTranscriber.kt
@@ -1,0 +1,17 @@
+package whl.trending.chat.engine
+
+/** 语音转写结果；[languages] 为服务端检测到的语言码（可空）。 */
+data class Transcription(val text: String, val languages: List<String> = emptyList())
+
+/**
+ * 语音录入的转写段：音频进、纯文本出。文本随后走 [ChatEngine.send] 的普通发送路径，
+ * 对话侧不感知音频。正式注入 [ChatApi]；Demo 不注入（麦克风入口随之隐藏）。
+ */
+interface VoiceTranscriber {
+    /**
+     * @param path 本地音频文件（AAC m4a）
+     * @param durationMs 录音时长，服务端校验上限与成本折算的兜底依据
+     * @throws ChatException HTTP 非 2xx / 传输异常，分类同 [ChatEngine.send]
+     */
+    suspend fun transcribe(path: String, durationMs: Long): Transcription
+}

--- a/chat/src/commonMain/kotlin/whl/trending/chat/host/ChatHost.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/host/ChatHost.kt
@@ -9,6 +9,9 @@ import whl.trending.chat.model.ChatModelsResponse
 /** AI 请求终态。 */
 enum class ChatAiOutcome { OK, ERROR, INTERRUPTED }
 
+/** 语音录入的终态（转写前漏斗）；一次按住恰好一条。 */
+enum class ChatVoiceOutcome { SENT, CANCELLED, TOO_SHORT, EMPTY, ERROR, PERMISSION_DENIED, PRO_GATE }
+
 /** SDK 上报给宿主的埋点事件；Requested 与 Completed 一次请求恰好各一条。 */
 sealed interface ChatAiEvent {
     data class Requested(
@@ -21,6 +24,12 @@ sealed interface ChatAiEvent {
         val durationMs: Long? = null,
         val reason: String? = null,
         val tier: String? = null,
+    ) : ChatAiEvent
+
+    /** 语音录入结果；转写成功后的发送另走 [Requested]（from = "voice"），不重复计。 */
+    data class VoiceInput(
+        val outcome: ChatVoiceOutcome,
+        val durationMs: Long? = null,
     ) : ChatAiEvent
 }
 
@@ -64,6 +73,9 @@ interface ChatHost {
 
     /** 单图压缩预算（KB）。 */
     fun imagesPerImageJpegKb(): Int
+
+    /** 单次语音录入时长上限（毫秒），与服务端校验闸同源。 */
+    fun voiceMaxDurationMs(): Int = 60_000
 
     /** 安装标识，随请求头 `X-Install-Id` 透传（服务端限流维度）。 */
     fun installId(): String

--- a/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatError.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatError.kt
@@ -40,6 +40,7 @@ data class ChatError(
 
         /** 个人配额触顶的机器码（服务端 chat.js quotaError）；重试放行与专属卡片选择都以它为判据 */
         const val CODE_QUOTA_DEVICE = "quota_device"
+        const val CODE_VOICE_REQUIRES_PRO = "voice_requires_pro"
 
         /** 流在 done 事件之前断了（见 engine/ChatApi）：埋点据此把「中断」与「真错误」分开 */
         const val CODE_STREAM_INTERRUPTED = "stream_interrupted"

--- a/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatUiState.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatUiState.kt
@@ -7,12 +7,14 @@ package whl.trending.chat.model
  * @param input         输入框当前文本
  * @param pendingImages 待发送图片（压缩后的本地缓存文件路径，随下一条消息发出）
  * @param isSending     是否正在等待助手回复（驱动「思考中」指示器与发送按钮禁用）
+ * @param isTranscribing 语音录入转写在途（松手到文本进入对话之间的等待）
  */
 data class ChatUiState(
     val messages: List<ChatMessage> = emptyList(),
     val input: String = "",
     val pendingImages: List<String> = emptyList(),
     val isSending: Boolean = false,
+    val isTranscribing: Boolean = false,
 ) {
-    val canSend: Boolean get() = (input.isNotBlank() || pendingImages.isNotEmpty()) && !isSending
+    val canSend: Boolean get() = (input.isNotBlank() || pendingImages.isNotEmpty()) && !isSending && !isTranscribing
 }

--- a/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatUiState.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatUiState.kt
@@ -16,5 +16,8 @@ data class ChatUiState(
     val isSending: Boolean = false,
     val isTranscribing: Boolean = false,
 ) {
-    val canSend: Boolean get() = (input.isNotBlank() || pendingImages.isNotEmpty()) && !isSending && !isTranscribing
+    /** 发送位被占用（回复在途或转写在途）：所有发送入口按此禁用，真正的门禁在 ViewModel */
+    val isBusy: Boolean get() = isSending || isTranscribing
+
+    val canSend: Boolean get() = (input.isNotBlank() || pendingImages.isNotEmpty()) && !isBusy
 }

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatInputBar.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatInputBar.kt
@@ -184,7 +184,10 @@ fun ChatInputBar(
     )
     // 录音中离开页面（返回键、Activity 重建）：手势协程随组合一起没了，录音器得跟着停
     DisposableEffect(recorder) {
-        onDispose { recorder.cancel() }
+        onDispose {
+            recorder.cancel()
+            recordingStartedAt = 0L
+        }
     }
     val showMic = voiceEnabled && recorder.isAvailable && input.isBlank() && pendingImages.isEmpty()
     val haptic = LocalHapticFeedback.current
@@ -377,7 +380,7 @@ fun ChatInputBar(
                         active = recordingStartedAt > 0L,
                         cancelZone = inCancelZone,
                         loading = isTranscribing,
-                        modifier = Modifier.pointerInput(isPro, isTranscribing) {
+                        modifier = Modifier.pointerInput(isPro, isTranscribing, recorder) {
                             awaitEachGesture {
                                 val down = awaitFirstDown()
                                 down.consume()

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatInputBar.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatInputBar.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.collectAsState
@@ -67,6 +68,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import okio.Path.Companion.toPath
 import whl.trending.chat.attach.VoiceRecording
+import whl.trending.chat.attach.VoiceStart
 import whl.trending.chat.attach.rememberChatImagePicker
 import whl.trending.chat.attach.rememberChatVoiceRecorder
 import whl.trending.chat.host.ChatVoiceOutcome
@@ -84,6 +86,7 @@ import trendingai.chat.generated.resources.chat_image_remove
 import trendingai.chat.generated.resources.chat_input_hint
 import trendingai.chat.generated.resources.chat_model_unlock_dismiss
 import trendingai.chat.generated.resources.chat_send
+import trendingai.chat.generated.resources.chat_voice_failed
 import trendingai.chat.generated.resources.chat_voice_mic
 import trendingai.chat.generated.resources.chat_voice_permission_message
 import trendingai.chat.generated.resources.chat_voice_permission_settings
@@ -179,8 +182,14 @@ fun ChatInputBar(
             onVoiceOutcome(ChatVoiceOutcome.PERMISSION_DENIED, null)
         },
     )
+    // 录音中离开页面（返回键、Activity 重建）：手势协程随组合一起没了，录音器得跟着停
+    DisposableEffect(recorder) {
+        onDispose { recorder.cancel() }
+    }
     val showMic = voiceEnabled && recorder.isAvailable && input.isBlank() && pendingImages.isEmpty()
     val haptic = LocalHapticFeedback.current
+    val showNotice = rememberShowNotice()
+    val voiceFailedText = stringResource(Res.string.chat_voice_failed)
 
     if (showProDialog) {
         AlertDialog(
@@ -378,7 +387,15 @@ fun ChatInputBar(
                                     onVoiceOutcome(ChatVoiceOutcome.PRO_GATE, null)
                                     return@awaitEachGesture
                                 }
-                                if (!recorder.start()) return@awaitEachGesture
+                                when (recorder.start()) {
+                                    VoiceStart.PERMISSION_PENDING -> return@awaitEachGesture
+                                    VoiceStart.FAILED -> {
+                                        showNotice(voiceFailedText)
+                                        onVoiceOutcome(ChatVoiceOutcome.ERROR, null)
+                                        return@awaitEachGesture
+                                    }
+                                    VoiceStart.STARTED -> Unit
+                                }
                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                 recordingStartedAt = epochNow()
                                 inCancelZone = false

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatInputBar.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatInputBar.kt
@@ -1,5 +1,7 @@
 package whl.trending.chat.ui
 
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,6 +22,7 @@ import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.PhotoCamera
 import androidx.compose.material.icons.outlined.TravelExplore
@@ -39,6 +42,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -51,13 +55,21 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import okio.Path.Companion.toPath
+import whl.trending.chat.attach.VoiceRecording
 import whl.trending.chat.attach.rememberChatImagePicker
+import whl.trending.chat.attach.rememberChatVoiceRecorder
+import whl.trending.chat.host.ChatVoiceOutcome
 import whl.trending.chat.host.chatHost
 import whl.trending.chat.ChatViewModel
 import trendingai.chat.generated.resources.Res
@@ -70,7 +82,17 @@ import trendingai.chat.generated.resources.chat_image_login_message
 import trendingai.chat.generated.resources.chat_image_login_title
 import trendingai.chat.generated.resources.chat_image_remove
 import trendingai.chat.generated.resources.chat_input_hint
+import trendingai.chat.generated.resources.chat_model_unlock_dismiss
 import trendingai.chat.generated.resources.chat_send
+import trendingai.chat.generated.resources.chat_voice_mic
+import trendingai.chat.generated.resources.chat_voice_permission_message
+import trendingai.chat.generated.resources.chat_voice_permission_settings
+import trendingai.chat.generated.resources.chat_voice_permission_title
+import trendingai.chat.generated.resources.chat_voice_pro_message
+import trendingai.chat.generated.resources.chat_voice_pro_title
+import trendingai.chat.generated.resources.chat_voice_release_cancel
+import trendingai.chat.generated.resources.chat_voice_release_send
+import trendingai.chat.generated.resources.chat_voice_transcribing
 import trendingai.chat.generated.resources.chat_user_image
 import trendingai.chat.generated.resources.chat_web_search
 
@@ -88,6 +110,15 @@ import trendingai.chat.generated.resources.chat_web_search
  *
  * 图片理解仅对登录用户开放：未登录点「+」弹登录引导（服务端另有 403 真闸）。
  * 选图走系统契约（Photo Picker / TakePicture），Android 13+ 全程零运行时权限。
+ *
+ * 语音录入：输入框为空时右侧主按钮是麦克风（有文字即变回发送键，不加第三个图标）。
+ * 按住说话、松手即发、上滑取消；转写成文本后直接发送，不经输入框。仅 Pro 可用，
+ * 非 Pro 按下弹纯告知弹窗（与锁定模型同一处理，不外跳）。
+ *
+ * @param voiceEnabled 宿主是否注入了转写能力；false 时永远显示发送键
+ * @param isTranscribing 转写在途：麦克风位显示 loading，输入框占位改为「正在识别」
+ * @param onVoiceRecorded 一段合格的录音就绪（松手或触顶）
+ * @param onVoiceOutcome 转写前就结束的语音结果（取消 / 太短 / 权限 / Pro 闸），供埋点
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -103,6 +134,11 @@ fun ChatInputBar(
     searchActive: Boolean = false,
     onToggleSearch: () -> Unit = {},
     autoFocus: Boolean = false,
+    voiceEnabled: Boolean = false,
+    isTranscribing: Boolean = false,
+    voiceMaxDurationMs: Int = 60_000,
+    onVoiceRecorded: (VoiceRecording) -> Unit = {},
+    onVoiceOutcome: (ChatVoiceOutcome, Long?) -> Unit = { _, _ -> },
 ) {
     // 进入页面自动聚焦输入框，键盘随焦点自动弹出（官方做法：focusRequester + 在组合外 requestFocus）
     val inputFocusRequester = remember { FocusRequester() }
@@ -123,6 +159,61 @@ fun ChatInputBar(
         onProcessingChange = { processingCount += it },
         onImageReady = onAddImage,
     )
+
+    val isPro by chatHost.isPro.collectAsState(chatHost.currentIsPro())
+    var showProDialog by remember { mutableStateOf(false) }
+    var showPermissionDialog by remember { mutableStateOf(false) }
+    // 录音中：startedAt > 0；inCancelZone 随手指上滑切换
+    var recordingStartedAt by remember { mutableLongStateOf(0L) }
+    var inCancelZone by remember { mutableStateOf(false) }
+    val recorder = rememberChatVoiceRecorder(
+        maxDurationMs = voiceMaxDurationMs,
+        minDurationMs = MIN_VOICE_DURATION_MS,
+        onAutoStop = { recording ->
+            // 手指仍按着：先收掉录音态，后续抬手在手势里被 startedAt==0 挡掉
+            recordingStartedAt = 0L
+            onVoiceRecorded(recording)
+        },
+        onPermissionDenied = {
+            showPermissionDialog = true
+            onVoiceOutcome(ChatVoiceOutcome.PERMISSION_DENIED, null)
+        },
+    )
+    val showMic = voiceEnabled && recorder.isAvailable && input.isBlank() && pendingImages.isEmpty()
+    val haptic = LocalHapticFeedback.current
+
+    if (showProDialog) {
+        AlertDialog(
+            onDismissRequest = { showProDialog = false },
+            title = { Text(stringResource(Res.string.chat_voice_pro_title)) },
+            text = { Text(stringResource(Res.string.chat_voice_pro_message)) },
+            confirmButton = {
+                TextButton(onClick = { showProDialog = false }) {
+                    Text(stringResource(Res.string.chat_model_unlock_dismiss))
+                }
+            },
+        )
+    }
+    if (showPermissionDialog) {
+        AlertDialog(
+            onDismissRequest = { showPermissionDialog = false },
+            title = { Text(stringResource(Res.string.chat_voice_permission_title)) },
+            text = { Text(stringResource(Res.string.chat_voice_permission_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showPermissionDialog = false
+                    recorder.openPermissionSettings()
+                }) {
+                    Text(stringResource(Res.string.chat_voice_permission_settings))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showPermissionDialog = false }) {
+                    Text(stringResource(Res.string.chat_image_login_dismiss))
+                }
+            },
+        )
+    }
 
     if (showLoginDialog) {
         AlertDialog(
@@ -174,6 +265,13 @@ fun ChatInputBar(
                 modifier = Modifier.padding(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                if (recordingStartedAt > 0L) {
+                    RecordingStatus(
+                        startedAt = recordingStartedAt,
+                        inCancelZone = inCancelZone,
+                        modifier = Modifier.weight(1f).padding(horizontal = 16.dp),
+                    )
+                } else {
                 // + 菜单常开：搜索 toggle 对匿名可用；图片两项在点击时才做登录闸
                 run {
                     Box {
@@ -241,7 +339,14 @@ fun ChatInputBar(
                     onValueChange = onInputChange,
                     // focusRequester 必须声明在可聚焦项之前才会关联（官方文档「焦点修饰符的优先级」）
                     modifier = Modifier.focusRequester(inputFocusRequester).weight(1f),
-                    placeholder = { Text(stringResource(Res.string.chat_input_hint)) },
+                    enabled = !isTranscribing,
+                    placeholder = {
+                        Text(
+                            stringResource(
+                                if (isTranscribing) Res.string.chat_voice_transcribing else Res.string.chat_input_hint,
+                            ),
+                        )
+                    },
                     textStyle = MaterialTheme.typography.bodyLarge,
                     // 容器与指示线全部透明：外层胶囊已经是这块区域的视觉容器，
                     // 再叠一层 TextField 自己的底色/下划线就成了「框中框」
@@ -255,6 +360,54 @@ fun ChatInputBar(
                     ),
                     maxLines = 5,
                 )
+                }
+                if (showMic || recordingStartedAt > 0L) {
+                    val cancelThresholdPx = with(LocalDensity.current) { CANCEL_SLIDE_THRESHOLD.toPx() }
+                    // 按住/上滑/抬手自行处理：FilledIconButton 的 onClick 表达不了「按下开始、抬手结束」
+                    MicButton(
+                        active = recordingStartedAt > 0L,
+                        cancelZone = inCancelZone,
+                        loading = isTranscribing,
+                        modifier = Modifier.pointerInput(isPro, isTranscribing) {
+                            awaitEachGesture {
+                                val down = awaitFirstDown()
+                                down.consume()
+                                if (isTranscribing) return@awaitEachGesture
+                                if (!isPro) {
+                                    showProDialog = true
+                                    onVoiceOutcome(ChatVoiceOutcome.PRO_GATE, null)
+                                    return@awaitEachGesture
+                                }
+                                if (!recorder.start()) return@awaitEachGesture
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                recordingStartedAt = epochNow()
+                                inCancelZone = false
+                                while (true) {
+                                    val event = awaitPointerEvent()
+                                    val change = event.changes.firstOrNull { it.id == down.id }
+                                    if (change == null || !change.pressed) {
+                                        // 触顶自动停止已取件时 startedAt 归零，这里的抬手不再重复取件
+                                        if (recordingStartedAt > 0L) {
+                                            val elapsed = epochNow() - recordingStartedAt
+                                            recordingStartedAt = 0L
+                                            if (change == null || inCancelZone) {
+                                                recorder.cancel()
+                                                onVoiceOutcome(ChatVoiceOutcome.CANCELLED, elapsed)
+                                            } else {
+                                                val recording = recorder.stop()
+                                                if (recording != null) onVoiceRecorded(recording)
+                                                else onVoiceOutcome(ChatVoiceOutcome.TOO_SHORT, elapsed)
+                                            }
+                                        }
+                                        break
+                                    }
+                                    inCancelZone = change.position.y < -cancelThresholdPx
+                                    change.consume()
+                                }
+                            }
+                        },
+                    )
+                } else {
                 FilledIconButton(
                     onClick = onSend,
                     enabled = canSend,
@@ -272,8 +425,85 @@ fun ChatInputBar(
                         modifier = Modifier.size(20.dp),
                     )
                 }
+                }
             }
         }
+    }
+}
+
+private const val MIN_VOICE_DURATION_MS = 1_000
+private val CANCEL_SLIDE_THRESHOLD = 80.dp
+
+private fun epochNow(): Long = whl.trending.chat.core.epochMillis()
+
+/** 麦克风主按钮：与发送键同位同尺寸；录音中放大一档、进入取消区换 error 色。 */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun MicButton(
+    active: Boolean,
+    cancelZone: Boolean,
+    loading: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val container = when {
+        active && cancelZone -> MaterialTheme.colorScheme.error
+        active -> MaterialTheme.colorScheme.primary
+        loading -> MaterialTheme.colorScheme.surfaceContainerHighest
+        else -> MaterialTheme.colorScheme.primary
+    }
+    val content = when {
+        active && cancelZone -> MaterialTheme.colorScheme.onError
+        loading -> MaterialTheme.colorScheme.onSurfaceVariant
+        else -> MaterialTheme.colorScheme.onPrimary
+    }
+    Surface(
+        shape = CircleShape,
+        color = container,
+        contentColor = content,
+        modifier = modifier.size(if (active) 56.dp else 48.dp),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            if (loading) {
+                LoadingIndicator(modifier = Modifier.size(24.dp))
+            } else {
+                Icon(
+                    imageVector = Icons.Default.Mic,
+                    contentDescription = stringResource(Res.string.chat_voice_mic),
+                    modifier = Modifier.size(if (active) 24.dp else 20.dp),
+                )
+            }
+        }
+    }
+}
+
+/** 录音中占据输入区的状态：计时 + 操作提示（进入取消区时换文案）。 */
+@Composable
+private fun RecordingStatus(
+    startedAt: Long,
+    inCancelZone: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    var elapsedMs by remember { mutableLongStateOf(0L) }
+    LaunchedEffect(startedAt) {
+        while (true) {
+            elapsedMs = epochNow() - startedAt
+            delay(200)
+        }
+    }
+    val seconds = elapsedMs / 1000
+    Column(modifier = modifier) {
+        Text(
+            text = "${seconds / 60}:${(seconds % 60).toString().padStart(2, '0')}",
+            style = MaterialTheme.typography.titleMedium,
+            color = if (inCancelZone) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = stringResource(
+                if (inCancelZone) Res.string.chat_voice_release_cancel else Res.string.chat_voice_release_send,
+            ),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -171,7 +171,7 @@ fun ChatScreen(
                             suggestions.forEach { suggestion ->
                                 OutlinedButton(
                                     onClick = { viewModel.sendText(suggestion.prompt) },
-                                    enabled = !state.isSending,
+                                    enabled = !state.isBusy,
                                 ) {
                                     Text(suggestion.label)
                                 }

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -41,8 +41,14 @@ import trendingai.chat.generated.resources.Res
 import trendingai.chat.generated.resources.chat_assistant_title
 import trendingai.chat.generated.resources.chat_back
 import trendingai.chat.generated.resources.chat_history
+import whl.trending.chat.VoiceNotice
 import whl.trending.chat.engine.ChatApi
 import whl.trending.chat.engine.ChatEngine
+import whl.trending.chat.engine.VoiceTranscriber
+import whl.trending.chat.host.chatHost
+import trendingai.chat.generated.resources.chat_voice_empty
+import trendingai.chat.generated.resources.chat_voice_failed
+import trendingai.chat.generated.resources.chat_voice_pro_message
 import whl.trending.chat.store.InMemoryChatStore
 import whl.trending.chat.store.rememberDefaultChatStore
 
@@ -64,12 +70,28 @@ fun ChatScreen(
     initialMessages: List<whl.trending.chat.model.ChatMessage> = emptyList(),
     persistent: Boolean = true,
     suggestions: List<ChatSuggestion> = emptyList(),
+    transcriber: VoiceTranscriber? = ChatApi.sharedTranscriber,
 ) {
     val store = if (persistent) rememberDefaultChatStore() else remember { InMemoryChatStore() }
     val viewModel: ChatViewModel = viewModel(key = "chat") {
-        ChatViewModel(engine, initialMessages, store)
+        ChatViewModel(engine, initialMessages, store, transcriber = transcriber)
     }
     val state by viewModel.uiState.collectAsState()
+    val showNotice = rememberShowNotice()
+    val voiceEmptyText = stringResource(Res.string.chat_voice_empty)
+    val voiceFailedText = stringResource(Res.string.chat_voice_failed)
+    val voiceProText = stringResource(Res.string.chat_voice_pro_message)
+    LaunchedEffect(viewModel) {
+        viewModel.voiceNotices.collect { notice ->
+            showNotice(
+                when (notice) {
+                    VoiceNotice.EMPTY -> voiceEmptyText
+                    VoiceNotice.FAILED -> voiceFailedText
+                    VoiceNotice.PRO_REQUIRED -> voiceProText
+                },
+            )
+        }
+    }
     val threads by viewModel.threads.collectAsState()
     val currentThreadId by viewModel.currentThreadId.collectAsState()
 
@@ -174,6 +196,11 @@ fun ChatScreen(
                         onAddImage = viewModel::addPendingImage,
                         onRemoveImage = viewModel::removePendingImage,
                         autoFocus = true,
+                        voiceEnabled = viewModel.voiceAvailable,
+                        isTranscribing = state.isTranscribing,
+                        voiceMaxDurationMs = chatHost.voiceMaxDurationMs(),
+                        onVoiceRecorded = viewModel::sendVoice,
+                        onVoiceOutcome = viewModel::reportVoiceOutcome,
                     )
                 }
             },

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ShowNotice.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ShowNotice.kt
@@ -1,0 +1,7 @@
+package whl.trending.chat.ui
+
+import androidx.compose.runtime.Composable
+
+/** 轻量即时提示（Android Toast 形态），用于不值得打断的失败反馈。 */
+@Composable
+internal expect fun rememberShowNotice(): (String) -> Unit

--- a/chat/src/iosMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.ios.kt
+++ b/chat/src/iosMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.ios.kt
@@ -127,7 +127,9 @@ private class IosVoiceRecorder(
     override fun stop(): VoiceRecording? {
         val rec = recorder ?: return null
         val target = path
-        val durationMs = epochMillis() - startedAt
+        // 取录音器自己计的秒数而非墙钟：音频会话激活到真正开录之间有延迟（模拟器可达数秒），
+        // 墙钟从 start() 返回起算会把有效时长算短，与文件里的音频对不上
+        val durationMs = (rec.currentTime * 1000).toLong().takeIf { it > 0 } ?: (epochMillis() - startedAt)
         release(rec)
         val size = target?.let { runCatching { FileSystem.SYSTEM.metadata(it.toPath()).size ?: 0L }.getOrDefault(0L) } ?: 0L
         if (target == null || durationMs < minDurationMs || size == 0L) {

--- a/chat/src/iosMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.ios.kt
+++ b/chat/src/iosMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.ios.kt
@@ -1,21 +1,168 @@
 package whl.trending.chat.attach
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import kotlinx.cinterop.ExperimentalForeignApi
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import okio.SYSTEM
+import platform.AVFAudio.AVAudioApplication
+import platform.AVFAudio.AVAudioApplicationRecordPermissionDenied
+import platform.AVFAudio.AVAudioApplicationRecordPermissionGranted
+import platform.AVFAudio.AVAudioRecorder
+import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionCategoryRecord
+import platform.AVFAudio.AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
+import platform.AVFAudio.AVEncoderBitRateKey
+import platform.AVFAudio.AVFormatIDKey
+import platform.AVFAudio.AVNumberOfChannelsKey
+import platform.AVFAudio.AVSampleRateKey
+import platform.AVFAudio.setActive
+import platform.CoreAudioTypes.kAudioFormatMPEG4AAC
+import platform.Foundation.NSCachesDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSTimer
+import platform.Foundation.NSURL
+import platform.Foundation.NSUserDomainMask
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationOpenSettingsURLString
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import whl.trending.chat.core.epochMillis
+import whl.trending.chat.core.logWarn
 
-/** iOS 录音尚未实现：isAvailable=false，麦克风入口不渲染。 */
+private const val TAG = "ChatVoiceRecorder"
+private const val DIR = "chat_voice"
+
+/**
+ * iOS 实现：AVAudioRecorder 直出 AAC m4a，规格对齐 Android 侧（单声道 16kHz 32kbps）。
+ * 权限走 AVAudioApplication（iOS 17+，部署目标 18.2），首次按下发起申请、再按一次才开始录。
+ * 录音期间把 AVAudioSession 切到 record 类别，取件/取消后立即释放，不影响其他 app 的播放。
+ */
 @Composable
 actual fun rememberChatVoiceRecorder(
     maxDurationMs: Int,
     minDurationMs: Int,
     onAutoStop: (VoiceRecording) -> Unit,
     onPermissionDenied: () -> Unit,
-): ChatVoiceRecorder = remember {
-    object : ChatVoiceRecorder {
-        override val isAvailable = false
-        override fun start() = VoiceStart.FAILED
-        override fun stop(): VoiceRecording? = null
-        override fun cancel() {}
-        override fun openPermissionSettings() {}
+): ChatVoiceRecorder {
+    val currentAutoStop by rememberUpdatedState(onAutoStop)
+    val currentDenied by rememberUpdatedState(onPermissionDenied)
+    return remember(maxDurationMs, minDurationMs) {
+        IosVoiceRecorder(
+            maxDurationMs = maxDurationMs,
+            minDurationMs = minDurationMs,
+            onAutoStop = { currentAutoStop(it) },
+            onPermissionDenied = { currentDenied() },
+        )
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalUuidApi::class)
+private class IosVoiceRecorder(
+    private val maxDurationMs: Int,
+    private val minDurationMs: Int,
+    private val onAutoStop: (VoiceRecording) -> Unit,
+    private val onPermissionDenied: () -> Unit,
+) : ChatVoiceRecorder {
+
+    private var recorder: AVAudioRecorder? = null
+    private var path: String? = null
+    private var startedAt = 0L
+    private var autoStopTimer: NSTimer? = null
+
+    override val isAvailable = true
+
+    override fun start(): VoiceStart {
+        if (recorder != null) return VoiceStart.FAILED
+        when (AVAudioApplication.sharedInstance.recordPermission) {
+            AVAudioApplicationRecordPermissionGranted -> Unit
+            AVAudioApplicationRecordPermissionDenied -> {
+                onPermissionDenied()
+                return VoiceStart.PERMISSION_PENDING
+            }
+            else -> {
+                AVAudioApplication.requestRecordPermissionWithCompletionHandler { granted ->
+                    if (!granted) dispatch_async(dispatch_get_main_queue()) { onPermissionDenied() }
+                }
+                return VoiceStart.PERMISSION_PENDING
+            }
+        }
+
+        val session = AVAudioSession.sharedInstance()
+        if (!session.setCategory(AVAudioSessionCategoryRecord, error = null) || !session.setActive(true, error = null)) {
+            logWarn(TAG, "audio session activation failed")
+            return VoiceStart.FAILED
+        }
+        val dir = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, true)
+            .first() as String + "/" + DIR
+        NSFileManager.defaultManager.createDirectoryAtPath(dir, true, null, null)
+        val target = "$dir/${Uuid.random()}.m4a"
+        val settings = mapOf<Any?, Any?>(
+            AVFormatIDKey to kAudioFormatMPEG4AAC,
+            AVSampleRateKey to 16_000.0,
+            AVNumberOfChannelsKey to 1,
+            AVEncoderBitRateKey to 32_000,
+        )
+        val rec = AVAudioRecorder(NSURL.fileURLWithPath(target), settings, null)
+        if (!rec.prepareToRecord() || !rec.record()) {
+            logWarn(TAG, "record start failed")
+            deactivateSession()
+            return VoiceStart.FAILED
+        }
+        recorder = rec
+        path = target
+        startedAt = epochMillis()
+        autoStopTimer = NSTimer.scheduledTimerWithTimeInterval(maxDurationMs / 1000.0, repeats = false) {
+            stop()?.let(onAutoStop)
+        }
+        return VoiceStart.STARTED
+    }
+
+    override fun stop(): VoiceRecording? {
+        val rec = recorder ?: return null
+        val target = path
+        val durationMs = epochMillis() - startedAt
+        release(rec)
+        val size = target?.let { runCatching { FileSystem.SYSTEM.metadata(it.toPath()).size ?: 0L }.getOrDefault(0L) } ?: 0L
+        if (target == null || durationMs < minDurationMs || size == 0L) {
+            target?.let { runCatching { FileSystem.SYSTEM.delete(it.toPath()) } }
+            return null
+        }
+        return VoiceRecording(target, durationMs)
+    }
+
+    override fun cancel() {
+        val rec = recorder ?: return
+        val target = path
+        release(rec)
+        target?.let { runCatching { FileSystem.SYSTEM.delete(it.toPath()) } }
+    }
+
+    override fun openPermissionSettings() {
+        val url = NSURL(string = UIApplicationOpenSettingsURLString)
+        UIApplication.sharedApplication.openURL(url, options = emptyMap<Any?, Any?>(), completionHandler = null)
+    }
+
+    private fun release(rec: AVAudioRecorder) {
+        autoStopTimer?.invalidate()
+        autoStopTimer = null
+        recorder = null
+        path = null
+        rec.stop()
+        deactivateSession()
+    }
+
+    private fun deactivateSession() {
+        AVAudioSession.sharedInstance().setActive(
+            false,
+            withOptions = AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation,
+            error = null,
+        )
     }
 }

--- a/chat/src/iosMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.ios.kt
+++ b/chat/src/iosMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.ios.kt
@@ -112,7 +112,9 @@ private class IosVoiceRecorder(
         val rec = AVAudioRecorder(NSURL.fileURLWithPath(target), settings, null)
         if (!rec.prepareToRecord() || !rec.record()) {
             logWarn(TAG, "record start failed")
+            rec.stop()
             deactivateSession()
+            runCatching { FileSystem.SYSTEM.delete(target.toPath()) }
             return VoiceStart.FAILED
         }
         recorder = rec

--- a/chat/src/iosMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.ios.kt
+++ b/chat/src/iosMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.ios.kt
@@ -1,0 +1,21 @@
+package whl.trending.chat.attach
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+/** iOS 录音尚未实现：isAvailable=false，麦克风入口不渲染。 */
+@Composable
+actual fun rememberChatVoiceRecorder(
+    maxDurationMs: Int,
+    minDurationMs: Int,
+    onAutoStop: (VoiceRecording) -> Unit,
+    onPermissionDenied: () -> Unit,
+): ChatVoiceRecorder = remember {
+    object : ChatVoiceRecorder {
+        override val isAvailable = false
+        override fun start() = false
+        override fun stop(): VoiceRecording? = null
+        override fun cancel() {}
+        override fun openPermissionSettings() {}
+    }
+}

--- a/chat/src/iosMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.ios.kt
+++ b/chat/src/iosMain/kotlin/whl/trending/chat/attach/ChatVoiceRecorder.ios.kt
@@ -13,7 +13,7 @@ actual fun rememberChatVoiceRecorder(
 ): ChatVoiceRecorder = remember {
     object : ChatVoiceRecorder {
         override val isAvailable = false
-        override fun start() = false
+        override fun start() = VoiceStart.FAILED
         override fun stop(): VoiceRecording? = null
         override fun cancel() {}
         override fun openPermissionSettings() {}

--- a/chat/src/iosMain/kotlin/whl/trending/chat/ui/ShowNotice.ios.kt
+++ b/chat/src/iosMain/kotlin/whl/trending/chat/ui/ShowNotice.ios.kt
@@ -1,0 +1,14 @@
+package whl.trending.chat.ui
+
+import androidx.compose.runtime.Composable
+import platform.UIKit.UIAlertAction
+import platform.UIKit.UIAlertActionStyleDefault
+import platform.UIKit.UIAlertController
+import platform.UIKit.UIAlertControllerStyleAlert
+
+@Composable
+internal actual fun rememberShowNotice(): (String) -> Unit = { text ->
+    val alert = UIAlertController.alertControllerWithTitle(null, text, UIAlertControllerStyleAlert)
+    alert.addAction(UIAlertAction.actionWithTitle("OK", UIAlertActionStyleDefault, null))
+    topViewController()?.presentViewController(alert, animated = true, completion = null)
+}

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Voice input for the AI assistant: hold the microphone to talk, release to send.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -339,6 +340,7 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Voice input for the AI assistant: hold the microphone to talk, release to send.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/shared/src/commonMain/kotlin/whl/trending/ai/chat/TrendingChatHost.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/chat/TrendingChatHost.kt
@@ -12,6 +12,7 @@ import whl.trending.ai.auth.globalAuthManager
 import whl.trending.ai.core.analytics.AiKind
 import whl.trending.ai.core.analytics.AiOutcome
 import whl.trending.ai.core.analytics.AppEvent
+import whl.trending.ai.core.analytics.VoiceInputOutcome
 import whl.trending.ai.core.analytics.track
 import whl.trending.ai.core.platform.getSystemLanguage
 import whl.trending.ai.data.local.globalSettingsManager
@@ -22,6 +23,7 @@ import whl.trending.ai.ui.profile.ProBadge
 import whl.trending.chat.host.ChatAiEvent
 import whl.trending.chat.host.ChatAiOutcome
 import whl.trending.chat.host.ChatHost
+import whl.trending.chat.host.ChatVoiceOutcome
 import whl.trending.chat.host.chatHost
 import whl.trending.chat.model.ChatModelsResponse
 
@@ -51,6 +53,7 @@ private object TrendingChatHost : ChatHost {
 
     override fun imagesMaxCount() = globalSettingsManager.chatImagesMaxCount()
     override fun imagesPerImageJpegKb() = globalSettingsManager.chatImagesPerImageJpegKb()
+    override fun voiceMaxDurationMs() = globalSettingsManager.chatVoiceMaxDurationMs()
     override fun installId() = globalSettingsManager.getOrCreateInstallId()
 
     /** 仅 app 语言为中文（或跟随系统且系统为中文）时用 zh，其余 en（与后端默认一致）。 */
@@ -83,6 +86,18 @@ private object TrendingChatHost : ChatHost {
                 durationMs = event.durationMs,
                 reason = event.reason,
                 tier = event.tier,
+            )
+            is ChatAiEvent.VoiceInput -> AppEvent.VoiceInput(
+                outcome = when (event.outcome) {
+                    ChatVoiceOutcome.SENT -> VoiceInputOutcome.SENT
+                    ChatVoiceOutcome.CANCELLED -> VoiceInputOutcome.CANCELLED
+                    ChatVoiceOutcome.TOO_SHORT -> VoiceInputOutcome.TOO_SHORT
+                    ChatVoiceOutcome.EMPTY -> VoiceInputOutcome.EMPTY
+                    ChatVoiceOutcome.ERROR -> VoiceInputOutcome.ERROR
+                    ChatVoiceOutcome.PERMISSION_DENIED -> VoiceInputOutcome.PERMISSION_DENIED
+                    ChatVoiceOutcome.PRO_GATE -> VoiceInputOutcome.PRO_GATE
+                },
+                durationMs = event.durationMs,
             )
         },
     )

--- a/shared/src/commonMain/kotlin/whl/trending/ai/core/analytics/AppEvent.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/core/analytics/AppEvent.kt
@@ -95,6 +95,10 @@ sealed class AppEvent(
         mapOf("kind" to kind, "from" to from, "image_count" to imageCount),
     )
 
+    /** 语音录入转写前的漏斗，一次按住恰好一条；转写成功后的发送另走 [AiRequested]（from = voice）。 */
+    data class VoiceInput(val outcome: VoiceInputOutcome, val durationMs: Long? = null) :
+        AppEvent("voice_input", mapOf("outcome" to outcome, "duration_ms" to durationMs))
+
     /** 与 [AiRequested] 成对，一次请求恰好一条：漏斗的分母分子都在这两个事件里。 */
     data class AiCompleted(
         val kind: AiKind,
@@ -259,6 +263,8 @@ enum class ListFilter {
 enum class AiKind { CHAT }
 
 enum class AiOutcome { OK, ERROR, INTERRUPTED }
+
+enum class VoiceInputOutcome { SENT, CANCELLED, TOO_SHORT, EMPTY, ERROR, PERMISSION_DENIED, PRO_GATE }
 
 enum class AuthAction { SIGN_IN, LINK }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -153,6 +153,7 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val MIN_VERSION_KEY = "prefs_min_version"
     private val CHAT_IMAGES_MAX_KEY = "prefs_chat_images_max"
     private val CHAT_IMAGES_PER_KB_KEY = "prefs_chat_images_per_kb"
+    private val CHAT_VOICE_MAX_MS_KEY = "prefs_chat_voice_max_ms"
     private val DAILY_PICKS_NOTIFICATION_KEY = "prefs_daily_picks_notification"
     private val PICKS_NEWSLETTER_BANNER_DISMISSED_KEY = "prefs_picks_newsletter_banner_dismissed"
     private val DEFAULT_HOME_TAB_KEY = "prefs_default_home_tab"
@@ -382,6 +383,14 @@ class SettingsManager(private val settings: ObservableSettings) {
     fun setChatImagesConfig(maxCount: Int?, perImageJpegKb: Int?) {
         if (maxCount != null) settings.putInt(CHAT_IMAGES_MAX_KEY, maxCount)
         if (perImageJpegKb != null) settings.putInt(CHAT_IMAGES_PER_KB_KEY, perImageJpegKb)
+    }
+
+    /** 单次语音录入时长上限（毫秒），服务端单源见后端 lib/chat-voice.js */
+    fun chatVoiceMaxDurationMs(): Int =
+        settings.getInt(CHAT_VOICE_MAX_MS_KEY, 60_000).takeIf { it > 0 } ?: 60_000
+
+    fun setChatVoiceConfig(maxDurationMs: Int?) {
+        if (maxDurationMs != null) settings.putInt(CHAT_VOICE_MAX_MS_KEY, maxDurationMs)
     }
 
     /** 最近一次看过更新说明的版本号；null 表示首次安装（从未记录） */

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/AppConfigResponse.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/AppConfigResponse.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.Serializable
 data class AppConfigResponse(
     @SerialName("min_version") val minVersion: String? = null,
     @SerialName("chat_images") val chatImages: ChatImagesRemoteConfig? = null,
+    @SerialName("chat_voice") val chatVoice: ChatVoiceRemoteConfig? = null,
 )
 
 /** chat 图片参数（服务端 KV 单源下发，与服务端校验闸同值；见后端 lib/chat-images.js） */
@@ -18,4 +19,10 @@ data class AppConfigResponse(
 data class ChatImagesRemoteConfig(
     @SerialName("max_count") val maxCount: Int? = null,
     @SerialName("per_image_jpeg_kb") val perImageJpegKb: Int? = null,
+)
+
+/** chat 语音录入参数（服务端 KV 单源下发，与服务端校验闸同值；见后端 lib/chat-voice.js） */
+@Serializable
+data class ChatVoiceRemoteConfig(
+    @SerialName("max_duration_ms") val maxDurationMs: Int? = null,
 )

--- a/shared/src/commonMain/kotlin/whl/trending/ai/update/AppConfigSync.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/update/AppConfigSync.kt
@@ -18,6 +18,7 @@ suspend fun refreshAppConfig(): AppConfigResponse? =
             config.chatImages?.maxCount,
             config.chatImages?.perImageJpegKb,
         )
+        globalSettingsManager.setChatVoiceConfig(config.chatVoice?.maxDurationMs)
         config
     } catch (e: CancellationException) {
         throw e


### PR DESCRIPTION
## 改动

两段式语音录入的客户端段（Android）。本地录 AAC m4a，上传 `/api/chat/transcribe` 拿回文本，再走现有发送路径；对话侧只见文本，消息模型与 Room 表不动，音频用后即删。

- 输入框为空时右侧主按钮为麦克风，有文字变回发送键；按住录音、上滑取消、不足 1 秒丢弃、触顶自动发送；转写在途输入区显示等待态
- 仅 Pro 可用：非 Pro 按下弹纯告知弹窗；服务端 403 真闸
- 录音时长上限经 `/api/app-config` 的 `chat_voice` 下发
- 麦克风权限声明在 chat 模块 manifest；被拒引导去系统设置
- 埋点：`voice_input` + `ai_requested from=voice`，词汇表已在 eventbase 仓先登记
- iOS 侧先放不可用的 actual（入口不渲染），编译通过，实现留待下一阶段

## 验证

- chat / shared hostTest 369 个全过（新增 5 个 ViewModel 语音用例）
- iOS 模拟器目标编译通过
- Pixel_9_2 模拟器（Pro 账号）实测：权限申请、录音态、上滑取消、过短丢弃、松手转写、空文本提示，五条路径事件与服务端账本（tier=pro / chat_voice / gpt-transcribe / 1 credit）均对上

方案：父仓 `ai-chat-语音录入-方案.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoGNuy7u3mTr41ioRrEKYr

## Sourcery 摘要

实现 Android 长按说话语音输入，将录音转换为文本，并通过现有的聊天体验提交。

新功能：
- 添加 Android 长按说话语音输入，录制 AAC 音频，通过聊天 API 转写，并将生成的文本通过现有聊天流程发送。
- 仅允许 Pro 用户使用语音输入，并处理麦克风权限、可配置的录音时长限制、取消手势和转写状态反馈。
- 添加语音输入分析事件，涵盖录音结果和由语音发起的 AI 请求。

增强功能：
- 音频仅临时保存，在转写完成或失败后将其删除，不更改聊天消息模型或持久化逻辑。
- 提供平台抽象，并在原生录音功能添加之前，为 iOS 提供不可用的实现。

测试：
- 添加 ViewModel 测试覆盖成功转写、空结果和失败结果、Pro 用户限制、阻止进行中的提交、清理操作以及不可用的转写器。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

启用 Android 长按语音输入功能，将录音转换为文本，并通过现有的聊天体验提交。

新功能：
- 添加 Android 长按语音输入功能，可录制音频、转写内容，并通过现有聊天流程发送生成的文本。
- 添加可配置的录音时长限制、取消手势、麦克风权限处理、仅限 Pro 用户访问检查以及转写反馈。
- 添加语音输入分析事件和语音发起的 AI 请求跟踪。

增强功能：
- 将语音音频保留为临时数据，不更改聊天消息模型和持久化逻辑。
- 引入跨平台语音录制抽象；在原生录音功能添加之前，iOS 实现暂不可用。

测试：
- 为成功、空内容、失败、受限、并发以及不可用的语音转写场景添加 ViewModel 覆盖测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

启用 Android 长按语音输入功能，该功能会转录录音内容，并通过聊天提交生成的文本。

新功能：
- 添加 Android 长按语音输入功能，可录制音频、转录内容，并通过现有聊天流程发送生成的文本。
- 将语音输入限制为 Pro 用户，并支持麦克风权限处理、取消手势、时长限制和转录反馈。

增强功能：
- 保持语音音频为临时数据，并保留现有的聊天消息和持久化模型。
- 引入多平台语音录音抽象；在添加原生录音功能之前，iOS 将提供不可用的实现。

测试：
- 为语音转录成功、内容为空、失败、未授权、并发以及不可用等场景添加 ViewModel 覆盖测试。

杂项：
- 添加语音输入分析，涵盖录音结果以及源自语音输入的 AI 请求。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

启用 Android 长按语音输入，将录音转换为文本，并通过现有聊天体验提交。

新功能：
- 添加 Android 长按语音输入功能，可录制音频、转写音频，并通过现有聊天流程发送生成的文本。
- 仅限 Pro 用户使用语音输入，并支持麦克风权限处理、取消手势、最短和可配置的最长录音时长，以及转写反馈。
- 添加语音输入分析，涵盖录音结果以及通过语音发起的 AI 请求。

错误修复：
- 在转写进行期间，阻止同时提交文本、重试或语音内容；切换或删除对话时取消待处理的转写任务。
- 确保在转写成功、结果为空、失败或取消后删除临时语音录音。

增强功能：
- 引入跨平台语音录制和转写抽象，同时保留 iOS 实现不可用的状态，直到添加原生录音支持。
- 通过应用设置公开服务器配置的语音录音时长限制。

测试：
- 添加 ViewModel 覆盖测试，涵盖转写成功、结果为空和失败、Pro 用户限制、阻止并发提交、取消、清理，以及转写器不可用等场景。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

启用 Android 长按语音输入，将录音转录为文本，并通过现有聊天体验发送。

新功能：
- 添加 Android 长按语音输入功能，可录制音频、将其转录为文本，并通过现有聊天流程提交生成的文本。

错误修复：
- 在转录期间阻止并发的文本、重试或语音提交；切换或删除对话时取消待处理的转录任务。
- 确保临时语音录音文件在转录成功、结果为空、失败或取消后都能被删除。

增强功能：
- 仅允许 Pro 用户使用语音输入，并支持麦克风权限处理、取消手势、最短和可配置的最长录音时长，以及转录反馈。
- 引入跨平台语音录制和转录抽象，同时在原生语音支持启用前保持 iOS 录音器不可用。
- 通过应用配置公开服务器配置的语音录制时长限制，并添加语音输入分析以及源自语音的 AI 请求跟踪。

测试：
- 为转录成功、结果为空和失败、Pro 用户限制、并发保护、取消、清理以及转录器不可用等场景添加 ViewModel 覆盖测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

启用 Android 长按说话语音输入功能，将录音转录为文本，并通过聊天发送生成的文本。

新功能：
- 添加 Android 按住说话语音输入功能，可录制音频、进行转录，并通过现有聊天流程提交生成的文本。

错误修复：
- 防止转录期间并发提交聊天请求；在切换或删除当前会话时取消待处理的转录任务；并在所有完成路径中清理临时录音。

增强功能：
- 仅限 Pro 用户使用语音输入，并处理麦克风权限、取消手势、最短时长和服务器可配置的最长时长，同时提供转录反馈。
- 引入跨平台录音和转录抽象，同时保留 iOS 录音器不可用的状态，等待原生语音支持。

测试：
- 为转录成功、结果为空或失败、Pro 用户限制、并发保护、取消操作、清理以及不可用的转录器添加 ViewModel 覆盖测试。

日常维护：
- 添加语音输入漏斗分析和语音发起的 AI 请求跟踪。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Android hold-to-talk voice input that transcribes recordings and sends the resulting text through chat.

New Features:
- Add Android press-and-hold voice input that records audio, transcribes it, and submits the resulting text through the existing chat flow.

Bug Fixes:
- Prevent concurrent chat submissions during transcription, cancel pending transcription when changing or deleting the active conversation, and clean up temporary recordings across all completion paths.

Enhancements:
- Restrict voice input to Pro users with microphone permission handling, cancellation gestures, minimum and server-configurable maximum durations, and transcription feedback.
- Introduce cross-platform recording and transcription abstractions while keeping the iOS recorder unavailable pending native voice support.

Tests:
- Add ViewModel coverage for transcription success, empty and failed results, Pro gating, concurrency protection, cancellation, cleanup, and unavailable transcribers.

Chores:
- Add voice-input funnel analytics and voice-originated AI request tracking.

</details>

</details>

</details>

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hold-to-talk voice input for chat on Android and iOS, including recording, cancellation gestures, automatic stop, and transcription.
  * Added microphone permission prompts, settings shortcuts, and feedback for empty, failed, and Pro-only requests.
  * Added configurable recording limits with localized English and Chinese text.
* **Analytics**
  * Added voice-input outcome tracking.
* **Tests**
  * Added coverage for successful, empty, failed, restricted, cancelled, and concurrent voice-input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->