### PR TITLE
feat(chat): 等待回复指示器加状态文案，等待期状态行收敛为一条

### DIFF
--- a/chat/src/commonMain/composeResources/values-zh/strings.xml
+++ b/chat/src/commonMain/composeResources/values-zh/strings.xml
@@ -56,6 +56,9 @@
     <!-- P2 联网搜索 -->
     <string name="chat_web_search">联网搜索</string>
     <string name="chat_searching">正在搜索网络…</string>
+    <string name="chat_waiting_processing">处理中…</string>
+    <string name="chat_waiting_thinking">思考中…</string>
+    <string name="chat_waiting_still_thinking">还在思考，请稍候…</string>
     <string name="chat_voice_mic">语音输入</string>
     <string name="chat_voice_release_send">松开发送 · 上滑取消</string>
     <string name="chat_voice_release_cancel">松开取消</string>

--- a/chat/src/commonMain/composeResources/values/strings.xml
+++ b/chat/src/commonMain/composeResources/values/strings.xml
@@ -59,6 +59,9 @@
     <!-- P2 联网搜索 -->
     <string name="chat_web_search">Web search</string>
     <string name="chat_searching">Searching the web…</string>
+    <string name="chat_waiting_processing">Processing…</string>
+    <string name="chat_waiting_thinking">Thinking…</string>
+    <string name="chat_waiting_still_thinking">Still thinking, hang tight…</string>
     <string name="chat_voice_mic">Voice input</string>
     <string name="chat_voice_release_send">Release to send · Slide up to cancel</string>
     <string name="chat_voice_release_cancel">Release to cancel</string>

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/MessageItem.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/MessageItem.kt
@@ -193,22 +193,24 @@ private fun AssistantMessage(
             if (message.sources.isNotEmpty()) {
                 SourcesRow(message.sources)
             }
-            Row {
-                CopyIconButton(
-                    text = message.content,
-                    modifier = Modifier.size(32.dp),
-                )
-                val share = rememberShareText()
-                IconButton(
-                    onClick = { share(message.content) },
-                    modifier = Modifier.size(32.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Share,
-                        contentDescription = stringResource(Res.string.chat_share),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(18.dp),
+            if (message.content.isNotBlank()) {
+                Row {
+                    CopyIconButton(
+                        text = message.content,
+                        modifier = Modifier.size(32.dp),
                     )
+                    val share = rememberShareText()
+                    IconButton(
+                        onClick = { share(message.content) },
+                        modifier = Modifier.size(32.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Share,
+                            contentDescription = stringResource(Res.string.chat_share),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
                 }
             }
         } else if (error.code == ChatError.CODE_QUOTA_DEVICE) {

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/MessageList.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/MessageList.kt
@@ -34,10 +34,11 @@ fun MessageList(
         if (messages.isNotEmpty()) listState.animateScrollToItem(0)
     }
 
-    // 流式占位一旦开始出字（或出错）就收起 typing 指示器，避免「正文下面还转圈」
+    // 任一时刻只有一条状态行：空占位由 typing 指示器顶替，搜索标签出现时指示器让位，
+    // 出字或出错后两者都收起
     val last = messages.lastOrNull()
-    val showTyping = isSending &&
-        (last == null || last.role == Role.USER || (last.content.isBlank() && last.error == null))
+    val showTyping = isSending && (last == null || last.role == Role.USER || last.isBlankPlaceholder)
+    val visible = if (last != null && last.isBlankPlaceholder) messages.dropLast(1) else messages
 
     LazyColumn(
         state = listState,
@@ -50,7 +51,7 @@ fun MessageList(
         if (showTyping) {
             item(key = "typing") { TypingIndicator() }
         }
-        items(messages.asReversed(), key = { it.id }) { message ->
+        items(visible.asReversed(), key = { it.id }) { message ->
             MessageItem(
                 message = message,
                 onRetry = { onRetry(message) },
@@ -58,3 +59,6 @@ fun MessageList(
         }
     }
 }
+
+private val ChatMessage.isBlankPlaceholder: Boolean
+    get() = role == Role.ASSISTANT && content.isBlank() && error == null && !searching

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/TypingIndicator.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/TypingIndicator.kt
@@ -12,14 +12,12 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,8 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.unit.dp
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
@@ -85,6 +82,7 @@ fun TypingIndicator(modifier: Modifier = Modifier) {
 @Composable
 private fun TypingDots() {
     val transition = rememberInfiniteTransition(label = "typing")
+    val dotColor = MaterialTheme.colorScheme.onSurfaceVariant
     Row {
         repeat(3) { index ->
             val alpha by transition.animateFloat(
@@ -106,9 +104,7 @@ private fun TypingDots() {
                 modifier = Modifier
                     .padding(end = 4.dp)
                     .size(8.dp)
-                    .alpha(alpha)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.onSurfaceVariant),
+                    .drawBehind { drawCircle(color = dotColor, alpha = alpha) },
             )
         }
     }

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/TypingIndicator.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/TypingIndicator.kt
@@ -1,29 +1,91 @@
 package whl.trending.chat.ui
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.StartOffset
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import org.jetbrains.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import trendingai.chat.generated.resources.Res
+import trendingai.chat.generated.resources.chat_waiting_processing
+import trendingai.chat.generated.resources.chat_waiting_still_thinking
+import trendingai.chat.generated.resources.chat_waiting_thinking
 
-/** 非流式等待回复时的「思考中」动画：三个交替闪烁的圆点。 */
+/** 等待文案按此间隔单向推进到下一句，走完后停在最后一句 */
+private val WAITING_PHRASE_STEP = 3.seconds
+
+private val waitingPhrases: List<StringResource> = listOf(
+    Res.string.chat_waiting_processing,
+    Res.string.chat_waiting_thinking,
+    Res.string.chat_waiting_still_thinking,
+)
+
+/** 首字到达前的等待指示：三个交替闪烁的圆点 + 随等待时长单向推进的文案。 */
 @Composable
 fun TypingIndicator(modifier: Modifier = Modifier) {
+    var phraseIndex by remember { mutableIntStateOf(0) }
+    LaunchedEffect(Unit) {
+        while (phraseIndex < waitingPhrases.lastIndex) {
+            delay(WAITING_PHRASE_STEP)
+            phraseIndex++
+        }
+    }
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        TypingDots()
+        Spacer(Modifier.width(6.dp))
+        AnimatedContent(
+            targetState = phraseIndex,
+            transitionSpec = {
+                (fadeIn(tween(200, delayMillis = 150)) + slideInVertically(tween(200, delayMillis = 150)) { it / 3 })
+                    .togetherWith(fadeOut(tween(150)))
+            },
+            label = "waitingPhrase",
+        ) { index ->
+            Text(
+                text = stringResource(waitingPhrases[index]),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TypingDots() {
     val transition = rememberInfiniteTransition(label = "typing")
-    Row(modifier = modifier) {
+    Row {
         repeat(3) { index ->
             val alpha by transition.animateFloat(
                 initialValue = 0.3f,
@@ -36,11 +98,11 @@ fun TypingIndicator(modifier: Modifier = Modifier) {
                         0.3f at 600
                     },
                     repeatMode = RepeatMode.Restart,
-                    initialStartOffset = androidx.compose.animation.core.StartOffset(index * 150),
+                    initialStartOffset = StartOffset(index * 150),
                 ),
                 label = "dot$index",
             )
-            androidx.compose.foundation.layout.Box(
+            Box(
                 modifier = Modifier
                     .padding(end = 4.dp)
                     .size(8.dp)


### PR DESCRIPTION
## 背景

AI 对话首字到达前只有三个闪烁圆点，等得久了没有任何反馈。参照第三方对话 App 的做法，给圆点加一句随等待时长推进的状态文案，并顺手收掉等待期的两处视觉重叠。

实测生产接口首字通常 2～3 秒到达，多数请求只会看到第一句；后两句只在慢网络、带图、联网搜索等场景兜底。纯客户端定时器，不动引擎与服务端。

## 改动

- **等待文案**（`TypingIndicator.kt`）：圆点右侧加文案，每 3 秒单向推进「处理中… → 思考中… → 还在思考，请稍候…」，走到最后一句停住不循环，避免反复切换暗示假进展；切换为先淡出再淡入。中英文案进 chat 模块 strings.xml。
- **圆点绘制**（同文件）：alpha 原先在组合阶段读取，动画每帧重组并重建修饰符链，且每个圆点挂两层 graphicsLayer；改为 `drawBehind` 里读 alpha 直接画圆，帧更新只重绘。
- **状态行收敛**（`MessageList.kt` / `MessageItem.kt`）：空占位消息此前无条件画复制/分享行，首字之前就出现能点的空按钮；开联网搜索时占位里的「正在搜索网络」与底部等待指示器同时在屏。改为操作行只在内容非空时画；空占位不渲染、由等待指示器顶替；搜索标签出现时指示器让位，搜索结束仍未出字则指示器回来。

## 验证

- `:chat` Android / iOS 模拟器目标编译通过
- Pixel_9_2 模拟器加 2.5 秒网络延迟录屏核对：普通发送三句依次推进到出字；开联网搜索时状态行为「处理中 → 思考中 → 正在搜索网络 → 处理中 → 正文」，逐帧核对任一时刻只有一条状态行

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En3yZzmcQo5t4gsa3sYzBP

## Sourcery 总结

通过渐进式等待文本和统一协调的状态行，改善响应前的聊天反馈。

新功能：
- 添加本地化的等待状态文本，依次从“处理中”变为“思考中”，然后在等待首个响应令牌期间保持显示最终的安抚性消息。

错误修复：
- 防止空的助手占位符显示不可用的复制/分享操作，并消除等待状态行与网页搜索状态行重叠的问题。

改进：
- 优化输入指示点的渲染，使动画更新能够触发重绘，而无需在每一帧重新构建修饰符链。
- 确保等待指示器在适当时让位于网页搜索状态，并仅在响应内容出现前的适当时机恢复显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve pre-response chat feedback with progressive waiting text and a single, coordinated status row.

New Features:
- Add localized waiting-status text that progresses from processing to thinking and then remains on a final reassurance message while awaiting the first response token.

Bug Fixes:
- Prevent empty assistant placeholders from displaying unusable copy/share actions and eliminate overlapping waiting and web-search status rows.

Enhancements:
- Optimize typing-dot rendering so animation updates trigger redraws without rebuilding modifier chains each frame.
- Ensure the waiting indicator yields to web-search status and returns only when appropriate before response content appears.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an animated typing indicator with blinking dots and rotating waiting messages.
  * Added localized waiting-status text in English and Chinese.

* **Bug Fixes**
  * Copy and share actions are now hidden for empty assistant messages.
  * Improved chat rendering to prevent duplicate waiting-status lines while searching or generating a response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->