### PR TITLE
feat(chat): 模型选择器挪到顶栏中央

### DIFF
--- a/chat/src/commonMain/composeResources/values-zh/strings.xml
+++ b/chat/src/commonMain/composeResources/values-zh/strings.xml
@@ -24,6 +24,7 @@
     <string name="chat_model_unlock_title">Pro 专属模型</string>
     <string name="chat_model_unlock_message">「%1$s」目前仅对 Pro 开放，可继续使用默认模型。</string>
     <string name="chat_model_unlock_dismiss">知道了</string>
+    <string name="chat_model_picker_title">选择模型</string>
     <string name="chat_model_provider">模型由 %1$s 的 API 提供</string>
     <string name="chat_cap_unsupported">当前模型不支持</string>
     <string name="chat_list_separator">、</string>

--- a/chat/src/commonMain/composeResources/values/strings.xml
+++ b/chat/src/commonMain/composeResources/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="chat_model_unlock_title">Pro-only model</string>
     <string name="chat_model_unlock_message">%1$s is currently available to Pro only. You can keep using the default model.</string>
     <string name="chat_model_unlock_dismiss">Got it</string>
+    <string name="chat_model_picker_title">Choose a model</string>
     <!-- 模型出处。刻意是事实陈述而非 "Powered by OpenAI" 那类品牌宣传语——后者读起来像背书。
          措辞受 OpenAI 品牌指南约束：提及模型必须表述精确，且禁止 "Powered by ChatGPT"/
          "Built with ChatGPT" 之类说法；改文案前先核对 openai.com/brand -->

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatChrome.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatChrome.kt
@@ -8,7 +8,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
@@ -53,12 +53,13 @@ internal fun ChatTopAppBar(
     navigationIcon: @Composable () -> Unit = {},
     actions: @Composable RowScope.() -> Unit = {},
 ) {
-    TopAppBar(
+    // 居中：标题槽放模型选择器（单模型时回落文字标题），两侧图标由组件自动避让
+    CenterAlignedTopAppBar(
         title = title,
         modifier = modifier,
         navigationIcon = navigationIcon,
         actions = actions,
-        colors = TopAppBarDefaults.topAppBarColors(
+        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer,
             scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
         ),

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatChrome.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatChrome.kt
@@ -6,6 +6,15 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -83,4 +92,36 @@ internal fun ChatDropdownMenu(
         tonalElevation = MenuDefaults.TonalElevation,
         content = content,
     )
+}
+
+/**
+ * chat 模块的底部浮层，规格镜像宿主 app 的 `TrendingBottomSheet`（chat 是独立 SDK，不能依赖 shared）：
+ * `titleLarge` 标题、24dp 水平边距、导航栏避让 + 16dp 底部留白。内容区不自带滚动。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ChatBottomSheet(
+    onDismissRequest: () -> Unit,
+    title: String,
+    modifier: Modifier = Modifier,
+    content: @Composable androidx.compose.foundation.layout.ColumnScope.() -> Unit,
+) {
+    // 全展开：内容是短列表，半展开会把末项与页脚裁在折叠线下
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .navigationBarsPadding()
+                .padding(bottom = 16.dp),
+        ) {
+            Text(text = title, style = MaterialTheme.typography.titleLarge)
+            Spacer(Modifier.height(16.dp))
+            content()
+        }
+    }
 }

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatChrome.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatChrome.kt
@@ -8,7 +8,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.height
@@ -68,7 +69,7 @@ internal fun ChatTopAppBar(
         modifier = modifier,
         navigationIcon = navigationIcon,
         actions = actions,
-        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+        colors = TopAppBarDefaults.topAppBarColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer,
             scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
         ),
@@ -110,7 +111,10 @@ internal fun ChatBottomSheet(
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         modifier = modifier,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        sheetState = rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        ),
     ) {
         Column(
             modifier = Modifier

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatContextRow.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatContextRow.kt
@@ -22,32 +22,26 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.resources.stringResource
 import androidx.compose.ui.unit.dp
-import whl.trending.chat.model.ChatModelsResponse
 import trendingai.chat.generated.resources.Res
 import trendingai.chat.generated.resources.chat_web_search
 
 /**
- * 输入胶囊正上方的单行「当前配置」区，回答一个问题：**下一条消息会以什么配置发出去**。
+ * 输入胶囊正上方的单行「已开启的能力」区，回答一个问题：**下一条消息会以什么配置发出去**。
+ * 模型选择器不在这里——它是常驻信息，挂在顶栏中央；这一行只放临时开启、需要被看见的能力。
  *
- * 参照 EchoFlow 的 `ContextChipRow`（`ChatComposer.kt`）：模型与已开启的能力本就是同一类信息，
- * 排成一行而不是各占一行——改版前它俩各占一行、右侧全是留白，最坏情况能把输入框顶高约 150dp。
- *
- * 行内一律用 M3 Expressive 的按钮而不是 chip。原因是圆角：chip 的规范是 32dp 高 + `CornerSmall`
- * （8dp），下面的输入胶囊是 72dp 高 + 36dp 全圆，两者放一起像方贴纸贴在圆胶囊上。Expressive 的
- * 按钮默认就是 40dp 高 + `CornerFull`，与胶囊同源。（ChatGPT / Gemini / 千问 / 豆包的同位置
- * 控件也都是全圆胶囊，没有用小圆角 chip 的。）
+ * 参照 EchoFlow 的 `ContextChipRow`（`ChatComposer.kt`）。行内用 M3 Expressive 的按钮而不是 chip：
+ * chip 的规范是 32dp 高 + `CornerSmall`（8dp），下面的输入胶囊是 72dp 高 + 36dp 全圆，两者放一起
+ * 像方贴纸贴在圆胶囊上；Expressive 的按钮默认 40dp 高 + `CornerFull`，与胶囊同源。
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun ChatContextRow(
-    catalog: ChatModelsResponse,
     searchActive: Boolean,
     onToggleSearch: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val showModel = chatModelPickerVisible(catalog)
-    // 两者都无内容时整行缺席：留一个空 Row 会在胶囊上方多出一段说不清来由的留白
-    if (!showModel && !searchActive) return
+    // 无内容时整行缺席：留一个空 Row 会在胶囊上方多出一段说不清来由的留白
+    if (!searchActive) return
 
     Row(
         // 能力将来变多时横向滚动而不是换行：换行会让输入框在开关能力时上下跳
@@ -55,7 +49,6 @@ internal fun ChatContextRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        if (showModel) ModelPicker(catalog = catalog)
         if (searchActive) {
             // 已开启的能力。用 TonalToggleButton 而不是带 × 的 InputChip：Expressive 的表达方式是
             // 让形状承担状态——选中态是 squircle（CornerMedium），按下时收成 6dp 圆角，撤销那一下

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatContextRow.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatContextRow.kt
@@ -26,8 +26,8 @@ import trendingai.chat.generated.resources.Res
 import trendingai.chat.generated.resources.chat_web_search
 
 /**
- * 输入胶囊正上方的单行「已开启的能力」区，回答一个问题：**下一条消息会以什么配置发出去**。
- * 模型选择器不在这里——它是常驻信息，挂在顶栏中央；这一行只放临时开启、需要被看见的能力。
+ * 输入胶囊正上方的单行「已开启的能力」区，只显示临时开启、需要被看见的能力（如联网搜索）。
+ * 模型选择器不在这里——它是常驻信息，挂在顶栏中央。
  *
  * 参照 EchoFlow 的 `ContextChipRow`（`ChatComposer.kt`）。行内用 M3 Expressive 的按钮而不是 chip：
  * chip 的规范是 32dp 高 + `CornerSmall`（8dp），下面的输入胶囊是 72dp 高 + 36dp 全圆，两者放一起

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -125,15 +125,21 @@ fun ChatScreen(
             )
         },
     ) {
+        val catalog by viewModel.catalog.collectAsState()
         ChatScaffold(
             topBar = {
                 ChatTopAppBar(
+                    // 模型选择器就是标题；只有一个可选模型时无从选择，回落文字标题
                     title = {
-                        Text(
-                            text = stringResource(Res.string.chat_assistant_title),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                        if (chatModelPickerVisible(catalog)) {
+                            ModelPicker(catalog = catalog)
+                        } else {
+                            Text(
+                                text = stringResource(Res.string.chat_assistant_title),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
                     },
                     navigationIcon = {
                         IconButton(onClick = onBack) {
@@ -158,7 +164,6 @@ fun ChatScreen(
             },
             bottomBar = {
                 val searchActive by viewModel.searchEnabled.collectAsState()
-                val catalog by viewModel.catalog.collectAsState()
                 val caps by viewModel.currentCaps.collectAsState()
                 Column {
                     // 建议动作行（描边 = 建议、填充的「当前配置」行 = 已生效状态，靠样式分层）：
@@ -180,9 +185,8 @@ fun ChatScreen(
                             }
                         }
                     }
-                    // 当前配置行：回答「下一条消息以什么配置发出去」
+                    // 已开启的能力行：回答「下一条消息以什么配置发出去」
                     ChatContextRow(
-                        catalog = catalog,
                         searchActive = searchActive,
                         onToggleSearch = viewModel::toggleWebSearch,
                         modifier = Modifier.padding(horizontal = 12.dp),
@@ -216,7 +220,6 @@ fun ChatScreen(
                     .pointerInput(Unit) { detectTapGestures { focusManager.clearFocus() } },
             ) {
                 if (state.messages.isEmpty()) {
-                    val catalog by viewModel.catalog.collectAsState()
                     ChatWelcome(providerNames = catalogProviderNames(catalog))
                 } else {
                     MessageList(

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ChatScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -47,11 +47,8 @@ import trendingai.chat.generated.resources.chat_model_unlock_message
 import trendingai.chat.generated.resources.chat_model_unlock_title
 
 /**
- * [ModelPicker] 是否有东西可渲染。
- *
- * 抽出来是给 [ChatContextRow] 用的：那一行要在「模型和能力 chip 都没有」时整行缺席，
- * 而选择器是否出现只有这里知道——组件内部 return 掉的话，外面看到的是一个高度为 0 却
- * 仍占着 Arrangement 间距的成员。
+ * [ModelPicker] 是否有东西可渲染：顶栏标题槽据此决定放选择器还是回落文字标题。
+ * 选择器是否出现只有这里知道——组件内部 return 掉的话，标题槽会空着。
  */
 internal fun chatModelPickerVisible(catalog: ChatModelsResponse): Boolean =
     catalog.models.size > 1 && catalogDefaultChatModel(catalog) != null

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Lock
@@ -27,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.style.TextOverflow
 import org.jetbrains.compose.resources.stringResource
 import androidx.compose.ui.unit.dp
 import whl.trending.chat.host.chatHost
@@ -116,25 +118,26 @@ internal fun ModelPicker(
 
     Box(modifier) {
         // M3 Expressive 的 SplitButton 而不是 chip：模型名与下拉箭头分成两块，「这是个选择器」
-        // 由形态本身讲清楚，不用靠「能不能点掉」去猜（chip 的老问题）。它天生 40dp 高 + 全圆，
-        // 与下面的输入胶囊同一套圆角语言。
-        //
-        // 配色刻意选中性的 surfaceContainerHigh，而不是 tonal 默认的 secondaryContainer：
-        // 模型是常驻的纯信息，带色相就会跟旁边「已开启的能力」抢注意力。也不能用再深一档的
-        // surfaceContainerHighest——那正是禁用态发送键的容器色（实测浅色下同为 #E7E0EC），
-        // 空输入时同屏会出现两块一样的颜色，一块可点一块禁用。选 High 后浅色梯度是
-        // 背景 #FDF7FE → 胶囊 #F3EDF4（High + 3dp tonal 提亮）→ 模型 #ECE6F0 → 禁用发送键 #E7E0EC。
+        // 由形态本身讲清楚，不用靠「能不能点掉」去猜（chip 的老问题）。
+        // 挂在顶栏中央当标题，用主色容器：这里没有别的能力控件与它抢注意力
         val modelColors = ButtonDefaults.filledTonalButtonColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-            contentColor = MaterialTheme.colorScheme.onSurface,
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
         )
         SplitButtonLayout(
+            // 限宽：长模型名截断成省略号，别把顶栏两侧的图标挤出去
+            modifier = Modifier.widthIn(max = 240.dp),
             leadingButton = {
                 SplitButtonDefaults.LeadingButton(
                     onClick = { expanded = true },
                     colors = modelColors,
                 ) {
-                    Text(current.name)
+                    Text(
+                        text = current.name,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false),
+                    )
                 }
             },
             trailingButton = {

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -1,16 +1,19 @@
 package whl.trending.chat.ui
 
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -27,6 +30,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.style.TextOverflow
 import org.jetbrains.compose.resources.stringResource
@@ -41,6 +46,7 @@ import whl.trending.chat.model.resolveDisplayedChatModel
 import whl.trending.chat.model.resolveEffectiveChatModel
 import trendingai.chat.generated.resources.Res
 import trendingai.chat.generated.resources.chat_list_separator
+import trendingai.chat.generated.resources.chat_model_picker_title
 import trendingai.chat.generated.resources.chat_model_provider
 import trendingai.chat.generated.resources.chat_model_unlock_dismiss
 import trendingai.chat.generated.resources.chat_model_unlock_message
@@ -159,57 +165,72 @@ internal fun ModelPicker(
                 }
             },
         )
-        ChatDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            // 多厂商时按厂商分段：段头只是小字标签，不可点；单厂商不加段头（信息与页脚重复）
-            val grouped = models.groupBy { it.provider }
-            val showGroupHeaders = grouped.size > 1
-            grouped.values.forEach { group ->
-                if (showGroupHeaders) {
-                    Text(
-                        text = group.first().providerName,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                    )
+        // 底部浮层而不是下拉：6 项以上、带段头与锁图标，已超出下拉菜单的适用范围（仓库 UI 规范）；
+        // 顶栏锚点的 Popup 定位在 edge-to-edge 下还会漂到状态栏上盖住选择器本身
+        if (expanded) {
+            ChatBottomSheet(
+                onDismissRequest = { expanded = false },
+                title = stringResource(Res.string.chat_model_picker_title),
+            ) {
+                // 多厂商时按厂商分节：节头只是小字标签，不可点；单厂商不加节头（信息与页脚重复）
+                val grouped = models.groupBy { it.provider }
+                val showGroupHeaders = grouped.size > 1
+                grouped.values.forEach { group ->
+                    if (showGroupHeaders) {
+                        Text(
+                            text = group.first().providerName,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            // ListItem 自带 16dp 水平内边距，节头与页脚对齐到同一条线
+                            modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 4.dp),
+                        )
+                    }
+                    group.forEach { model ->
+                        val locked = model.proOnly && !isPro
+                        ListItem(
+                            headlineContent = { Text(model.name) },
+                            trailingContent = {
+                                when {
+                                    locked -> Icon(
+                                        Icons.Filled.Lock,
+                                        contentDescription = "Pro",
+                                        modifier = Modifier.size(18.dp),
+                                        tint = MaterialTheme.colorScheme.primary,
+                                    )
+                                    model.id == current.id -> Icon(
+                                        Icons.Filled.Check,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary,
+                                    )
+                                }
+                            },
+                            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                            modifier = Modifier
+                                .clip(MaterialTheme.shapes.medium)
+                                .clickable {
+                                    expanded = false
+                                    when {
+                                        locked -> unlockDialogModel = model
+                                        else -> select(model)
+                                    }
+                                },
+                        )
+                    }
                 }
-                group.forEach { model ->
-                    val locked = model.proOnly && !isPro
-                    DropdownMenuItem(
-                        text = { Text(model.name) },
-                        trailingIcon = if (locked) {
-                            {
-                                Icon(
-                                    Icons.Filled.Lock,
-                                    contentDescription = "Pro",
-                                    modifier = Modifier.size(16.dp),
-                                    tint = MaterialTheme.colorScheme.primary,
-                                )
-                            }
-                        } else null,
-                        onClick = {
-                            expanded = false
-                            when {
-                                locked -> unlockDialogModel = model
-                                else -> select(model)
-                            }
-                        },
-                    )
-                }
-                }
-            // 模型出处。放在菜单末尾而不是常驻行内：起疑的人会点开选择器（型号名就是疑问的原点），
-            // 而常驻行受 horizontalScroll + 防输入框跳位约束，塞不下也留不住。
-            // 视觉压到 bodySmall + onSurfaceVariant——OpenAI 品牌指南要求其展示不得比我们自己的
-            // 名称更显著，且醒目的供应商声明本身会读作辩解。
-            HorizontalDivider(Modifier.padding(vertical = 4.dp))
-            Text(
-                text = stringResource(
-                    Res.string.chat_model_provider,
-                    catalogProviderNames(catalog).joinToString(stringResource(Res.string.chat_list_separator)),
-                ),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-            )
+                // 模型出处。放在浮层末尾而不是常驻行内：起疑的人会点开选择器（型号名就是疑问的原点）。
+                // 视觉压到 bodySmall + onSurfaceVariant——OpenAI 品牌指南要求其展示不得比我们自己的
+                // 名称更显著，且醒目的供应商声明本身会读作辩解。
+                HorizontalDivider(Modifier.padding(vertical = 8.dp))
+                Text(
+                    text = stringResource(
+                        Res.string.chat_model_provider,
+                        catalogProviderNames(catalog).joinToString(stringResource(Res.string.chat_list_separator)),
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+            }
         }
     }
 }

--- a/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
+++ b/chat/src/commonMain/kotlin/whl/trending/chat/ui/ModelPicker.kt
@@ -119,10 +119,11 @@ internal fun ModelPicker(
     Box(modifier) {
         // M3 Expressive 的 SplitButton 而不是 chip：模型名与下拉箭头分成两块，「这是个选择器」
         // 由形态本身讲清楚，不用靠「能不能点掉」去猜（chip 的老问题）。
-        // 挂在顶栏中央当标题，用主色容器：这里没有别的能力控件与它抢注意力
+        // 挂在顶栏中央当标题，配色保持中性：模型是常驻信息，不该是页面第一眼的落点。
+        // 顶栏底色是 surfaceContainer，取深两档的 Highest 才在浅色下看得出胶囊轮廓
         val modelColors = ButtonDefaults.filledTonalButtonColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer,
-            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+            contentColor = MaterialTheme.colorScheme.onSurface,
         )
         SplitButtonLayout(
             // 限宽：长模型名截断成省略号，别把顶栏两侧的图标挤出去

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/TrendingBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/common/TrendingBottomSheet.kt
@@ -14,7 +14,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,7 +40,10 @@ fun TrendingBottomSheet(
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     title: String? = null,
-    sheetState: SheetState = rememberModalBottomSheetState(),
+    sheetState: SheetState = rememberBottomSheetState(
+        initialValue = SheetValue.Hidden,
+        enabledValues = setOf(SheetValue.Hidden, SheetValue.PartiallyExpanded, SheetValue.Expanded),
+    ),
     titleAction: (@Composable () -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/trending/TrendingScreen.kt
@@ -48,7 +48,8 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.material3.rememberDatePickerState
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -561,7 +562,10 @@ private fun FilterBottomSheet(
 
     var tempPeriod by remember { mutableStateOf(selectedPeriod) }
     var tempLanguage by remember { mutableStateOf(selectedLanguage) }
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val sheetState = rememberBottomSheetState(
+        initialValue = SheetValue.Hidden,
+        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+    )
 
     // 这里曾挂一个「更新机制」InfoDialog：更新节奏与筛选周期/语言无关，位置本就错了，
     // 且那份文案已并入「数据来源与更新」页（从列表头部的抓取时机条进入）。
@@ -653,7 +657,10 @@ private fun HistoryBottomSheet(
     var tempDate by remember { mutableStateOf(selectedDate ?: "") }
     var tempBatch by remember { mutableStateOf(selectedBatch ?: "am") }
     var showHelpDialog by remember { mutableStateOf(false) }
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val sheetState = rememberBottomSheetState(
+        initialValue = SheetValue.Hidden,
+        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+    )
 
     val datePickerState = rememberDatePickerState()
     var showDatePicker by remember { mutableStateOf(false) }


### PR DESCRIPTION
## 改动

- 顶栏改为 `CenterAlignedTopAppBar`，标题槽放模型选择器；只有一个可选模型时回落文字标题「AI 助手」。返回键与会话抽屉图标不动。
- 选择器保持中性容器色（`surfaceContainerHighest`，比顶栏底色深两档），限宽 240dp、长模型名省略号截断。
- 输入栏上方那一行只剩已开启的搜索胶囊，未开启时整行缺席，输入区更紧凑。
- 点选择器改为弹出底部浮层（`ModalBottomSheet`，全展开）：标题「选择模型」、按厂商分节、当前项打勾、Pro 项带锁、页脚出处文案。原顶栏锚定的下拉在 edge-to-edge 下会漂到状态栏上盖住选择器，且 6 项带节头与锁图标已超出仓库 UI 规范里下拉的适用范围。

## 验证

`:chat` 121 条单测全过，iOS 目标编译通过。Pixel_9_2 模拟器与小米真机实测：顶栏居中选择器、浮层分节与页脚、切到 DeepSeek 后加号菜单三项置灰均正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUyiuHzvLebNGMSxx1A5dJ

## Sourcery 总结

将模型选择器置于聊天顶部栏中央，并简化编辑器上下文区域。

新功能：
- 将模型选择器移至居中的聊天顶部栏；当没有可用选项时，显示备用助手标题。

改进：
- 限制过长的模型名称并使用省略号显示，同时使用主容器颜色设置顶部栏选择器的样式。
- 仅在启用网页搜索时显示编辑器上下文行，使输入区域更加紧凑。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

重新调整聊天标题栏中的模型选择器位置，并简化编辑器上下文区域。

新功能：
- 将聊天模型选择器移至居中的顶部应用栏；当没有可用选项时，改为显示助手标题。

改进：
- 仅在编辑器上方显示已启用的网页搜索控件；当未启用任何功能时，隐藏上下文行。
- 限制顶部栏模型选择器中的长模型名称，并使用省略号显示，同时保留现有的模型菜单内容。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将模型选择器整合到聊天顶栏中央，并精简输入区上方的上下文展示。

新功能：
- 将聊天模型选择器移至居中顶栏，并在模型不可选择时显示“AI 助手”标题。
- 通过底部浮层提供按厂商分类的模型选择界面，同时保留 Pro 锁定状态、当前选择标记和模型来源信息。

改进：
- 优化模型选择器的视觉样式与布局，限制宽度，并对过长的模型名称使用省略号。
- 简化输入栏上方的上下文区域，仅在网页搜索启用时显示搜索控件。
- 统一底部浮层的展开状态配置，支持按场景启用半展开或仅完全展开。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将模型选择器整合到聊天顶栏中央，并精简输入区上方的上下文展示。

New Features:
- 将聊天模型选择器移至居中顶栏，并在模型不可选择时显示“AI 助手”标题。
- 通过底部浮层提供分厂商的模型选择界面，同时保留 Pro 锁定状态、当前选择标记和模型来源信息。

Enhancements:
- 优化模型选择器的视觉样式与布局，限制宽度并对过长模型名称使用省略号。
- 简化输入栏上方的上下文区域，仅在网页搜索启用时显示搜索控件。
- 统一底部浮层的展开状态配置，支持按场景启用半展开或仅完全展开。

</details>

</details>

</details>
