### PR TITLE
feat(chat): 模型目录多厂商——按厂商分段、能力位置灰入口、出处文案按目录拼

### DIFF
--- a/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelCapsTest.kt
+++ b/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelCapsTest.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import whl.trending.chat.engine.ChatEngine
+import whl.trending.chat.host.chatHost
+import whl.trending.chat.sample.DemoChatHost
 import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.ChatModelCaps
 import whl.trending.chat.model.ChatModelOption
@@ -28,7 +30,11 @@ class ChatViewModelCapsTest {
     private val dispatcher = StandardTestDispatcher()
 
     @BeforeTest
-    fun setUp() = Dispatchers.setMain(dispatcher)
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        // addPendingImage 读宿主的图片上限；用 Demo 宿主装上，模型选择流仍由构造参数注入
+        chatHost = DemoChatHost
+    }
 
     @AfterTest
     fun tearDown() = Dispatchers.resetMain()
@@ -80,6 +86,26 @@ class ChatViewModelCapsTest {
         assertFalse(viewModel.searchEnabled.value)
         viewModel.toggleWebSearch()
         assertFalse(viewModel.searchEnabled.value)
+    }
+
+    @Test
+    fun `切到不接受图片的模型：待发图片清空，且此后新增被忽略`() = runTest(dispatcher) {
+        val choice = MutableStateFlow(FOLLOW_SERVER_DEFAULT)
+        val viewModel = vm(choice)
+        advanceUntilIdle()
+        viewModel.addPendingImage("/cache/a.jpg")
+        assertEquals(listOf("/cache/a.jpg"), viewModel.uiState.value.pendingImages)
+
+        choice.value = deepseek.id
+        advanceUntilIdle()
+        assertTrue(viewModel.uiState.value.pendingImages.isEmpty())
+        viewModel.addPendingImage("/cache/b.jpg") // 异步选图在切换后才返回
+        assertTrue(viewModel.uiState.value.pendingImages.isEmpty())
+
+        choice.value = FOLLOW_SERVER_DEFAULT
+        advanceUntilIdle()
+        viewModel.addPendingImage("/cache/c.jpg")
+        assertEquals(listOf("/cache/c.jpg"), viewModel.uiState.value.pendingImages)
     }
 
     @Test

--- a/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelCapsTest.kt
+++ b/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelCapsTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -15,8 +16,6 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import whl.trending.chat.engine.ChatEngine
-import whl.trending.chat.host.chatHost
-import whl.trending.chat.sample.DemoChatHost
 import whl.trending.chat.model.ChatMessage
 import whl.trending.chat.model.ChatModelCaps
 import whl.trending.chat.model.ChatModelOption
@@ -30,11 +29,7 @@ class ChatViewModelCapsTest {
     private val dispatcher = StandardTestDispatcher()
 
     @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(dispatcher)
-        // addPendingImage 读宿主的图片上限；用 Demo 宿主装上，模型选择流仍由构造参数注入
-        chatHost = DemoChatHost
-    }
+    fun setUp() = Dispatchers.setMain(dispatcher)
 
     @AfterTest
     fun tearDown() = Dispatchers.resetMain()
@@ -89,28 +84,11 @@ class ChatViewModelCapsTest {
     }
 
     @Test
-    fun `切到不接受图片的模型：待发图片清空，且此后新增被忽略`() = runTest(dispatcher) {
-        val choice = MutableStateFlow(FOLLOW_SERVER_DEFAULT)
-        val viewModel = vm(choice)
-        advanceUntilIdle()
-        viewModel.addPendingImage("/cache/a.jpg")
-        assertEquals(listOf("/cache/a.jpg"), viewModel.uiState.value.pendingImages)
-
-        choice.value = deepseek.id
-        advanceUntilIdle()
-        assertTrue(viewModel.uiState.value.pendingImages.isEmpty())
-        viewModel.addPendingImage("/cache/b.jpg") // 异步选图在切换后才返回
-        assertTrue(viewModel.uiState.value.pendingImages.isEmpty())
-
-        choice.value = FOLLOW_SERVER_DEFAULT
-        advanceUntilIdle()
-        viewModel.addPendingImage("/cache/c.jpg")
-        assertEquals(listOf("/cache/c.jpg"), viewModel.uiState.value.pendingImages)
-    }
-
-    @Test
-    fun `无宿主（选择流缺席）时能力位保持全开`() = runTest(dispatcher) {
-        val viewModel = ChatViewModel(NoopEngine, loadModels = { catalog }, track = {})
+    fun `选择流抛错（无宿主）时能力位保持全开`() = runTest(dispatcher) {
+        val viewModel = ChatViewModel(
+            NoopEngine, loadModels = { catalog }, track = {},
+            modelSelection = { flow { error("chatHost not installed") } },
+        )
         advanceUntilIdle()
         assertEquals(ChatModelCaps(true, true), viewModel.currentCaps.value)
     }

--- a/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelCapsTest.kt
+++ b/chat/src/androidHostTest/kotlin/whl/trending/chat/ChatViewModelCapsTest.kt
@@ -1,0 +1,91 @@
+package whl.trending.chat
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import whl.trending.chat.engine.ChatEngine
+import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.ChatModelCaps
+import whl.trending.chat.model.ChatModelOption
+import whl.trending.chat.model.ChatModelsResponse
+import whl.trending.chat.model.FOLLOW_SERVER_DEFAULT
+import whl.trending.chat.model.SearchEvent
+
+/** 能力位驱动的入口显隐：切到不支持搜索的模型时搜索开关收回、且不可再开。 */
+class ChatViewModelCapsTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @AfterTest
+    fun tearDown() = Dispatchers.resetMain()
+
+    private object NoopEngine : ChatEngine {
+        override suspend fun send(
+            history: List<ChatMessage>,
+            onDelta: (String) -> Unit,
+            search: Boolean,
+            onSearch: (SearchEvent) -> Unit,
+        ): String = ""
+    }
+
+    private val openai = ChatModelOption(id = "gpt-5.6-luna", name = "GPT-5.6 Luna")
+    private val deepseek = ChatModelOption(
+        id = "deepseek-v4-flash", name = "DeepSeek V4 Flash",
+        provider = "deepseek", providerName = "DeepSeek",
+        caps = ChatModelCaps(images = false, search = false),
+    )
+    private val catalog = ChatModelsResponse(models = listOf(openai, deepseek), default = openai.id)
+
+    private fun vm(choice: MutableStateFlow<String>) = ChatViewModel(
+        NoopEngine,
+        loadModels = { catalog },
+        track = {},
+        modelSelection = { choice.map { it to false } },
+    )
+
+    @Test
+    fun `默认模型全能力：搜索可开`() = runTest(dispatcher) {
+        val viewModel = vm(MutableStateFlow(FOLLOW_SERVER_DEFAULT))
+        advanceUntilIdle()
+        assertEquals(ChatModelCaps(true, true), viewModel.currentCaps.value)
+        viewModel.toggleWebSearch()
+        assertTrue(viewModel.searchEnabled.value)
+    }
+
+    @Test
+    fun `切到不支持搜索的模型：已开的搜索收回，且不可再开`() = runTest(dispatcher) {
+        val choice = MutableStateFlow(FOLLOW_SERVER_DEFAULT)
+        val viewModel = vm(choice)
+        advanceUntilIdle()
+        viewModel.toggleWebSearch()
+        assertTrue(viewModel.searchEnabled.value)
+
+        choice.value = deepseek.id
+        advanceUntilIdle()
+        assertEquals(ChatModelCaps(false, false), viewModel.currentCaps.value)
+        assertFalse(viewModel.searchEnabled.value)
+        viewModel.toggleWebSearch()
+        assertFalse(viewModel.searchEnabled.value)
+    }
+
+    @Test
+    fun `无宿主（选择流缺席）时能力位保持全开`() = runTest(dispatcher) {
+        val viewModel = ChatViewModel(NoopEngine, loadModels = { catalog }, track = {})
+        advanceUntilIdle()
+        assertEquals(ChatModelCaps(true, true), viewModel.currentCaps.value)
+    }
+}

--- a/chat/src/commonMain/composeResources/values-zh/strings.xml
+++ b/chat/src/commonMain/composeResources/values-zh/strings.xml
@@ -24,6 +24,10 @@
     <string name="chat_model_unlock_title">Pro 专属模型</string>
     <string name="chat_model_unlock_message">「%1$s」目前仅对 Pro 开放，可继续使用默认模型。</string>
     <string name="chat_model_unlock_dismiss">知道了</string>
+    <string name="chat_model_switch_discard_title">切换到「%1$s」？</string>
+    <string name="chat_model_switch_discard_message">该模型不支持图片，已选的 %1$d 张图片将被移除。</string>
+    <string name="chat_model_switch_discard_confirm">切换</string>
+    <string name="chat_model_switch_discard_cancel">取消</string>
     <string name="chat_model_provider">模型由 %1$s 的 API 提供</string>
     <string name="chat_cap_unsupported">当前模型不支持</string>
     <string name="chat_list_separator">、</string>

--- a/chat/src/commonMain/composeResources/values-zh/strings.xml
+++ b/chat/src/commonMain/composeResources/values-zh/strings.xml
@@ -24,10 +24,6 @@
     <string name="chat_model_unlock_title">Pro 专属模型</string>
     <string name="chat_model_unlock_message">「%1$s」目前仅对 Pro 开放，可继续使用默认模型。</string>
     <string name="chat_model_unlock_dismiss">知道了</string>
-    <string name="chat_model_switch_discard_title">切换到「%1$s」？</string>
-    <string name="chat_model_switch_discard_message">该模型不支持图片，已选的 %1$d 张图片将被移除。</string>
-    <string name="chat_model_switch_discard_confirm">切换</string>
-    <string name="chat_model_switch_discard_cancel">取消</string>
     <string name="chat_model_provider">模型由 %1$s 的 API 提供</string>
     <string name="chat_cap_unsupported">当前模型不支持</string>
     <string name="chat_list_separator">、</string>

--- a/chat/src/commonMain/composeResources/values-zh/strings.xml
+++ b/chat/src/commonMain/composeResources/values-zh/strings.xml
@@ -24,7 +24,9 @@
     <string name="chat_model_unlock_title">Pro 专属模型</string>
     <string name="chat_model_unlock_message">「%1$s」目前仅对 Pro 开放，可继续使用默认模型。</string>
     <string name="chat_model_unlock_dismiss">知道了</string>
-    <string name="chat_model_provider">模型由 OpenAI API 提供支持</string>
+    <string name="chat_model_provider">模型由 %1$s 的 API 提供</string>
+    <string name="chat_cap_unsupported">当前模型不支持</string>
+    <string name="chat_list_separator">、</string>
     <string name="chat_quota_unlocked">已解锁更多额度，重新发送即可继续。</string>
     <string name="chat_quota_auth_degraded">登录状态未生效，本次请求被按未登录处理——请检查网络后重试，必要时退出后重新登录。</string>
     <string name="chat_error_auth_invalid">登录状态已过期，请退出后重新登录再继续。</string>

--- a/chat/src/commonMain/composeResources/values/strings.xml
+++ b/chat/src/commonMain/composeResources/values/strings.xml
@@ -27,7 +27,9 @@
     <!-- 模型出处。刻意是事实陈述而非 "Powered by OpenAI" 那类品牌宣传语——后者读起来像背书。
          措辞受 OpenAI 品牌指南约束：提及模型必须表述精确，且禁止 "Powered by ChatGPT"/
          "Built with ChatGPT" 之类说法；改文案前先核对 openai.com/brand -->
-    <string name="chat_model_provider">Models provided via the OpenAI API</string>
+    <string name="chat_model_provider">Models provided via %1$s APIs</string>
+    <string name="chat_cap_unsupported">Not supported by this model</string>
+    <string name="chat_list_separator">, </string>
     <string name="chat_quota_unlocked">More quota unlocked — resend to continue.</string>
     <string name="chat_quota_auth_degraded">Signed in, but this request was treated as signed out — check your network and retry, or sign out and sign in again.</string>
     <string name="chat_error_auth_invalid">Your session has expired — sign out and sign in again to continue.</string>

--- a/chat/src/commonMain/composeResources/values/strings.xml
+++ b/chat/src/commonMain/composeResources/values/strings.xml
@@ -24,6 +24,10 @@
     <string name="chat_model_unlock_title">Pro-only model</string>
     <string name="chat_model_unlock_message">%1$s is currently available to Pro only. You can keep using the default model.</string>
     <string name="chat_model_unlock_dismiss">Got it</string>
+    <string name="chat_model_switch_discard_title">Switch to %1$s?</string>
+    <string name="chat_model_switch_discard_message">This model does not accept images. %1$d selected image(s) will be removed.</string>
+    <string name="chat_model_switch_discard_confirm">Switch</string>
+    <string name="chat_model_switch_discard_cancel">Cancel</string>
     <!-- 模型出处。刻意是事实陈述而非 "Powered by OpenAI" 那类品牌宣传语——后者读起来像背书。
          措辞受 OpenAI 品牌指南约束：提及模型必须表述精确，且禁止 "Powered by ChatGPT"/
          "Built with ChatGPT" 之类说法；改文案前先核对 openai.com/brand -->

--- a/chat/src/commonMain/composeResources/values/strings.xml
+++ b/chat/src/commonMain/composeResources/values/strings.xml
@@ -24,10 +24,6 @@
     <string name="chat_model_unlock_title">Pro-only model</string>
     <string name="chat_model_unlock_message">%1$s is currently available to Pro only. You can keep using the default model.</string>
     <string name="chat_model_unlock_dismiss">Got it</string>
-    <string name="chat_model_switch_discard_title">Switch to %1$s?</string>
-    <string name="chat_model_switch_discard_message">This model does not accept images. %1$d selected image(s) will be removed.</string>
-    <string name="chat_model_switch_discard_confirm">Switch</string>
-    <string name="chat_model_switch_discard_cancel">Cancel</string>
     <!-- 模型出处。刻意是事实陈述而非 "Powered by OpenAI" 那类品牌宣传语——后者读起来像背书。
          措辞受 OpenAI 品牌指南约束：提及模型必须表述精确，且禁止 "Powered by ChatGPT"/
          "Built with ChatGPT" 之类说法；改文案前先核对 openai.com/brand -->

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -4,7 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -27,10 +32,12 @@ import whl.trending.chat.host.chatHost
 import whl.trending.chat.model.ChatError
 import whl.trending.chat.model.ChatErrorCategory
 import whl.trending.chat.model.ChatMessage
+import whl.trending.chat.model.ChatModelCaps
 import whl.trending.chat.model.ChatModelsProvider
 import whl.trending.chat.model.ChatModelsResponse
 import whl.trending.chat.model.ChatUiState
 import whl.trending.chat.model.Role
+import whl.trending.chat.model.effectiveChatModelCaps
 import whl.trending.chat.model.SearchEvent
 import whl.trending.chat.model.SourceRef
 import whl.trending.chat.model.resolveDisplayedChatModel
@@ -71,6 +78,10 @@ class ChatViewModel(
     private val transcriber: VoiceTranscriber? = null,
     private val loadModels: suspend () -> ChatModelsResponse = { ChatModelsProvider.get() },
     private val track: (ChatAiEvent) -> Unit = { chatHost.onAiEvent(it) },
+    // 「手选 id × 是否 Pro」流，驱动能力位；懒取宿主，无宿主（单测）时静默为空流
+    private val modelSelection: () -> Flow<Pair<String, Boolean>> = {
+        combine(chatHost.chatModelChoice, chatHost.isPro) { id, pro -> id to pro }
+    },
     private val selectedModelId: () -> String? = {
         // 留痕记「实际生效」而非「手选值」：未手选时手选值是空哨兵，实际用的是目录里的免费默认项
         runCatching {
@@ -97,11 +108,18 @@ class ChatViewModel(
     private val _currentThreadId = MutableStateFlow<Long?>(null)
     val currentThreadId: StateFlow<Long?> = _currentThreadId.asStateFlow()
 
+    /** 当前生效模型的能力位：入口显隐的依据。切到不支持的模型时，已开的搜索开关随之收回 */
+    val currentCaps: StateFlow<ChatModelCaps> =
+        combine(_catalog, flow { emitAll(modelSelection()) }.catch { }) { catalog, (id, pro) ->
+            effectiveChatModelCaps(catalog, id, pro)
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, ChatModelCaps())
+
     /** 联网搜索开关（P2）。粘滞语义：开启后对后续每条消息生效，直到手动关闭 */
     private val _searchEnabled = MutableStateFlow(false)
     val searchEnabled: StateFlow<Boolean> = _searchEnabled.asStateFlow()
 
     fun toggleWebSearch() {
+        if (!_searchEnabled.value && !currentCaps.value.search) return
         _searchEnabled.value = !_searchEnabled.value
     }
 
@@ -119,6 +137,9 @@ class ChatViewModel(
     init {
         viewModelScope.launch {
             _catalog.value = runCatching { loadModels() }.getOrDefault(ChatModelsResponse())
+        }
+        viewModelScope.launch {
+            currentCaps.collect { caps -> if (!caps.search) _searchEnabled.value = false }
         }
     }
 

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -108,7 +108,8 @@ class ChatViewModel(
     private val _currentThreadId = MutableStateFlow<Long?>(null)
     val currentThreadId: StateFlow<Long?> = _currentThreadId.asStateFlow()
 
-    /** 当前生效模型的能力位：入口置灰的依据。切到不支持的模型时，已开的搜索开关与待发图片随之收回 */
+    /** 当前生效模型的能力位：入口置灰的依据。切到不支持搜索的模型时已开的搜索开关随之收回；
+     *  已选图片刻意不清理——带图发到不吃图的模型由服务端 400 拒绝且不扣额度，客户端不为此加状态 */
     val currentCaps: StateFlow<ChatModelCaps> =
         combine(_catalog, flow { emitAll(modelSelection()) }.catch { }) { catalog, (id, pro) ->
             effectiveChatModelCaps(catalog, id, pro)
@@ -139,10 +140,7 @@ class ChatViewModel(
             _catalog.value = runCatching { loadModels() }.getOrDefault(ChatModelsResponse())
         }
         viewModelScope.launch {
-            currentCaps.collect { caps ->
-                if (!caps.search) _searchEnabled.value = false
-                if (!caps.images) discardPendingImages()
-            }
+            currentCaps.collect { caps -> if (!caps.search) _searchEnabled.value = false }
         }
     }
 
@@ -155,10 +153,8 @@ class ChatViewModel(
         _uiState.update { it.copy(input = text) }
     }
 
-    /** 追加一张已压缩好的待发图片（本地缓存路径），超过单条上限或当前模型不接受图片时忽略
-     *  （后者堵住「选图异步返回时已切到不支持的模型」的竞态）。 */
+    /** 追加一张已压缩好的待发图片（本地缓存路径），超过单条上限时忽略。 */
     fun addPendingImage(path: String) {
-        if (!currentCaps.value.images) return
         _uiState.update {
             if (it.pendingImages.size >= maxImagesPerMessage() || path in it.pendingImages) it
             else it.copy(pendingImages = it.pendingImages + path)
@@ -167,11 +163,6 @@ class ChatViewModel(
 
     fun removePendingImage(path: String) {
         _uiState.update { it.copy(pendingImages = it.pendingImages - path) }
-    }
-
-    /** 清空待发图片（切到不接受图片的模型时由选择器在用户确认后调用；能力位变化时也自动兜底） */
-    fun discardPendingImages() {
-        _uiState.update { if (it.pendingImages.isEmpty()) it else it.copy(pendingImages = emptyList()) }
     }
 
     fun send() {

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ChatViewModel.kt
@@ -108,7 +108,7 @@ class ChatViewModel(
     private val _currentThreadId = MutableStateFlow<Long?>(null)
     val currentThreadId: StateFlow<Long?> = _currentThreadId.asStateFlow()
 
-    /** 当前生效模型的能力位：入口显隐的依据。切到不支持的模型时，已开的搜索开关随之收回 */
+    /** 当前生效模型的能力位：入口置灰的依据。切到不支持的模型时，已开的搜索开关与待发图片随之收回 */
     val currentCaps: StateFlow<ChatModelCaps> =
         combine(_catalog, flow { emitAll(modelSelection()) }.catch { }) { catalog, (id, pro) ->
             effectiveChatModelCaps(catalog, id, pro)
@@ -139,7 +139,10 @@ class ChatViewModel(
             _catalog.value = runCatching { loadModels() }.getOrDefault(ChatModelsResponse())
         }
         viewModelScope.launch {
-            currentCaps.collect { caps -> if (!caps.search) _searchEnabled.value = false }
+            currentCaps.collect { caps ->
+                if (!caps.search) _searchEnabled.value = false
+                if (!caps.images) discardPendingImages()
+            }
         }
     }
 
@@ -152,8 +155,10 @@ class ChatViewModel(
         _uiState.update { it.copy(input = text) }
     }
 
-    /** 追加一张已压缩好的待发图片（本地缓存路径），超过单条上限时忽略。 */
+    /** 追加一张已压缩好的待发图片（本地缓存路径），超过单条上限或当前模型不接受图片时忽略
+     *  （后者堵住「选图异步返回时已切到不支持的模型」的竞态）。 */
     fun addPendingImage(path: String) {
+        if (!currentCaps.value.images) return
         _uiState.update {
             if (it.pendingImages.size >= maxImagesPerMessage() || path in it.pendingImages) it
             else it.copy(pendingImages = it.pendingImages + path)
@@ -162,6 +167,11 @@ class ChatViewModel(
 
     fun removePendingImage(path: String) {
         _uiState.update { it.copy(pendingImages = it.pendingImages - path) }
+    }
+
+    /** 清空待发图片（切到不接受图片的模型时由选择器在用户确认后调用；能力位变化时也自动兜底） */
+    fun discardPendingImages() {
+        _uiState.update { if (it.pendingImages.isEmpty()) it else it.copy(pendingImages = emptyList()) }
     }
 
     fun send() {

--- a/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatModelOption.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatModelOption.kt
@@ -80,10 +80,6 @@ fun resolveDisplayedChatModel(catalog: ChatModelsResponse, selectedId: String, i
 fun effectiveChatModelCaps(catalog: ChatModelsResponse, selectedId: String, isPro: Boolean): ChatModelCaps =
     resolveDisplayedChatModel(catalog, selectedId, isPro)?.caps ?: ChatModelCaps()
 
-/** 切到 [target] 是否会移除已选图片：目标模型不接受图片且待发区非空。选择器据此弹二次确认。 */
-fun switchDiscardsImages(target: ChatModelOption, pendingImageCount: Int): Boolean =
-    pendingImageCount > 0 && !target.caps.images
-
 /** 目录里出现的厂商展示名（按目录顺序去重），供出处标注拼接；目录未到时为空。 */
 fun catalogProviderNames(catalog: ChatModelsResponse): List<String> =
     catalog.models.map { it.providerName }.distinct()

--- a/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatModelOption.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatModelOption.kt
@@ -10,14 +10,27 @@ import kotlinx.serialization.Serializable
 const val FOLLOW_SERVER_DEFAULT = ""
 
 /**
+ * 模型接受的输入能力（契约 `caps`）。缺省全开：旧服务端不下发时行为不变，
+ * 服务端在请求时另有真闸（`images_unsupported` / `search_unsupported`），这里只管隐藏入口。
+ */
+@Serializable
+data class ChatModelCaps(
+    val images: Boolean = true,
+    val search: Boolean = true,
+)
+
+/**
  * 一个可选聊天模型（`GET /api/chat/models`）。
- * `name`/`minTier` 带缺省容错：单条缺字段不该让整个目录解码失败（服务端仍按 tier 强制，不越权）。
+ * `name`/`minTier`/`provider`/`caps` 带缺省容错：单条缺字段不该让整个目录解码失败（服务端仍按 tier 强制，不越权）。
  */
 @Serializable
 data class ChatModelOption(
     val id: String,
     val name: String = id,
     val minTier: String = TIER_USER,
+    val provider: String = PROVIDER_DEFAULT,
+    val providerName: String = PROVIDER_DEFAULT_NAME,
+    val caps: ChatModelCaps = ChatModelCaps(),
 ) {
     val proOnly: Boolean get() = minTier == TIER_PRO
 
@@ -25,6 +38,10 @@ data class ChatModelOption(
         /** minTier 取值词汇，与后端 models.js 契约对齐。 */
         const val TIER_USER = "user"
         const val TIER_PRO = "pro"
+
+        /** 旧服务端不下发 provider 字段时的缺省：多厂商上线前目录只有 OpenAI */
+        const val PROVIDER_DEFAULT = "openai"
+        const val PROVIDER_DEFAULT_NAME = "OpenAI"
     }
 }
 
@@ -58,3 +75,11 @@ fun resolveDisplayedChatModel(catalog: ChatModelsResponse, selectedId: String, i
     val effective = resolveEffectiveChatModel(catalog.models, selectedId, isPro)
     return catalog.models.firstOrNull { it.id == effective } ?: catalogDefaultChatModel(catalog)
 }
+
+/** 当前生效模型的能力位；目录未到或解析不出时按全开处理（与缺省一致，不多藏入口）。 */
+fun effectiveChatModelCaps(catalog: ChatModelsResponse, selectedId: String, isPro: Boolean): ChatModelCaps =
+    resolveDisplayedChatModel(catalog, selectedId, isPro)?.caps ?: ChatModelCaps()
+
+/** 目录里出现的厂商展示名（按目录顺序去重），供出处标注拼接；目录未到时为空。 */
+fun catalogProviderNames(catalog: ChatModelsResponse): List<String> =
+    catalog.models.map { it.providerName }.distinct()

--- a/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatModelOption.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/model/ChatModelOption.kt
@@ -80,6 +80,10 @@ fun resolveDisplayedChatModel(catalog: ChatModelsResponse, selectedId: String, i
 fun effectiveChatModelCaps(catalog: ChatModelsResponse, selectedId: String, isPro: Boolean): ChatModelCaps =
     resolveDisplayedChatModel(catalog, selectedId, isPro)?.caps ?: ChatModelCaps()
 
+/** 切到 [target] 是否会移除已选图片：目标模型不接受图片且待发区非空。选择器据此弹二次确认。 */
+fun switchDiscardsImages(target: ChatModelOption, pendingImageCount: Int): Boolean =
+    pendingImageCount > 0 && !target.caps.images
+
 /** 目录里出现的厂商展示名（按目录顺序去重），供出处标注拼接；目录未到时为空。 */
 fun catalogProviderNames(catalog: ChatModelsResponse): List<String> =
     catalog.models.map { it.providerName }.distinct()

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatContextRow.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatContextRow.kt
@@ -44,6 +44,8 @@ internal fun ChatContextRow(
     searchActive: Boolean,
     onToggleSearch: () -> Unit,
     modifier: Modifier = Modifier,
+    pendingImageCount: Int = 0,
+    onDiscardImages: () -> Unit = {},
 ) {
     val showModel = chatModelPickerVisible(catalog)
     // 两者都无内容时整行缺席：留一个空 Row 会在胶囊上方多出一段说不清来由的留白
@@ -55,7 +57,7 @@ internal fun ChatContextRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        if (showModel) ModelPicker(catalog = catalog)
+        if (showModel) ModelPicker(catalog = catalog, pendingImageCount = pendingImageCount, onDiscardImages = onDiscardImages)
         if (searchActive) {
             // 已开启的能力。用 TonalToggleButton 而不是带 × 的 InputChip：Expressive 的表达方式是
             // 让形状承担状态——选中态是 squircle（CornerMedium），按下时收成 6dp 圆角，撤销那一下

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatContextRow.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatContextRow.kt
@@ -44,8 +44,6 @@ internal fun ChatContextRow(
     searchActive: Boolean,
     onToggleSearch: () -> Unit,
     modifier: Modifier = Modifier,
-    pendingImageCount: Int = 0,
-    onDiscardImages: () -> Unit = {},
 ) {
     val showModel = chatModelPickerVisible(catalog)
     // 两者都无内容时整行缺席：留一个空 Row 会在胶囊上方多出一段说不清来由的留白
@@ -57,7 +55,7 @@ internal fun ChatContextRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        if (showModel) ModelPicker(catalog = catalog, pendingImageCount = pendingImageCount, onDiscardImages = onDiscardImages)
+        if (showModel) ModelPicker(catalog = catalog)
         if (searchActive) {
             // 已开启的能力。用 TonalToggleButton 而不是带 × 的 InputChip：Expressive 的表达方式是
             // 让形状承担状态——选中态是 squircle（CornerMedium），按下时收成 6dp 圆角，撤销那一下

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatInputBar.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatInputBar.kt
@@ -71,6 +71,7 @@ import whl.trending.chat.attach.VoiceRecording
 import whl.trending.chat.attach.VoiceStart
 import whl.trending.chat.attach.rememberChatImagePicker
 import whl.trending.chat.attach.rememberChatVoiceRecorder
+import whl.trending.chat.model.ChatModelCaps
 import whl.trending.chat.host.ChatVoiceOutcome
 import whl.trending.chat.host.chatHost
 import whl.trending.chat.ChatViewModel
@@ -78,6 +79,7 @@ import trendingai.chat.generated.resources.Res
 import trendingai.chat.generated.resources.chat_attach
 import trendingai.chat.generated.resources.chat_attach_album
 import trendingai.chat.generated.resources.chat_attach_camera
+import trendingai.chat.generated.resources.chat_cap_unsupported
 import trendingai.chat.generated.resources.chat_image_login_confirm
 import trendingai.chat.generated.resources.chat_image_login_dismiss
 import trendingai.chat.generated.resources.chat_image_login_message
@@ -136,6 +138,7 @@ fun ChatInputBar(
     modifier: Modifier = Modifier,
     searchActive: Boolean = false,
     onToggleSearch: () -> Unit = {},
+    caps: ChatModelCaps = ChatModelCaps(),
     autoFocus: Boolean = false,
     voiceEnabled: Boolean = false,
     isTranscribing: Boolean = false,
@@ -284,7 +287,8 @@ fun ChatInputBar(
                         modifier = Modifier.weight(1f).padding(horizontal = 16.dp),
                     )
                 } else {
-                // + 菜单常开：搜索 toggle 对匿名可用；图片两项在点击时才做登录闸
+                // + 菜单常开：搜索 toggle 对匿名可用；图片两项在点击时才做登录闸。
+                // 所选模型不接受的能力置灰而不隐藏：用户要能看出「这个模型不能发图」，而不是找不到入口
                 run {
                     Box {
                         // 无容器裸图标：附件/能力开关是次要入口，给它填充容器就等于在输入区里
@@ -312,8 +316,10 @@ fun ChatInputBar(
                                 text = { Text(stringResource(Res.string.chat_web_search)) },
                                 leadingIcon = { Icon(Icons.Outlined.TravelExplore, contentDescription = null) },
                                 trailingIcon = {
-                                    if (searchActive) Icon(Icons.Filled.Check, contentDescription = null)
+                                    if (!caps.search) UnsupportedHint()
+                                    else if (searchActive) Icon(Icons.Filled.Check, contentDescription = null)
                                 },
+                                enabled = caps.search,
                                 onClick = {
                                     menuExpanded = false
                                     onToggleSearch()
@@ -322,6 +328,8 @@ fun ChatInputBar(
                             if (chatHost.canSignIn && picker.canCapture) DropdownMenuItem(
                                 text = { Text(stringResource(Res.string.chat_attach_camera)) },
                                 leadingIcon = { Icon(Icons.Outlined.PhotoCamera, contentDescription = null) },
+                                trailingIcon = { if (!caps.images) UnsupportedHint() },
+                                enabled = caps.images,
                                 onClick = {
                                     menuExpanded = false
                                     if (!loggedIn) {
@@ -334,6 +342,8 @@ fun ChatInputBar(
                             if (chatHost.canSignIn) DropdownMenuItem(
                                 text = { Text(stringResource(Res.string.chat_attach_album)) },
                                 leadingIcon = { Icon(Icons.Outlined.Image, contentDescription = null) },
+                                trailingIcon = { if (!caps.images) UnsupportedHint() },
+                                enabled = caps.images,
                                 onClick = {
                                     menuExpanded = false
                                     if (!loggedIn) {
@@ -596,4 +606,14 @@ private fun ChatInputBarPreview() {
             onRemoveImage = {},
         )
     }
+}
+
+/** 禁用态菜单项的尾注：说明为何不可用（所选模型不接受该输入） */
+@Composable
+private fun UnsupportedHint() {
+    Text(
+        text = stringResource(Res.string.chat_cap_unsupported),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
 }

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -186,6 +186,8 @@ fun ChatScreen(
                         searchActive = searchActive,
                         onToggleSearch = viewModel::toggleWebSearch,
                         modifier = Modifier.padding(horizontal = 12.dp),
+                        pendingImageCount = state.pendingImages.size,
+                        onDiscardImages = viewModel::discardPendingImages,
                     )
                     ChatInputBar(
                         input = state.input,

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -186,8 +186,6 @@ fun ChatScreen(
                         searchActive = searchActive,
                         onToggleSearch = viewModel::toggleWebSearch,
                         modifier = Modifier.padding(horizontal = 12.dp),
-                        pendingImageCount = state.pendingImages.size,
-                        onDiscardImages = viewModel::discardPendingImages,
                     )
                     ChatInputBar(
                         input = state.input,

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -45,6 +45,7 @@ import whl.trending.chat.VoiceNotice
 import whl.trending.chat.engine.ChatApi
 import whl.trending.chat.engine.ChatEngine
 import whl.trending.chat.engine.VoiceTranscriber
+import whl.trending.chat.model.catalogProviderNames
 import whl.trending.chat.host.chatHost
 import trendingai.chat.generated.resources.chat_voice_empty
 import trendingai.chat.generated.resources.chat_voice_failed
@@ -158,6 +159,7 @@ fun ChatScreen(
             bottomBar = {
                 val searchActive by viewModel.searchEnabled.collectAsState()
                 val catalog by viewModel.catalog.collectAsState()
+                val caps by viewModel.currentCaps.collectAsState()
                 Column {
                     // 建议动作行（描边 = 建议、填充的「当前配置」行 = 已生效状态，靠样式分层）：
                     // 宿主按入口注入，仅空会话欢迎态展示——发送后与恢复历史会话都自然隐藏
@@ -191,6 +193,7 @@ fun ChatScreen(
                         pendingImages = state.pendingImages,
                         searchActive = searchActive,
                         onToggleSearch = viewModel::toggleWebSearch,
+                        caps = caps,
                         onInputChange = viewModel::updateInput,
                         onSend = viewModel::send,
                         onAddImage = viewModel::addPendingImage,
@@ -213,7 +216,8 @@ fun ChatScreen(
                     .pointerInput(Unit) { detectTapGestures { focusManager.clearFocus() } },
             ) {
                 if (state.messages.isEmpty()) {
-                    ChatWelcome()
+                    val catalog by viewModel.catalog.collectAsState()
+                    ChatWelcome(providerNames = catalogProviderNames(catalog))
                 } else {
                     MessageList(
                         messages = state.messages,

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatWelcome.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatWelcome.kt
@@ -33,7 +33,7 @@ internal enum class WelcomeTier { Anonymous, Free, Pro }
 
 /** 空状态欢迎区，尚无任何对话时显示。[providerNames] 是目录里的厂商展示名，空则不标出处。 */
 @Composable
-fun ChatWelcome(providerNames: List<String> = emptyList(), modifier: Modifier = Modifier) {
+fun ChatWelcome(modifier: Modifier = Modifier, providerNames: List<String> = emptyList()) {
     // 档位判据取本地缓存而非 GET /api/quota：一行小字不值得打网络。失准窗口只有「订阅已到期
     // 且 app 未冷启」，下次冷启的 syncMe 即纠正（唯一日常写入点见 App.kt 根部 LaunchedEffect）
     val isPro by chatHost.isPro.collectAsState(

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatWelcome.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatWelcome.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import whl.trending.chat.host.chatHost
 import trendingai.chat.generated.resources.Res
 import trendingai.chat.generated.resources.chat_assistant_title
+import trendingai.chat.generated.resources.chat_list_separator
 import trendingai.chat.generated.resources.chat_model_provider
 import trendingai.chat.generated.resources.chat_quota_login_cta
 import trendingai.chat.generated.resources.chat_quota_notice
@@ -30,9 +31,9 @@ import trendingai.chat.generated.resources.chat_quota_notice_user
 /** 欢迎区的额度口径档位，与服务端 `resolveQuotaTier` 的三档同名同义。 */
 internal enum class WelcomeTier { Anonymous, Free, Pro }
 
-/** 空状态欢迎区，尚无任何对话时显示。 */
+/** 空状态欢迎区，尚无任何对话时显示。[providerNames] 是目录里的厂商展示名，空则不标出处。 */
 @Composable
-fun ChatWelcome(modifier: Modifier = Modifier) {
+fun ChatWelcome(providerNames: List<String> = emptyList(), modifier: Modifier = Modifier) {
     // 档位判据取本地缓存而非 GET /api/quota：一行小字不值得打网络。失准窗口只有「订阅已到期
     // 且 app 未冷启」，下次冷启的 syncMe 即纠正（唯一日常写入点见 App.kt 根部 LaunchedEffect）
     val isPro by chatHost.isPro.collectAsState(
@@ -50,6 +51,7 @@ fun ChatWelcome(modifier: Modifier = Modifier) {
         canSignIn = chatHost.canSignIn,
         onSignIn = { chatHost.signIn("chat_welcome") },
         proBadge = chatHost.proBadge,
+        providerNames = providerNames,
         modifier = modifier,
     )
 }
@@ -58,6 +60,7 @@ fun ChatWelcome(modifier: Modifier = Modifier) {
 internal fun ChatWelcomeContent(
     tier: WelcomeTier,
     canSignIn: Boolean,
+    providerNames: List<String> = emptyList(),
     onSignIn: () -> Unit,
     proBadge: (@Composable () -> Unit)? = null,
     modifier: Modifier = Modifier,
@@ -99,12 +102,17 @@ internal fun ChatWelcomeContent(
             Spacer(Modifier.height(6.dp))
         }
         // 模型出处不做视觉强调：OpenAI 品牌指南要求其展示不得比我们自己的名称更显著
-        Text(
-            text = stringResource(Res.string.chat_model_provider),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-        )
+        if (providerNames.isNotEmpty()) {
+            Text(
+                text = stringResource(
+                    Res.string.chat_model_provider,
+                    providerNames.joinToString(stringResource(Res.string.chat_list_separator)),
+                ),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
     }
 }
 

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -34,9 +34,11 @@ import whl.trending.chat.model.FOLLOW_SERVER_DEFAULT
 import whl.trending.chat.model.ChatModelOption
 import whl.trending.chat.model.ChatModelsResponse
 import whl.trending.chat.model.catalogDefaultChatModel
+import whl.trending.chat.model.catalogProviderNames
 import whl.trending.chat.model.resolveDisplayedChatModel
 import whl.trending.chat.model.resolveEffectiveChatModel
 import trendingai.chat.generated.resources.Res
+import trendingai.chat.generated.resources.chat_list_separator
 import trendingai.chat.generated.resources.chat_model_provider
 import trendingai.chat.generated.resources.chat_model_unlock_dismiss
 import trendingai.chat.generated.resources.chat_model_unlock_message
@@ -151,40 +153,56 @@ internal fun ModelPicker(
             },
         )
         ChatDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            models.forEach { model ->
-                val locked = model.proOnly && !isPro
-                DropdownMenuItem(
-                    text = { Text(model.name) },
-                    trailingIcon = if (locked) {
-                        {
-                            Icon(
-                                Icons.Filled.Lock,
-                                contentDescription = "Pro",
-                                modifier = Modifier.size(16.dp),
-                                tint = MaterialTheme.colorScheme.primary,
-                            )
-                        }
-                    } else null,
-                    onClick = {
-                        expanded = false
-                        when {
-                            locked -> unlockDialogModel = model
-                            // 选「默认项」记为跟随服务端默认而非钉住这个 id：否则后端换默认模型时，
-                            // 只是点过一次默认的用户会被永久留在旧模型上——正是要解掉的耦合
-                            model.id == catalogDefault.id ->
-                                chatHost.followServerDefault()
-                            else -> chatHost.pinChatModel(model.id)
-                        }
-                    },
-                )
-            }
+            // 多厂商时按厂商分段：段头只是小字标签，不可点；单厂商不加段头（信息与页脚重复）
+            val grouped = models.groupBy { it.provider }
+            val showGroupHeaders = grouped.size > 1
+            grouped.values.forEach { group ->
+                if (showGroupHeaders) {
+                    Text(
+                        text = group.first().providerName,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                    )
+                }
+                group.forEach { model ->
+                    val locked = model.proOnly && !isPro
+                    DropdownMenuItem(
+                        text = { Text(model.name) },
+                        trailingIcon = if (locked) {
+                            {
+                                Icon(
+                                    Icons.Filled.Lock,
+                                    contentDescription = "Pro",
+                                    modifier = Modifier.size(16.dp),
+                                    tint = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                        } else null,
+                        onClick = {
+                            expanded = false
+                            when {
+                                locked -> unlockDialogModel = model
+                                // 选「默认项」记为跟随服务端默认而非钉住这个 id：否则后端换默认模型时，
+                                // 只是点过一次默认的用户会被永久留在旧模型上——正是要解掉的耦合
+                                model.id == catalogDefault.id ->
+                                    chatHost.followServerDefault()
+                                else -> chatHost.pinChatModel(model.id)
+                            }
+                        },
+                    )
+                }
+                }
             // 模型出处。放在菜单末尾而不是常驻行内：起疑的人会点开选择器（型号名就是疑问的原点），
             // 而常驻行受 horizontalScroll + 防输入框跳位约束，塞不下也留不住。
             // 视觉压到 bodySmall + onSurfaceVariant——OpenAI 品牌指南要求其展示不得比我们自己的
             // 名称更显著，且醒目的供应商声明本身会读作辩解。
             HorizontalDivider(Modifier.padding(vertical = 4.dp))
             Text(
-                text = stringResource(Res.string.chat_model_provider),
+                text = stringResource(
+                    Res.string.chat_model_provider,
+                    catalogProviderNames(catalog).joinToString(stringResource(Res.string.chat_list_separator)),
+                ),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -37,9 +37,14 @@ import whl.trending.chat.model.catalogDefaultChatModel
 import whl.trending.chat.model.catalogProviderNames
 import whl.trending.chat.model.resolveDisplayedChatModel
 import whl.trending.chat.model.resolveEffectiveChatModel
+import whl.trending.chat.model.switchDiscardsImages
 import trendingai.chat.generated.resources.Res
 import trendingai.chat.generated.resources.chat_list_separator
 import trendingai.chat.generated.resources.chat_model_provider
+import trendingai.chat.generated.resources.chat_model_switch_discard_cancel
+import trendingai.chat.generated.resources.chat_model_switch_discard_confirm
+import trendingai.chat.generated.resources.chat_model_switch_discard_message
+import trendingai.chat.generated.resources.chat_model_switch_discard_title
 import trendingai.chat.generated.resources.chat_model_unlock_dismiss
 import trendingai.chat.generated.resources.chat_model_unlock_message
 import trendingai.chat.generated.resources.chat_model_unlock_title
@@ -68,6 +73,8 @@ internal fun chatModelPickerVisible(catalog: ChatModelsResponse): Boolean =
 internal fun ModelPicker(
     catalog: ChatModelsResponse,
     modifier: Modifier = Modifier,
+    pendingImageCount: Int = 0,
+    onDiscardImages: () -> Unit = {},
 ) {
     val models = catalog.models
     if (models.size <= 1) return
@@ -81,6 +88,36 @@ internal fun ModelPicker(
     var expanded by remember { mutableStateOf(false) }
     // 点锁定项弹纯告知弹窗：说明这是 Pro 模型、默认模型仍可用，单按钮关闭，不外跳
     var unlockDialogModel by remember { mutableStateOf<ChatModelOption?>(null) }
+    // 目标模型不接受图片且待发区有图：二次确认后才切换并清图，取消则什么都不动
+    var discardDialogModel by remember { mutableStateOf<ChatModelOption?>(null) }
+
+    // 选「默认项」记为跟随服务端默认而非钉住这个 id：否则后端换默认模型时，
+    // 只是点过一次默认的用户会被永久留在旧模型上——正是要解掉的耦合
+    val select = { model: ChatModelOption ->
+        if (model.id == catalogDefault.id) chatHost.followServerDefault() else chatHost.pinChatModel(model.id)
+    }
+
+    discardDialogModel?.let { model ->
+        AlertDialog(
+            onDismissRequest = { discardDialogModel = null },
+            title = { Text(stringResource(Res.string.chat_model_switch_discard_title, model.name)) },
+            text = { Text(stringResource(Res.string.chat_model_switch_discard_message, pendingImageCount)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    discardDialogModel = null
+                    onDiscardImages()
+                    select(model)
+                }) {
+                    Text(stringResource(Res.string.chat_model_switch_discard_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { discardDialogModel = null }) {
+                    Text(stringResource(Res.string.chat_model_switch_discard_cancel))
+                }
+            },
+        )
+    }
 
     unlockDialogModel?.let { model ->
         AlertDialog(
@@ -183,11 +220,8 @@ internal fun ModelPicker(
                             expanded = false
                             when {
                                 locked -> unlockDialogModel = model
-                                // 选「默认项」记为跟随服务端默认而非钉住这个 id：否则后端换默认模型时，
-                                // 只是点过一次默认的用户会被永久留在旧模型上——正是要解掉的耦合
-                                model.id == catalogDefault.id ->
-                                    chatHost.followServerDefault()
-                                else -> chatHost.pinChatModel(model.id)
+                                switchDiscardsImages(model, pendingImageCount) -> discardDialogModel = model
+                                else -> select(model)
                             }
                         },
                     )

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -37,14 +37,9 @@ import whl.trending.chat.model.catalogDefaultChatModel
 import whl.trending.chat.model.catalogProviderNames
 import whl.trending.chat.model.resolveDisplayedChatModel
 import whl.trending.chat.model.resolveEffectiveChatModel
-import whl.trending.chat.model.switchDiscardsImages
 import trendingai.chat.generated.resources.Res
 import trendingai.chat.generated.resources.chat_list_separator
 import trendingai.chat.generated.resources.chat_model_provider
-import trendingai.chat.generated.resources.chat_model_switch_discard_cancel
-import trendingai.chat.generated.resources.chat_model_switch_discard_confirm
-import trendingai.chat.generated.resources.chat_model_switch_discard_message
-import trendingai.chat.generated.resources.chat_model_switch_discard_title
 import trendingai.chat.generated.resources.chat_model_unlock_dismiss
 import trendingai.chat.generated.resources.chat_model_unlock_message
 import trendingai.chat.generated.resources.chat_model_unlock_title
@@ -73,8 +68,6 @@ internal fun chatModelPickerVisible(catalog: ChatModelsResponse): Boolean =
 internal fun ModelPicker(
     catalog: ChatModelsResponse,
     modifier: Modifier = Modifier,
-    pendingImageCount: Int = 0,
-    onDiscardImages: () -> Unit = {},
 ) {
     val models = catalog.models
     if (models.size <= 1) return
@@ -88,36 +81,12 @@ internal fun ModelPicker(
     var expanded by remember { mutableStateOf(false) }
     // 点锁定项弹纯告知弹窗：说明这是 Pro 模型、默认模型仍可用，单按钮关闭，不外跳
     var unlockDialogModel by remember { mutableStateOf<ChatModelOption?>(null) }
-    // 目标模型不接受图片且待发区有图：二次确认后才切换并清图，取消则什么都不动
-    var discardDialogModel by remember { mutableStateOf<ChatModelOption?>(null) }
-
     // 选「默认项」记为跟随服务端默认而非钉住这个 id：否则后端换默认模型时，
     // 只是点过一次默认的用户会被永久留在旧模型上——正是要解掉的耦合
     val select = { model: ChatModelOption ->
         if (model.id == catalogDefault.id) chatHost.followServerDefault() else chatHost.pinChatModel(model.id)
     }
 
-    discardDialogModel?.let { model ->
-        AlertDialog(
-            onDismissRequest = { discardDialogModel = null },
-            title = { Text(stringResource(Res.string.chat_model_switch_discard_title, model.name)) },
-            text = { Text(stringResource(Res.string.chat_model_switch_discard_message, pendingImageCount)) },
-            confirmButton = {
-                TextButton(onClick = {
-                    discardDialogModel = null
-                    onDiscardImages()
-                    select(model)
-                }) {
-                    Text(stringResource(Res.string.chat_model_switch_discard_confirm))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { discardDialogModel = null }) {
-                    Text(stringResource(Res.string.chat_model_switch_discard_cancel))
-                }
-            },
-        )
-    }
 
     unlockDialogModel?.let { model ->
         AlertDialog(
@@ -220,7 +189,6 @@ internal fun ModelPicker(
                             expanded = false
                             when {
                                 locked -> unlockDialogModel = model
-                                switchDiscardsImages(model, pendingImageCount) -> discardDialogModel = model
                                 else -> select(model)
                             }
                         },

--- a/chat/src/commonTest/kotlin/whl/trending/chat/model/ChatModelOptionTest.kt
+++ b/chat/src/commonTest/kotlin/whl/trending/chat/model/ChatModelOptionTest.kt
@@ -97,4 +97,36 @@ class ChatModelOptionTest {
         // 有效的手选不受契约破损影响，照常显示
         assertEquals(pro, resolveDisplayedChatModel(broken, "gpt-6", isPro = true))
     }
+
+    /** 契约 v2 新增字段：旧服务端不下发时按 OpenAI 全能力解析（行为不变） */
+    @Test
+    fun entry_missing_provider_and_caps_defaults_to_openai_full_caps() {
+        val parsed = Json.decodeFromString<ChatModelsResponse>("""{"default":"m1","models":[{"id":"m1"}]}""")
+        val model = parsed.models.single()
+        assertEquals("openai", model.provider)
+        assertEquals("OpenAI", model.providerName)
+        assertEquals(ChatModelCaps(images = true, search = true), model.caps)
+    }
+
+    @Test
+    fun entry_with_provider_and_caps_decodes() {
+        val parsed = Json.decodeFromString<ChatModelsResponse>(
+            """{"default":"m1","models":[{"id":"m1"},{"id":"deepseek-v4-flash","name":"DeepSeek V4 Flash","minTier":"user","provider":"deepseek","providerName":"DeepSeek","caps":{"images":false,"search":false}}]}""",
+        )
+        val ds = parsed.models.last()
+        assertEquals("deepseek", ds.provider)
+        assertEquals(ChatModelCaps(images = false, search = false), ds.caps)
+        assertEquals(listOf("OpenAI", "DeepSeek"), catalogProviderNames(parsed))
+    }
+
+    @Test
+    fun effective_caps_follow_selected_model_and_fall_back_to_full() {
+        val ds = ChatModelOption(id = "deepseek-v4-flash", provider = "deepseek", providerName = "DeepSeek", caps = ChatModelCaps(images = false, search = false))
+        val withDs = ChatModelsResponse(models = listOf(free, pro, ds), default = free.id)
+        assertEquals(ChatModelCaps(false, false), effectiveChatModelCaps(withDs, "deepseek-v4-flash", isPro = false))
+        // 未手选 → 默认项（OpenAI）的全能力
+        assertEquals(ChatModelCaps(true, true), effectiveChatModelCaps(withDs, FOLLOW_SERVER_DEFAULT, isPro = false))
+        // 目录未到 → 全开，不多藏入口
+        assertEquals(ChatModelCaps(true, true), effectiveChatModelCaps(ChatModelsResponse(), "deepseek-v4-flash", isPro = false))
+    }
 }

--- a/chat/src/commonTest/kotlin/whl/trending/chat/model/ChatModelOptionTest.kt
+++ b/chat/src/commonTest/kotlin/whl/trending/chat/model/ChatModelOptionTest.kt
@@ -120,6 +120,14 @@ class ChatModelOptionTest {
     }
 
     @Test
+    fun switch_discards_images_only_when_target_rejects_images_and_images_pending() {
+        val ds = ChatModelOption(id = "deepseek-v4-flash", caps = ChatModelCaps(images = false, search = false))
+        assertEquals(true, switchDiscardsImages(ds, pendingImageCount = 2))
+        assertEquals(false, switchDiscardsImages(ds, pendingImageCount = 0))
+        assertEquals(false, switchDiscardsImages(free, pendingImageCount = 2))
+    }
+
+    @Test
     fun effective_caps_follow_selected_model_and_fall_back_to_full() {
         val ds = ChatModelOption(id = "deepseek-v4-flash", provider = "deepseek", providerName = "DeepSeek", caps = ChatModelCaps(images = false, search = false))
         val withDs = ChatModelsResponse(models = listOf(free, pro, ds), default = free.id)

--- a/chat/src/commonTest/kotlin/whl/trending/chat/model/ChatModelOptionTest.kt
+++ b/chat/src/commonTest/kotlin/whl/trending/chat/model/ChatModelOptionTest.kt
@@ -120,14 +120,6 @@ class ChatModelOptionTest {
     }
 
     @Test
-    fun switch_discards_images_only_when_target_rejects_images_and_images_pending() {
-        val ds = ChatModelOption(id = "deepseek-v4-flash", caps = ChatModelCaps(images = false, search = false))
-        assertEquals(true, switchDiscardsImages(ds, pendingImageCount = 2))
-        assertEquals(false, switchDiscardsImages(ds, pendingImageCount = 0))
-        assertEquals(false, switchDiscardsImages(free, pendingImageCount = 2))
-    }
-
-    @Test
     fun effective_caps_follow_selected_model_and_fall_back_to_full() {
         val ds = ChatModelOption(id = "deepseek-v4-flash", provider = "deepseek", providerName = "DeepSeek", caps = ChatModelCaps(images = false, search = false))
         val withDs = ChatModelsResponse(models = listOf(free, pro, ds), default = free.id)


### PR DESCRIPTION
## 背景

后端已上线 AI chat 多厂商（github-ai-trending-api #47，DeepSeek 首批、Pro 专属、无图无搜索）。目录接口每条模型新增 `provider` / `providerName` / `caps` 三个字段，契约见后端仓 `docs/chat-protocol.md`。本 PR 让客户端按这些字段渲染，厂商名与能力不再写死。

## 用户可感知的变化

- 模型选择器多厂商时按厂商分段，段头一行小字厂商名；单厂商不分段。DeepSeek 两条对非 Pro 显示锁并沿用既有告知框。
- 出处文案从写死的「模型由 OpenAI API 提供支持」改为按目录拼「模型由 OpenAI、DeepSeek 的 API 提供」（英文 `Models provided via OpenAI, DeepSeek APIs`），选择器菜单末尾与欢迎页两处同源；目录未到时欢迎页不显示这行。
- 选中不接受图片 / 搜索的模型时，加号菜单里对应项置灰并尾注「当前模型不支持」，不隐藏。
- 开着搜索切到不支持的模型，搜索开关自动关闭，且在该模型上点不出搜索。

## 改动

全部在 `:chat` 模块，`ChatHost` 接口与 `shared` 接线零改动：

- `model/ChatModelOption.kt`：`ChatModelCaps`；三个带缺省的新字段（旧服务端响应照常解码）；`effectiveChatModelCaps` / `catalogProviderNames`
- `ChatViewModel.kt`：`currentCaps` 状态流（目录 × 手选 × Pro 合成，宿主流经构造参数注入、无宿主时静默全开）；`toggleWebSearch` 守卫；能力位变化时收回搜索
- `ui/ChatInputBar.kt`：`caps` 参数，三个菜单项 `enabled` 与尾注
- `ui/ModelPicker.kt`：分段渲染；页脚文案拼接
- `ui/ChatWelcome.kt`、`ui/ChatScreen.kt`：厂商名与 caps 透传
- 中英 strings：`chat_model_provider` 改带占位符，新增 `chat_list_separator`、`chat_cap_unsupported`

## 测试

`:chat:testAndroidHostTest` 121 条全过：`ChatModelOptionTest` 新增新字段解码 / 缺省回退 / 能力位解析三条；新增 `ChatViewModelCapsTest` 三条（默认全开、切模型收回搜索且不可再开、无宿主全开）。`:chat` iOS 目标与 `:androidApp` github 口味编译通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUyiuHzvLebNGMSxx1A5dJ

## Sourcery 摘要

支持多提供商聊天模型目录，并使用模型能力控制可用的聊天输入。

新功能：
- 使用按提供商分组的选择菜单呈现聊天模型目录，并显示包含提供商信息的归属文本。
- 根据每个模型是否支持图像和网页搜索，禁用不受支持的输入操作；切换模型时自动关闭搜索。

错误修复：
- 当较旧或不可用的目录数据缺少提供商和能力字段时，保留完整能力行为。

增强功能：
- 集中处理来自目录、选择状态和订阅状态的有效模型能力及提供商名称解析。

测试：
- 增加对提供商和能力解码默认值、有效能力解析以及搜索状态强制执行的覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

渲染多提供商聊天目录，并在模型选择和消息组成的整个过程中强制执行每个模型声明的输入能力。

新功能：
- 支持多提供商聊天模型目录，按提供商分组进行模型选择，并显示包含提供商信息的归属文本。
- 在聊天输入中反映模型的图像和网页搜索能力，禁用不受支持的操作，并在切换模型时自动关闭搜索。

错误修复：
- 当旧版目录响应缺少提供商或能力字段时，保留 OpenAI 默认值和完整能力。
- 防止在切换模型后重新启用不受支持的图像附件和网页搜索。

增强功能：
- 在切换到无法接受当前所选图像的模型前添加确认步骤。
- 在按提供商分组的模型列表中保留仅限 Pro 的模型锁定状态和现有访问提示。

测试：
- 增加对提供商和能力解码默认值、能力解析、模型切换行为以及不受支持输入强制执行的覆盖测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持多提供商聊天模型目录，并在模型选择和消息组合过程中，强制遵循每个所选模型声明的输入能力。

新功能：
- 按提供商分组呈现聊天模型目录，并根据目录数据生成提供商归属文本。
- 使用模型声明的图像和网页搜索能力，禁用不受支持的聊天输入操作；切换模型时自动关闭搜索。

错误修复：
- 当较旧的目录响应缺少提供商或能力字段时，保留 OpenAI 默认值和完整能力。
- 防止为不支持网页搜索的模型重新启用网页搜索。

改进：
- 在目录、模型选择和订阅状态之间集中解析有效能力和提供商名称，同时保留现有的 Pro 访问行为。

测试：
- 增加对目录字段默认值、提供商和能力解码、有效能力解析以及搜索状态强制执行的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support multi-provider chat model catalogs and enforce each selected model’s declared input capabilities throughout model selection and message composition.

New Features:
- Render chat model catalogs grouped by provider and generate provider attribution text from catalog data.
- Use model-declared image and web-search capabilities to disable unsupported chat input actions and automatically turn off search when switching models.

Bug Fixes:
- Preserve OpenAI defaults and full capabilities when older catalog responses omit provider or capability fields.
- Prevent web search from being re-enabled for models that do not support it.

Enhancements:
- Centralize effective capability and provider-name resolution across catalog, model selection, and subscription state while retaining existing Pro access behavior.

Tests:
- Add coverage for catalog field defaults, provider and capability decoding, effective capability resolution, and search-state enforcement.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chat now reflects the selected model’s supported capabilities.
  - Web search, camera, and photo attachments are visibly disabled when unsupported.
  - Welcome messaging identifies available model providers.
  - Model and provider information is displayed more flexibly.

- **Bug Fixes**
  - Web search automatically turns off when switching to a model that does not support it.
  - Models without image support can be selected without losing pending images; unsupported submissions are handled by the service.

- **Tests**
  - Added coverage for model capabilities, provider information, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->