### PR TITLE
feat(profile): 额度卡加「额度说明」ⓘ 弹窗，文案随 app-config 下发

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@
 
 **订阅页的标题、副标题、权益清单、CTA、退款说明、致谢、失败提示以 `/api/app-config` 的 `pro_paywall` 为准，本地 strings 只是从未拉到配置时的兜底默认。改这些文案先改服务端（`github-ai-trending-api/src/lib/pro-paywall.js`）；订阅页新增任何文字位置，必须先进服务端契约，禁止只在本地加键。** 权益行的图标由服务端 key 映射，认不出的 key 用通用图标，加新行不需要先发版。方案标签（年付 / 月付等）与价格仍在原处；单功能锁定提示、账户页一句话升级提示不受此限。取舍见后端 `docs/pro-paywall.md`。
 
+**账户页额度说明（额度卡 ⓘ 弹窗）以 `/api/app-config` 的 `quota_help` 为准，客户端不保留本地默认，禁止在本地 strings 写任何费率或档位数字。** 说明全是数字，落后的本地文案就是错误信息，从未拉到配置就不显示入口。改说明先改服务端（`github-ai-trending-api/src/lib/quota-help.js`，数字从常量拼出）。取舍见后端 `docs/quota-help.md`。
+
 ## 埋点（自建 eventbase，2026-08-19 起）
 
 上报走 `wang.harlon:eventbase-kt`（仓库 `~/eventbase-kt`，服务端 `~/eventbase`），Aptabase 已下线。

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -227,6 +227,7 @@
     <string name="profile_quota_reset_hours">约 %1$d 小时后重置</string>
     <string name="profile_quota_reset_soon">1 小时内重置</string>
     <string name="profile_quota_error">额度信息暂时无法获取</string>
+    <string name="profile_quota_help">额度说明</string>
     <!-- 账户中心 -->
     <string name="account_title">账户</string>
     <string name="account_signed_out_title">未登录</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -226,6 +226,7 @@
     <string name="profile_quota_reset_hours">Resets in ~%1$d h</string>
     <string name="profile_quota_reset_soon">Resets within an hour</string>
     <string name="profile_quota_error">Couldn&apos;t load credits right now</string>
+    <string name="profile_quota_help">About credits</string>
     <string name="profile_pro_badge_desc">Pro member</string>
     <!-- Account hub -->
     <string name="account_title">Account</string>

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -24,6 +24,7 @@ import whl.trending.chat.model.FOLLOW_SERVER_DEFAULT
 import whl.trending.ai.data.model.FavoriteItem
 import whl.trending.ai.data.model.PendingFavoriteOp
 import whl.trending.ai.data.model.ProPaywallRemoteConfig
+import whl.trending.ai.data.model.QuotaHelpRemoteConfig
 
 /**
  * 持久化存的是 ordinal，新档位只能追加在末尾，否则老用户的选择会错位。
@@ -156,6 +157,7 @@ class SettingsManager(private val settings: ObservableSettings) {
     private val CHAT_IMAGES_PER_KB_KEY = "prefs_chat_images_per_kb"
     private val CHAT_VOICE_MAX_MS_KEY = "prefs_chat_voice_max_ms"
     private val PRO_PAYWALL_KEY = "prefs_pro_paywall"
+    private val QUOTA_HELP_KEY = "prefs_quota_help"
     private val DAILY_PICKS_NOTIFICATION_KEY = "prefs_daily_picks_notification"
     private val PICKS_NEWSLETTER_BANNER_DISMISSED_KEY = "prefs_picks_newsletter_banner_dismissed"
     private val DEFAULT_HOME_TAB_KEY = "prefs_default_home_tab"
@@ -405,6 +407,23 @@ class SettingsManager(private val settings: ObservableSettings) {
     fun setProPaywall(config: ProPaywallRemoteConfig?) {
         if (config == null) settings.remove(PRO_PAYWALL_KEY)
         else settings.putString(PRO_PAYWALL_KEY, Json.encodeToString(config))
+    }
+
+    /** 最近一次成功拉取的额度说明；从未拉到或解码失败为 null，账户页不显示说明入口 */
+    fun quotaHelp(): QuotaHelpRemoteConfig? {
+        val json = settings.getStringOrNull(QUOTA_HELP_KEY) ?: return null
+        return runCatching { Json.decodeFromString<QuotaHelpRemoteConfig>(json) }.getOrNull()
+    }
+
+    fun setQuotaHelp(config: QuotaHelpRemoteConfig?) {
+        if (config == null) settings.remove(QUOTA_HELP_KEY)
+        else settings.putString(QUOTA_HELP_KEY, Json.encodeToString(config))
+    }
+
+    /** 服务端双语文案按此取字段：App 内语言优先，跟随系统时取系统语言 */
+    fun uiLanguage(): String {
+        val lang = currentAppLanguage().isoCode ?: getSystemLanguage()
+        return if (lang.startsWith("zh")) "zh" else "en"
     }
 
     /** 最近一次看过更新说明的版本号；null 表示首次安装（从未记录） */

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/local/SettingsManager.kt
@@ -410,10 +410,8 @@ class SettingsManager(private val settings: ObservableSettings) {
     }
 
     /** 最近一次成功拉取的额度说明；从未拉到或解码失败为 null，账户页不显示说明入口 */
-    fun quotaHelp(): QuotaHelpRemoteConfig? {
-        val json = settings.getStringOrNull(QUOTA_HELP_KEY) ?: return null
-        return runCatching { Json.decodeFromString<QuotaHelpRemoteConfig>(json) }.getOrNull()
-    }
+    val quotaHelp: Flow<QuotaHelpRemoteConfig?> = settings.getStringOrNullFlow(QUOTA_HELP_KEY)
+        .map { json -> json?.let { runCatching { Json.decodeFromString<QuotaHelpRemoteConfig>(it) }.getOrNull() } }
 
     fun setQuotaHelp(config: QuotaHelpRemoteConfig?) {
         if (config == null) settings.remove(QUOTA_HELP_KEY)
@@ -421,8 +419,13 @@ class SettingsManager(private val settings: ObservableSettings) {
     }
 
     /** 服务端双语文案按此取字段：App 内语言优先，跟随系统时取系统语言 */
-    fun uiLanguage(): String {
-        val lang = currentAppLanguage().isoCode ?: getSystemLanguage()
+    fun uiLanguage(): String = uiLanguageOf(currentAppLanguage())
+
+    /** [uiLanguage] 的响应式版本，语言切换后重取文案 */
+    val uiLanguageFlow: Flow<String> = appLanguage.map { uiLanguageOf(it) }
+
+    private fun uiLanguageOf(language: AppLanguage): String {
+        val lang = language.isoCode ?: getSystemLanguage()
         return if (lang.startsWith("zh")) "zh" else "en"
     }
 

--- a/shared/src/commonMain/kotlin/whl/trending/ai/data/model/AppConfigResponse.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/data/model/AppConfigResponse.kt
@@ -13,6 +13,7 @@ data class AppConfigResponse(
     @SerialName("chat_images") val chatImages: ChatImagesRemoteConfig? = null,
     @SerialName("chat_voice") val chatVoice: ChatVoiceRemoteConfig? = null,
     @SerialName("pro_paywall") val proPaywall: ProPaywallRemoteConfig? = null,
+    @SerialName("quota_help") val quotaHelp: QuotaHelpRemoteConfig? = null,
 )
 
 /** chat 图片参数（服务端 KV 单源下发，与服务端校验闸同值；见后端 lib/chat-images.js） */
@@ -56,6 +57,16 @@ data class ProBenefitRow(
     val icon: String? = null,
     // 可空：一行漏了 text 只丢这一行，不能让整个 app-config（含强更配置）解码失败
     val text: LocalizedText? = null,
+)
+
+/**
+ * 账户页额度说明（服务端单源下发；见后端 docs/quota-help.md）。
+ * 没有本地默认：说明全是数字，落后的默认即错误信息，未下发就不显示入口。
+ */
+@Serializable
+data class QuotaHelpRemoteConfig(
+    val title: LocalizedText? = null,
+    val paragraphs: List<LocalizedText> = emptyList(),
 )
 
 @Serializable

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -28,6 +29,7 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
@@ -82,6 +84,7 @@ import trendingai.shared.generated.resources.profile_followers
 import trendingai.shared.generated.resources.profile_load_failed
 import trendingai.shared.generated.resources.profile_quota_error
 import trendingai.shared.generated.resources.profile_quota_exhausted
+import trendingai.shared.generated.resources.profile_quota_help
 import trendingai.shared.generated.resources.profile_quota_reset_hours
 import trendingai.shared.generated.resources.profile_quota_reset_soon
 import trendingai.shared.generated.resources.profile_quota_used
@@ -97,6 +100,7 @@ import whl.trending.ai.core.AccountLink
 import whl.trending.ai.core.DateTimeUtils
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.QuotaResponse
+import whl.trending.ai.ui.common.InfoDialog
 import whl.trending.ai.ui.common.LocalContentBottomPadding
 import whl.trending.ai.ui.common.LocalContentTopPadding
 import whl.trending.ai.ui.common.SettingsGroup
@@ -207,6 +211,7 @@ fun ProfileScreen(
                     PlanUsageCard(
                         quota = uiState.quota,
                         quotaError = uiState.quotaError,
+                        quotaHelp = viewModel.quotaHelp,
                         loggedIn = uiState.loggedIn,
                         isPro = isPro,
                         // 进订阅页，不再直奔 Sponsors，也不再要求先关联 GitHub：
@@ -388,7 +393,7 @@ private fun AccountHeader(
 }
 
 /**
- * 套餐 & 用量卡：档位徽章 + 余额进度 + 重置倒计时 + 费率；底部按状态给不同 CTA
+ * 套餐 & 用量卡：档位徽章 + 余额进度 + 重置倒计时 + 额度说明入口；底部按状态给不同 CTA
  * （匿名→登录引导 / Free 登录→升级 Pro / Pro→致谢）。数据与整页解耦，失败只降级本卡。
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -396,6 +401,7 @@ private fun AccountHeader(
 private fun PlanUsageCard(
     quota: QuotaResponse?,
     quotaError: Boolean,
+    quotaHelp: QuotaHelpContent?,
     loggedIn: Boolean,
     isPro: Boolean,
     onUpgrade: () -> Unit,
@@ -410,19 +416,38 @@ private fun PlanUsageCard(
             modifier = Modifier.fillMaxWidth().padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
+            var showHelp by remember { mutableStateOf(false) }
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     stringResource(Res.string.account_plan_title),
                     style = MaterialTheme.typography.titleSmall,
                 )
+                // 说明文案随 app-config 下发，从未拉到过就没有入口；与额度是否加载成功无关
+                if (quotaHelp != null) {
+                    IconButton(onClick = { showHelp = true }, modifier = Modifier.size(32.dp)) {
+                        Icon(
+                            Icons.Outlined.Info,
+                            contentDescription = stringResource(Res.string.profile_quota_help),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                }
                 Spacer(Modifier.weight(1f))
                 if (isPro) ProBadge() else if (loggedIn) TierPillFree()
+            }
+            if (showHelp && quotaHelp != null) {
+                InfoDialog(
+                    title = quotaHelp.title,
+                    content = quotaHelp.paragraphs.joinToString("\n\n"),
+                    onDismiss = { showHelp = false },
+                )
             }
 
             when {
                 quota != null -> {
-                    // 只讲「用掉了多大比例」和「何时重置」，不透出余额绝对值与单价：
-                    // 用户无从算计单价，后端调价/调额度也不必跟着改文案（改了就会说谎）。
+                    // 主展示只讲「用掉了多大比例」和「何时重置」，不透出余额绝对值；
+                    // 费率与档位数字由服务端下发的说明弹窗承担，本地不写任何数字。
                     val usedRatio = remember(quota.balance, quota.dailyGrant) {
                         if (quota.dailyGrant <= 0) 0f
                         else ((quota.dailyGrant - quota.balance).toFloat() / quota.dailyGrant)

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileScreen.kt
@@ -130,6 +130,7 @@ fun ProfileScreen(
 ) {
     val viewModel: ProfileViewModel = viewModel { ProfileViewModel() }
     val uiState by viewModel.uiState.collectAsState()
+    val quotaHelp by viewModel.quotaHelp.collectAsState()
     // 未接入登录的平台（iOS NoopAuthManager）：身份/额度/GitHub/登录都无意义，
     // 隐藏这些动态区块，本页退化成「收藏 + 设置 + 关于」三个入口。
     val authSupported = globalAuthManager.isSupported
@@ -211,7 +212,7 @@ fun ProfileScreen(
                     PlanUsageCard(
                         quota = uiState.quota,
                         quotaError = uiState.quotaError,
-                        quotaHelp = viewModel.quotaHelp,
+                        quotaHelp = quotaHelp,
                         loggedIn = uiState.loggedIn,
                         isPro = isPro,
                         // 进订阅页，不再直奔 Sponsors，也不再要求先关联 GitHub：

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -4,9 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Duration.Companion.seconds
@@ -90,9 +93,13 @@ class ProfileViewModel(
     private val _uiState = MutableStateFlow(ProfileUiState())
     val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
 
-    /** 额度卡 ⓘ 弹窗内容；读冷启动落盘的 app-config 缓存，未拉到过为 null（不显示入口） */
-    val quotaHelp: QuotaHelpContent? =
-        resolveQuotaHelp(settingsManager.quotaHelp(), settingsManager.uiLanguage())
+    /**
+     * 额度卡 ⓘ 弹窗内容，未拉到过 app-config 为 null（不显示入口）。跟着缓存与语言走：
+     * VM 常驻 Activity，升级后首启用户可能先进账户页、配置后落盘，读一次就会永久错过。
+     */
+    val quotaHelp: StateFlow<QuotaHelpContent?> =
+        combine(settingsManager.quotaHelp, settingsManager.uiLanguageFlow, ::resolveQuotaHelp)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     private var nextFeedPage = 1
     /** 已消费的原始 events 总数（用于判断是否到达 GitHub 300 条硬上限） */

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/ProfileViewModel.kt
@@ -90,6 +90,10 @@ class ProfileViewModel(
     private val _uiState = MutableStateFlow(ProfileUiState())
     val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
 
+    /** 额度卡 ⓘ 弹窗内容；读冷启动落盘的 app-config 缓存，未拉到过为 null（不显示入口） */
+    val quotaHelp: QuotaHelpContent? =
+        resolveQuotaHelp(settingsManager.quotaHelp(), settingsManager.uiLanguage())
+
     private var nextFeedPage = 1
     /** 已消费的原始 events 总数（用于判断是否到达 GitHub 300 条硬上限） */
     private var consumedRawCount = 0

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/QuotaHelpContent.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/profile/QuotaHelpContent.kt
@@ -1,0 +1,14 @@
+package whl.trending.ai.ui.profile
+
+import whl.trending.ai.data.model.QuotaHelpRemoteConfig
+
+/** 额度说明，已按 UI 语言选好；[paragraphs] 非空才有东西可弹 */
+data class QuotaHelpContent(val title: String, val paragraphs: List<String>)
+
+/** 标题或全部段落取不到即视为未下发，返回 null；取不到文案的段落跳过 */
+internal fun resolveQuotaHelp(remote: QuotaHelpRemoteConfig?, lang: String): QuotaHelpContent? {
+    val title = remote?.title?.forLang(lang) ?: return null
+    val paragraphs = remote.paragraphs.mapNotNull { it.forLang(lang) }
+    if (paragraphs.isEmpty()) return null
+    return QuotaHelpContent(title, paragraphs)
+}

--- a/shared/src/commonMain/kotlin/whl/trending/ai/ui/subscription/SubscriptionViewModel.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/ui/subscription/SubscriptionViewModel.kt
@@ -13,7 +13,6 @@ import whl.trending.ai.core.ProCheckout
 import whl.trending.ai.core.analytics.AppEvent
 import whl.trending.ai.core.analytics.CheckoutStepKind
 import whl.trending.ai.core.analytics.track
-import whl.trending.ai.core.platform.getSystemLanguage
 import whl.trending.ai.data.local.globalSettingsManager
 import whl.trending.ai.data.model.PricesResponse
 import whl.trending.ai.data.repository.BillingRepository
@@ -60,7 +59,7 @@ class SubscriptionViewModel(
         viewModelScope.launch {
             _uiState.update { it.copy(loading = true) }
             val prices = repository.fetchPrices()
-            val content = resolvePaywallContent(globalSettingsManager.proPaywall(), uiLanguage())
+            val content = resolvePaywallContent(globalSettingsManager.proPaywall(), globalSettingsManager.uiLanguage())
             _uiState.update {
                 it.copy(loading = false, prices = prices, content = content)
             }
@@ -91,9 +90,4 @@ class SubscriptionViewModel(
             ProCheckout.openCheckout(checkout.url, plan)
         }
     }
-}
-
-private fun uiLanguage(): String {
-    val lang = globalSettingsManager.currentAppLanguage().isoCode ?: getSystemLanguage()
-    return if (lang.startsWith("zh")) "zh" else "en"
 }

--- a/shared/src/commonMain/kotlin/whl/trending/ai/update/AppConfigSync.kt
+++ b/shared/src/commonMain/kotlin/whl/trending/ai/update/AppConfigSync.kt
@@ -20,6 +20,7 @@ suspend fun refreshAppConfig(): AppConfigResponse? =
         )
         globalSettingsManager.setChatVoiceConfig(config.chatVoice?.maxDurationMs)
         globalSettingsManager.setProPaywall(config.proPaywall)
+        globalSettingsManager.setQuotaHelp(config.quotaHelp)
         config
     } catch (e: CancellationException) {
         throw e

--- a/shared/src/commonTest/kotlin/whl/trending/ai/data/model/AppConfigResponseTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/data/model/AppConfigResponseTest.kt
@@ -58,4 +58,19 @@ class AppConfigResponseTest {
         assertEquals("1.0.0", config.minVersion)
         assertNull(config.proPaywall!!.benefits.single().text)
     }
+
+    @Test
+    fun decodes_quota_help_and_tolerates_missing_title() {
+        val config = json.decodeFromString<AppConfigResponse>(
+            """{"quota_help":{"title":{"zh":"说明","en":"About"},"paragraphs":[{"zh":"一","en":"One"},{"en":"Two"}]}}"""
+        )
+        val help = config.quotaHelp!!
+        assertEquals("About", help.title!!.en)
+        assertEquals(2, help.paragraphs.size)
+        assertNull(help.paragraphs[1].zh)
+
+        val partial = json.decodeFromString<AppConfigResponse>("""{"quota_help":{"paragraphs":[]}}""")
+        assertNull(partial.quotaHelp!!.title)
+        assertNull(json.decodeFromString<AppConfigResponse>("""{}""").quotaHelp)
+    }
 }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/ProfileViewModelTest.kt
@@ -4,6 +4,7 @@ import com.russhwolf.settings.MapSettings
 import com.russhwolf.settings.ObservableSettings
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -30,7 +31,10 @@ import whl.trending.ai.auth.GithubTokenProvider
 import whl.trending.ai.auth.OwnRepoEventsProvider
 import whl.trending.ai.data.local.FakeCacheFileStore
 import whl.trending.ai.data.local.LastDataCache
+import whl.trending.ai.data.local.AppLanguage
 import whl.trending.ai.data.local.SettingsManager
+import whl.trending.ai.data.model.LocalizedText
+import whl.trending.ai.data.model.QuotaHelpRemoteConfig
 import whl.trending.ai.data.model.ContributionCalendar
 import whl.trending.ai.data.model.MeUser
 import whl.trending.ai.data.model.QuotaResponse
@@ -315,5 +319,29 @@ class ProfileViewModelTest {
         advanceUntilIdle()
 
         assertNull(cache.get<ProfileCache>(ProfileCache.KEY))
+    }
+
+    @Test
+    fun quotaHelpFollowsCacheWrittenAfterCreationAndLanguageSwitch() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+        val settings = settings().also { it.setLanguage(AppLanguage.ENGLISH) }
+        val vm = viewModel(cache(), settingsManager = settings)
+        val collector = launch { vm.quotaHelp.collect {} }
+        advanceUntilIdle()
+        assertNull(vm.quotaHelp.value)
+
+        settings.setQuotaHelp(
+            QuotaHelpRemoteConfig(
+                title = LocalizedText("说明", "About"),
+                paragraphs = listOf(LocalizedText("一", "One")),
+            )
+        )
+        advanceUntilIdle()
+        assertEquals(QuotaHelpContent("About", listOf("One")), vm.quotaHelp.value)
+
+        settings.setLanguage(AppLanguage.CHINESE)
+        advanceUntilIdle()
+        assertEquals(QuotaHelpContent("说明", listOf("一")), vm.quotaHelp.value)
+        collector.cancel()
     }
 }

--- a/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/QuotaHelpContentTest.kt
+++ b/shared/src/commonTest/kotlin/whl/trending/ai/ui/profile/QuotaHelpContentTest.kt
@@ -1,0 +1,34 @@
+package whl.trending.ai.ui.profile
+
+import whl.trending.ai.data.model.LocalizedText
+import whl.trending.ai.data.model.QuotaHelpRemoteConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class QuotaHelpContentTest {
+
+    private fun t(zh: String? = null, en: String? = null) = LocalizedText(zh, en)
+
+    @Test
+    fun null_remote_or_missing_title_yields_null_so_entry_is_hidden() {
+        assertNull(resolveQuotaHelp(null, "zh"))
+        assertNull(resolveQuotaHelp(QuotaHelpRemoteConfig(paragraphs = listOf(t(en = "x"))), "zh"))
+    }
+
+    @Test
+    fun no_readable_paragraph_yields_null() {
+        val remote = QuotaHelpRemoteConfig(title = t(en = "About"), paragraphs = listOf(t(zh = "只有中文")))
+        assertNull(resolveQuotaHelp(remote, "en"))
+    }
+
+    @Test
+    fun zh_falls_back_to_en_per_paragraph_and_skips_empty_rows() {
+        val remote = QuotaHelpRemoteConfig(
+            title = t(en = "About"),
+            paragraphs = listOf(t("一", "One"), t(en = "Two"), t()),
+        )
+        assertEquals(QuotaHelpContent("About", listOf("一", "Two")), resolveQuotaHelp(remote, "zh"))
+        assertEquals(QuotaHelpContent("About", listOf("One", "Two")), resolveQuotaHelp(remote, "en"))
+    }
+}


### PR DESCRIPTION
## 做了什么

账户页「套餐与用量」卡标题行加一个 ⓘ 图标，点开 `InfoDialog` 显示 AI 额度使用说明：每条消耗多少、三档每天授予多少、重置时刻与不结转、失败不扣费、当天升 Pro 立即重授。

说明内容由服务端 `/api/app-config` 新增的 `quota_help` 下发（api 仓 c346bd3，标题 + 段落、zh/en），数字从费率表与档位常量拼出，调数字不改文案。客户端沿用 `pro_paywall` 那条路：冷启动 `refreshAppConfig()` 落盘，账户页只读缓存。

## 取舍

- **没有本地默认**：说明全是数字，落后的默认即错误信息，从未拉到过配置就不显示 ⓘ。
- ⓘ 的显隐只看有没有说明文案，与额度加载成功与否无关（额度拉失败时说明反而更有用）。
- 原代码注释「不透出单价，改了会说谎」的前提被服务端拼数字拆掉，注释据此改写；主展示仍只显示「已用 %」。
- 不埋点：说明弹窗不是页面，第一版先不加事件。
- `uiLanguage()` 从 `SubscriptionViewModel` 挪进 `SettingsManager`，订阅页与账户页共用。

## 验证

- `QuotaHelpContentTest` 3 条、`AppConfigResponseTest` 新增解码用例、`ProfileViewModelTest` 9 条全绿。
- `assembleDebug` 通过。模拟器目测待服务端推送后补。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ho3532GMKXZ9zooXj3uywE

## Sourcery 摘要

在账户套餐卡片中添加由服务器配置的配额说明条目。

新功能：
- 添加账户套餐配额信息对话框，并提供本地化的服务器使用指南。

改进：
- 从应用配置中持久化配额帮助配置，并从缓存的设置中解析本地化内容。
- 在 SettingsManager 中集中管理界面语言选择，以便订阅和个人资料页面共享使用。

测试：
- 添加对配额帮助解码、本地化回退、内容缺失情况以及个人资料行为的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在账户套餐和用量卡片中添加由服务器配置的配额说明入口。

新功能：
- 添加账户套餐配额信息对话框，通过应用配置提供本地化的用量指导。

增强功能：
- 持久化配额帮助配置，并从缓存设置中解析本地化内容；当没有可用内容时隐藏该入口。
- 在 SettingsManager 中集中管理界面语言选择，以便个人资料和订阅页面复用。

文档：
- 记录由服务器配置的配额帮助协议，并禁止使用本地数字配额文案。

测试：
- 增加对配额帮助解码、本地化回退、内容缺失和个人资料行为的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在账户套餐和用量卡片中添加由服务器配置的配额说明条目。

新功能：
- 添加账户套餐用量卡片信息对话框，并提供本地化的配额指南。

增强功能：
- 持久化服务器提供的配额指南，并以响应式方式更新其显示语言；当没有可用内容时隐藏该条目。
- 在 SettingsManager 中集中解析界面语言，以便在个人资料和订阅视图中复用。

文档：
- 记录由服务器管理的配额帮助协议，并禁止使用本地数字配额文案。

测试：
- 添加对配额帮助解码、本地化回退、缺失内容及个人资料行为的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a server-configured quota explanation entry to the account plan and usage card.

New Features:
- Add an account plan usage-card info dialog with localized quota guidance.

Enhancements:
- Persist server-provided quota guidance and update its displayed language reactively, hiding the entry when usable content is unavailable.
- Centralize UI language resolution in SettingsManager for reuse across profile and subscription views.

Documentation:
- Document the server-managed quota-help contract and prohibit local numeric quota copy.

Tests:
- Add coverage for quota-help decoding, localization fallback, missing content, and profile behavior.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a quota help option to the profile plan card.
  - Displays server-provided quota explanations in the user’s language, with English fallback where available.
  - Updates quota help when content or language settings change.
  - Added Simplified Chinese and English labels.
  - Hides quota help when content is unavailable or incomplete.

- **Tests**
  - Added coverage for configuration decoding, language fallback, reactive updates, and missing content handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->